### PR TITLE
Perf comparison

### DIFF
--- a/Test/TestCases/edgejs-perf/Edge.Performance.cs
+++ b/Test/TestCases/edgejs-perf/Edge.Performance.cs
@@ -3,6 +3,7 @@
 using System;
 using NodeApi;
 
+#pragma warning disable IDE0060 // Unused parameter 'input'
 
 namespace Edge.Performance
 {

--- a/Test/TestCases/edgejs-perf/measure-latency.js
+++ b/Test/TestCases/edgejs-perf/measure-latency.js
@@ -11,7 +11,7 @@ const dotnetHost = process.env['TEST_DOTNET_HOST_PATH'];
 /** @type {import('./edgejs-perf')} */
 const binding = dotnetHost ? require(dotnetHost).require(dotnetModule) : require(dotnetModule);
 
-const callCount = process.env.EDGE_CALL_COUNT || 100000;
+const callCount = process.env.EDGE_CALL_COUNT || 10000;
 
 const measure = function (func) {
 	var start = Date.now();


### PR DESCRIPTION
> [<img alt="jasongin" height="40" width="40" align="left" src="https://avatars0.githubusercontent.com/u/13093042?s=40&v=4">](/jasongin) **Authored by [jasongin](/jasongin)** on _<time datetime="2023-02-17T10:17:12Z" title="Friday, February 17th 2023, 2:17:12 am -08:00">Feb 17, 2023</time>_, merged on _<time datetime="2023-02-18T00:36:22Z" title="Friday, February 17th 2023, 4:36:22 pm -08:00">Feb 17, 2023</time>_
Imported from _jasongin/napi-dotnet_ repo
---
I ported the perf measurement script from `edge-js`, and took some measurements using release builds. Numbers are microseconds per function call, averaged over 100,000 iterations.

| Run #          | js-baseline | edge-js | napi-clr | napi-aot |
|--------------|-----------|---------|---------|----------|
| 1                 | 16.78       | 92.67   | 52.9     | 51.93 |
| 2                 | 16.37       | 95.84   | 53.34    | 51.77 |
| 3                 | 15.78       | 87.93   | 49.67    | 48.65 |
| 4                 | 16.24       | 95.13   | 51.97    | 48.70 |
| 5                 | 15.31       | 95.09   | 49.51    | 48.53 |
| average      | 16.10      | 93.33  | 51.48  | 49.92 |


| | Relative performance | 
|------------------------|------|
| edge-js/baseline  | 579.8%      | 
| napi-aot/baseline | 310.1%      | 
| napi-aot/edge-js  | 53.5%       |
| napi-clr/napi-aot | 97.2%       | 

Interpretation
 - The edge-js/baseline ratio is consistent with the "6x" difference [reported in the original Edge project](https://github.com/tjanczuk/edge/wiki/Performance).
 - `napi-dotnet` is about twice as fast as edge-js, or 3x slower than plain in-engine JS function calls, in this scenario.
 - The `napi-dotnet` AOT compiled build is consistently about 3% faster than the CLR build. I'd expect a greater difference for a smaller number of iterations, since AOT has the biggest impact on startup time.
 - I'd expect more advanced scenarios to show a larger advantage for `napi-dotnet` because it supports shared-memory typed-arrays and marshalling classes by reference, whereas edge-js serializes everything.