### PR TITLE
Generate TS type definitions for C# module exports

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,6 +16,7 @@
 
 	<ItemGroup>
 		<CompilerVisibleProperty Include="BaseIntermediateOutputPath" /><!-- Used by NodeApi source generator. -->
+		<CompilerVisibleProperty Include="TargetPath" /><!-- Used by NodeApi TS source generator. -->
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Generator/ModuleGenerator.cs
+++ b/Generator/ModuleGenerator.cs
@@ -53,6 +53,20 @@ public class ModuleGenerator : SourceGenerator, ISourceGenerator
                     $"{nameof(NodeApi)}.{ModuleInitializerClassName}.cs");
                 File.WriteAllText(generatedSourcePath, initializerSource.ToString());
             }
+
+            // No type definitions are generated when using a custom init function.
+            if (moduleInitializer is not IMethodSymbol)
+            {
+                SourceText typeDefinitions = TypeDefinitionsGenerator.GenerateTypeDefinitions(
+                    exportItems);
+                if (context.AnalyzerConfigOptions.GlobalOptions.TryGetValue(
+                    "build_property.TargetPath", out string? targetPath))
+                {
+                    string typeDefinitionsPath = Path.ChangeExtension(targetPath, ".d.ts");
+                    File.WriteAllText(typeDefinitionsPath, typeDefinitions.ToString());
+                }
+            }
+
         }
         catch (Exception ex)
         {
@@ -552,5 +566,4 @@ public class ModuleGenerator : SourceGenerator, ISourceGenerator
 
         return symbol is ITypeSymbol ? symbol.Name : ToCamelCase(symbol.Name);
     }
-
 }

--- a/Generator/NodeApi.Generator.csproj
+++ b/Generator/NodeApi.Generator.csproj
@@ -4,6 +4,7 @@
     <RootNamespace>NodeApi.Generator</RootNamespace>
     <AssemblyName>NodeApi.Generator</AssemblyName>
     <IsPackable>true</IsPackable>
+    <NoWarn>$(NoWarn);SYSLIB1045</NoWarn><!-- Use GeneratedRegexAttribute -->
   </PropertyGroup>
 
   <ItemGroup>

--- a/Generator/TypeDefinitionsGenerator.cs
+++ b/Generator/TypeDefinitionsGenerator.cs
@@ -1,0 +1,218 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Text;
+
+namespace NodeApi.Generator;
+
+internal class TypeDefinitionsGenerator : SourceGenerator
+{
+    private static readonly Regex s_newlineRegex = new("\n *");
+    private static readonly Regex s_summaryRegex = new("<summary>(.*)</summary>");
+    private static readonly Regex s_remarksRegex = new("<remarks>(.*)</remarks>");
+
+    internal static SourceText GenerateTypeDefinitions(IEnumerable<ISymbol> exportItems)
+    {
+        var s = new SourceBuilder();
+
+        s += "// Generated type definitions for .NET module";
+
+        foreach (ISymbol exportItem in exportItems)
+        {
+            if (exportItem is ITypeSymbol exportType && exportType.TypeKind == TypeKind.Class)
+            {
+                GenerateClassTypeDefinitions(ref s, exportType);
+            }
+            else if (exportItem is IMethodSymbol exportMethod)
+            {
+                s++;
+                GenerateDocComments(ref s, exportItem);
+                string exportName = ModuleGenerator.GetExportName(exportItem);
+                string parameters = GetTSParameters(exportMethod, s.Indent);
+                string returnType = GetTSType(exportMethod.ReturnType);
+                s += $"export declare function {exportName}({parameters}): {returnType};";
+            }
+            else if (exportItem is IPropertySymbol exportProperty)
+            {
+                s++;
+                GenerateDocComments(ref s, exportItem);
+                string exportName = ModuleGenerator.GetExportName(exportItem);
+                string propertyType = GetTSType(exportProperty.Type);
+                string varKind = exportProperty.SetMethod == null ? "const " : "var ";
+                s += $"export declare {varKind}{exportName}: {propertyType};";
+            }
+        }
+
+        return s;
+    }
+
+    private static void GenerateClassTypeDefinitions(ref SourceBuilder s, ITypeSymbol exportClass)
+    {
+        s++;
+        GenerateDocComments(ref s, exportClass);
+        string classKind = exportClass.IsStatic ? "namespace" : "class";
+        string exportName = ModuleGenerator.GetExportName(exportClass);
+        s += $"export declare {classKind} {exportName} {{";
+
+        bool isFirstMember = true;
+        foreach (ISymbol member in exportClass.GetMembers()
+            .Where((m) => m.DeclaredAccessibility == Accessibility.Public))
+        {
+            string memberName = ToCamelCase(member.Name);
+
+            if (!exportClass.IsStatic &&
+                member is IMethodSymbol exportConstructor &&
+                exportConstructor.MethodKind == MethodKind.Constructor &&
+                !exportConstructor.IsImplicitlyDeclared)
+            {
+                if (isFirstMember) isFirstMember = false; else s++;
+                GenerateDocComments(ref s, member);
+                string parameters = GetTSParameters(exportConstructor, s.Indent);
+                s += $"constructor({parameters});";
+            }
+            else if (member is IMethodSymbol exportMethod &&
+                exportMethod.MethodKind == MethodKind.Ordinary)
+            {
+                if (isFirstMember) isFirstMember = false; else s++;
+                GenerateDocComments(ref s, member);
+                string parameters = GetTSParameters(exportMethod, s.Indent);
+                string returnType = GetTSType(exportMethod.ReturnType);
+
+                if (exportClass.IsStatic)
+                {
+                    s += "export declare function " +
+                        $"{memberName}({parameters}): {returnType};";
+                }
+                else
+                {
+                    s += $"{memberName}({parameters}): {returnType};";
+                }
+            }
+            else if (member is IPropertySymbol exportProperty)
+            {
+                if (isFirstMember) isFirstMember = false; else s++;
+                GenerateDocComments(ref s, member);
+                string propertyType = GetTSType(exportProperty.Type);
+
+                if (exportClass.IsStatic)
+                {
+                    string varKind = exportProperty.SetMethod == null ? "const " : "var ";
+                    s += $"export declare {varKind}{memberName}: {propertyType};";
+                }
+                else
+                {
+                    string readonlyModifier =
+                        exportProperty.SetMethod == null ? "readonly " : "";
+                    s += $"{readonlyModifier}{memberName}: {propertyType};";
+                }
+            }
+        }
+
+        s += "}";
+    }
+
+    private static string GetTSType(ITypeSymbol type)
+    {
+        string? specialType = type.SpecialType switch
+        {
+            SpecialType.System_Void => "void",
+            SpecialType.System_Boolean => "boolean",
+            SpecialType.System_SByte => "number",
+            SpecialType.System_Int16 => "number",
+            SpecialType.System_Int32 => "number",
+            SpecialType.System_Int64 => "number",
+            SpecialType.System_Byte => "number",
+            SpecialType.System_UInt16 => "number",
+            SpecialType.System_UInt32 => "number",
+            SpecialType.System_UInt64 => "number",
+            SpecialType.System_Single => "number",
+            SpecialType.System_Double => "number",
+            SpecialType.System_String => "string",
+            ////SpecialType.System_DateTime => "Date",
+            _ => null,
+        };
+        if (specialType != null)
+        {
+            return specialType;
+        }
+
+        if (type.TypeKind == TypeKind.Class)
+        {
+            // TODO: Check if class is exported.
+        }
+        else if (type.TypeKind == TypeKind.Array)
+        {
+            // TODO: Get element type.
+            return "any[]";
+        }
+
+        return "any";
+    }
+
+    private static string GetTSParameters(IMethodSymbol method, string indent)
+    {
+        if (method.Parameters.Length == 0)
+        {
+            return string.Empty;
+        }
+        else if (method.Parameters.Length == 1)
+        {
+            string parameterType = GetTSType(method.Parameters[0].Type);
+            return $"{method.Parameters[0].Name}: {parameterType}";
+        }
+
+        var s = new StringBuilder();
+        s.AppendLine();
+
+        foreach (IParameterSymbol p in method.Parameters)
+        {
+            string parameterType = GetTSType(p.Type);
+            s.AppendLine($"{indent}\t{p.Name}: {parameterType},");
+        }
+
+        s.Append(indent);
+        return s.ToString();
+    }
+
+    private static void GenerateDocComments(ref SourceBuilder s, ISymbol symbol)
+    {
+        string? comment = symbol.GetDocumentationCommentXml();
+        if (string.IsNullOrEmpty(comment))
+        {
+            return;
+        }
+
+        comment = comment.Replace("\r", "");
+        comment = s_newlineRegex.Replace(comment, " ");
+        /*
+        comment = new Regex($"<see cref=\".:({this.csNamespace}\\.)?(\\w+)\\.(\\w+)\" ?/>")
+            .Replace(comment, (m) => $"{{@link {m.Groups[2].Value}.{ToCamelCase(m.Groups[3].Value)}}}");
+        comment = new Regex($"<see cref=\".:({this.csNamespace}\\.)?([^\"]+)\" ?/>")
+            .Replace(comment, "{@link $2}");
+        */
+
+        string summary = s_summaryRegex.Match(comment).Groups[1].Value.Trim();
+        string remarks = s_remarksRegex.Match(comment).Groups[1].Value.Trim();
+
+        s += "/**";
+
+        foreach (string commentLine in WrapComment(summary, 90 - 3 - s.Indent.Length))
+        {
+            s += " * " + commentLine;
+        }
+
+        if (!string.IsNullOrEmpty(remarks))
+        {
+            s += " *";
+            foreach (string commentLine in WrapComment(remarks, 90 - 3 - s.Indent.Length))
+            {
+                s += " * " + commentLine;
+            }
+        }
+
+        s += " */";
+    }
+}

--- a/Test/HostedClrTests.cs
+++ b/Test/HostedClrTests.cs
@@ -35,6 +35,7 @@ public class HostedClrTests
 
             if (moduleFilePath != null)
             {
+                CopyTypeDefinitions(moduleName, moduleFilePath);
                 BuildTestModuleTypeScript(moduleName);
             }
 

--- a/Test/NativeAotTests.cs
+++ b/Test/NativeAotTests.cs
@@ -29,6 +29,7 @@ public class NativeAotTests
 
             if (moduleFilePath != null)
             {
+                CopyTypeDefinitions(moduleName, moduleFilePath);
                 BuildTestModuleTypeScript(moduleName);
             }
 

--- a/Test/TestBuilder.cs
+++ b/Test/TestBuilder.cs
@@ -110,6 +110,7 @@ internal static class TestBuilder
             foreach (string jsFile in Directory.GetFiles(dir, "*.js")
               .Concat(Directory.GetFiles(dir, "*.ts")))
             {
+                if (jsFile.EndsWith(".d.ts")) continue;
                 string testCaseName = Path.GetFileNameWithoutExtension(jsFile);
                 yield return new[] { moduleName + "/" + testCaseName };
             }
@@ -193,6 +194,20 @@ internal static class TestBuilder
 
         string returnValue = project.GetPropertyValue(returnProperty);
         return returnValue;
+    }
+
+    public static void CopyTypeDefinitions(string moduleName, string moduleFilePath)
+    {
+        string sourceFilePath = Path.ChangeExtension(moduleFilePath, ".d.ts");
+        string destFilePath = Path.Join(TestCasesDirectory, moduleName, moduleName + ".d.ts");
+        try
+        {
+            File.Copy(sourceFilePath, destFilePath, true);
+        }
+        catch (FileNotFoundException)
+        {
+            File.Delete(destFilePath);
+        }
     }
 
     public static void RunNodeTestCase(

--- a/Test/TestCases/.gitignore
+++ b/Test/TestCases/.gitignore
@@ -1,2 +1,5 @@
-# Test case project files are auto-generated
+# Test case project files are auto-generated.
 *.csproj
+
+# TS type definitions files are auto-generated.
+*.d.ts

--- a/Test/TestCases/Directory.Build.props
+++ b/Test/TestCases/Directory.Build.props
@@ -8,6 +8,8 @@
         <IntermediateOutputPath>$(BaseIntermediateOutputPath)</IntermediateOutputPath>
         <OutputPath>$(BaseOutputPath)bin/$(Configuration)/TestCases/$(MSBuildProjectName)/</OutputPath>
         <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <NoWarn>CS1591</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Test/TestCases/napi-dotnet/Counter.cs
+++ b/Test/TestCases/napi-dotnet/Counter.cs
@@ -3,6 +3,9 @@ using System.Threading;
 
 namespace NodeApi.TestCases;
 
+/// <summary>
+/// Enables testing static state.
+/// </summary>
 [JSExport]
 public static class Counter
 {

--- a/Test/TestCases/napi-dotnet/Hello.cs
+++ b/Test/TestCases/napi-dotnet/Hello.cs
@@ -4,6 +4,11 @@ namespace NodeApi.TestCases;
 
 public static class Hello
 {
+    /// <summary>
+    /// Gets a greeting string for testing.
+    /// </summary>
+    /// <param name="greeter">Name of the greeter.</param>
+    /// <returns>A greeting with the name.</returns>
     [JSExport("hello")]
     public static string Test(string greeter)
     {

--- a/Test/TestCases/napi-dotnet/hello.js
+++ b/Test/TestCases/napi-dotnet/hello.js
@@ -3,6 +3,8 @@ const assert = require('assert');
 // Load the addon module, using either hosted or native AOT mode.
 const dotnetModule = process.env['TEST_DOTNET_MODULE_PATH'];
 const dotnetHost = process.env['TEST_DOTNET_HOST_PATH'];
+
+/** @type {import('./napi-dotnet')} */
 const binding = dotnetHost ? require(dotnetHost).require(dotnetModule) : require(dotnetModule);
 
 // Call a method exported by the addon module.

--- a/Test/TestCases/napi-dotnet/multi_instance.js
+++ b/Test/TestCases/napi-dotnet/multi_instance.js
@@ -4,6 +4,9 @@ const { Worker, isMainThread, parentPort } = require('worker_threads');
 // Load the addon module, using either hosted or native AOT mode.
 const dotnetModule = process.env['TEST_DOTNET_MODULE_PATH'];
 const dotnetHost = process.env['TEST_DOTNET_HOST_PATH'];
+
+/** @typedef {import('./napi-dotnet')} Binding */
+/** @type Binding */
 const binding = dotnetHost ? require(dotnetHost).require(dotnetModule) : require(dotnetModule);
 
 if (isMainThread) {
@@ -17,6 +20,7 @@ if (isMainThread) {
   delete require.cache[dotnetHost];
   delete require.cache[dotnetModule];
 
+  /** @type Binding */
   const rebinding = dotnetHost ? require(dotnetHost).require(dotnetModule) : require(dotnetModule);
 
   // The static counter should be reinitialized after rebinding.


### PR DESCRIPTION
> [<img alt="jasongin" height="40" width="40" align="left" src="https://avatars0.githubusercontent.com/u/13093042?s=40&v=4">](/jasongin) **Authored by [jasongin](/jasongin)** on _<time datetime="2023-02-02T02:37:12Z" title="Wednesday, February 1st 2023, 6:37:12 pm -08:00">Feb 1, 2023</time>_, merged on _<time datetime="2023-02-02T19:22:36Z" title="Thursday, February 2nd 2023, 11:22:36 am -08:00">Feb 2, 2023</time>_
Imported from _jasongin/napi-dotnet_ repo
---
 - Add `TypeDefinitionsGenerator` class
   - Generate type definitions for exported classes, properties, and methods.
   - Convert/reformat doc-comments for exported items.
 - Update some test JS code to reference the generated type definitions.

For now the TS generator only handles C# primitive types; anything else gets represented in TS as `any`. As I add support for exporting method parameters with other specific or complex types, I plan to implement the TS definitions at the same time.