### PR TITLE
Update namespaces

### DIFF
--- a/src/NodeApi.DotNetHost/AssemblyExporter.cs
+++ b/src/NodeApi.DotNetHost/AssemblyExporter.cs
@@ -3,10 +3,11 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
+using Microsoft.JavaScript.NodeApi.Interop;
 
-using static NodeApi.Hosting.ManagedHost;
+using static Microsoft.JavaScript.NodeApi.DotNetHost.ManagedHost;
 
-namespace NodeApi.Hosting;
+namespace Microsoft.JavaScript.NodeApi.DotNetHost;
 /// <summary>
 /// Dynamically exports APIs from a .NET assembly to JS.
 /// </summary>

--- a/src/NodeApi.DotNetHost/JSInterfaceMarshaler.cs
+++ b/src/NodeApi.DotNetHost/JSInterfaceMarshaler.cs
@@ -3,8 +3,9 @@ using System.Collections.Concurrent;
 using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
+using Microsoft.JavaScript.NodeApi.Interop;
 
-namespace NodeApi.Hosting;
+namespace Microsoft.JavaScript.NodeApi.DotNetHost;
 
 /// <summary>
 /// Supports dynamic implementation of .NET interfaces by JavaScript.

--- a/src/NodeApi.DotNetHost/JSMarshaler.cs
+++ b/src/NodeApi.DotNetHost/JSMarshaler.cs
@@ -6,8 +6,9 @@ using System.Linq.Expressions;
 using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
+using Microsoft.JavaScript.NodeApi.Interop;
 
-namespace NodeApi.Hosting;
+namespace Microsoft.JavaScript.NodeApi.DotNetHost;
 
 /// <summary>
 /// Generates expressions and delegates that support marshaling between .NET and JS.

--- a/src/NodeApi.DotNetHost/JSMarshalerException.cs
+++ b/src/NodeApi.DotNetHost/JSMarshalerException.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Reflection;
 
-namespace NodeApi.Hosting;
+namespace Microsoft.JavaScript.NodeApi.DotNetHost;
 
 /// <summary>
 /// Exception thrown by <see cref="JSMarshaler" /> about a failure while dynamically generating

--- a/src/NodeApi.DotNetHost/ManagedHost.cs
+++ b/src/NodeApi.DotNetHost/ManagedHost.cs
@@ -6,9 +6,9 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Loader;
-using static NodeApi.JSNativeApi.Interop;
+using static Microsoft.JavaScript.NodeApi.JSNativeApi.Interop;
 
-namespace NodeApi.Hosting;
+namespace Microsoft.JavaScript.NodeApi.DotNetHost;
 
 /// <summary>
 /// Supports loading and invoking managed .NET assemblies in a JavaScript process.
@@ -128,7 +128,8 @@ public sealed class ManagedHost : IDisposable
         MethodInfo? initializeMethod = null;
 
         // First look for an auto-generated module initializer.
-        Type? moduleClass = assembly.GetType("NodeApi.Generated.Module", throwOnError: false);
+        Type? moduleClass = assembly.GetType(
+            typeof(JSValue).Namespace + ".Generated.Module", throwOnError: false);
         if (moduleClass != null && moduleClass.IsClass && moduleClass.IsPublic &&
             moduleClass.IsAbstract && moduleClass.IsSealed)
         {

--- a/src/NodeApi.DotNetHost/TypeExtensions.cs
+++ b/src/NodeApi.DotNetHost/TypeExtensions.cs
@@ -2,7 +2,7 @@ using System;
 using System.Linq;
 using System.Reflection;
 
-namespace NodeApi.Hosting;
+namespace Microsoft.JavaScript.NodeApi.DotNetHost;
 
 /// <summary>
 /// Helper methods for getting public properties and methods, used for building dynamic

--- a/src/NodeApi.Generator/ExpressionExtensions.cs
+++ b/src/NodeApi.Generator/ExpressionExtensions.cs
@@ -6,9 +6,8 @@ using System.Linq.Expressions;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text;
-using Microsoft.CodeAnalysis.CSharp;
 
-namespace NodeApi.Generator;
+namespace Microsoft.JavaScript.NodeApi.Generator;
 
 /// <summary>
 /// Extension method for generating C# code from expressions.
@@ -20,7 +19,7 @@ internal static class ExpressionExtensions
     /// </summary>
     /// <remarks>
     /// This supports just enough expression types to handle generating C# code for lambda
-    /// expressions constructed by <see cref="NodeApi.Hosting.JSMarsaler" />.
+    /// expressions constructed by <see cref="Microsoft.JavaScript.NodeApi.DotNetHost.JSMarsaler" />.
     /// </remarks>
     /// <exception cref="NotImplementedException">Thrown if expression includes a node type
     /// for which C# conversion is not implemented.</exception>

--- a/src/NodeApi.Generator/ModuleGenerator.cs
+++ b/src/NodeApi.Generator/ModuleGenerator.cs
@@ -5,9 +5,10 @@ using System.Linq;
 using System.Linq.Expressions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Text;
-using NodeApi.Hosting;
+using Microsoft.JavaScript.NodeApi.DotNetHost;
+using Microsoft.JavaScript.NodeApi.Interop;
 
-namespace NodeApi.Generator;
+namespace Microsoft.JavaScript.NodeApi.Generator;
 
 // An analyzer bug results in incorrect reports of CA1822 against methods in this class.
 #pragma warning disable CA1822 // Mark members as static
@@ -94,7 +95,8 @@ public class ModuleGenerator : SourceGenerator, ISourceGenerator
 
         foreach (ITypeSymbol type in GetCompilationTypes())
         {
-            if (type.GetAttributes().Any((a) => a.AttributeClass?.Name == "JSModuleAttribute"))
+            if (type.GetAttributes().Any(
+                (a) => a.AttributeClass?.AsType() == typeof(JSModuleAttribute)))
             {
                 if (type.TypeKind != TypeKind.Class)
                 {
@@ -120,7 +122,7 @@ public class ModuleGenerator : SourceGenerator, ISourceGenerator
                 foreach (ISymbol? member in type.GetMembers())
                 {
                     if (member.GetAttributes().Any(
-                        (a) => a.AttributeClass?.Name == "JSModuleAttribute"))
+                        (a) => a.AttributeClass?.AsType() == typeof(JSModuleAttribute)))
                     {
                         // TODO: Check method parameter and return types.
                         if (member is not IMethodSymbol)
@@ -262,10 +264,11 @@ public class ModuleGenerator : SourceGenerator, ISourceGenerator
 
         s += "using System.CodeDom.Compiler;";
         s += "using System.Runtime.InteropServices;";
-        s += "using static NodeApi.JSNativeApi.Interop;";
+        s += "using Microsoft.JavaScript.NodeApi.Interop;";
+        s += "using static Microsoft.JavaScript.NodeApi.JSNativeApi.Interop;";
 
         s++;
-        s += "namespace NodeApi.Generated;";
+        s += "namespace Microsoft.JavaScript.NodeApi.Generated;";
         s++;
 
         string generatorName = typeof(ModuleGenerator).Assembly.GetName()!.Name!;

--- a/src/NodeApi.Generator/Program.cs
+++ b/src/NodeApi.Generator/Program.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace NodeApi.Generator;
+namespace Microsoft.JavaScript.NodeApi.Generator;
 
 /// <summary>
 /// Command-line interface for the Node API TS type-definitions generator tool.

--- a/src/NodeApi.Generator/SourceBuilder.cs
+++ b/src/NodeApi.Generator/SourceBuilder.cs
@@ -2,7 +2,7 @@ using System;
 using System.Text;
 using Microsoft.CodeAnalysis.Text;
 
-namespace NodeApi.Generator;
+namespace Microsoft.JavaScript.NodeApi.Generator;
 
 internal class SourceBuilder : SourceText
 {

--- a/src/NodeApi.Generator/SourceGenerator.cs
+++ b/src/NodeApi.Generator/SourceGenerator.cs
@@ -5,7 +5,7 @@ using System.Text;
 using System.Text.RegularExpressions;
 using Microsoft.CodeAnalysis;
 
-namespace NodeApi.Generator;
+namespace Microsoft.JavaScript.NodeApi.Generator;
 
 // An analyzer bug results in incorrect reports of CA1822 against methods in this class.
 #pragma warning disable CA1822 // Mark members as static

--- a/src/NodeApi.Generator/SymbolExtensions.cs
+++ b/src/NodeApi.Generator/SymbolExtensions.cs
@@ -5,7 +5,7 @@ using System.Reflection;
 using System.Reflection.Emit;
 using Microsoft.CodeAnalysis;
 
-namespace NodeApi.Generator;
+namespace Microsoft.JavaScript.NodeApi.Generator;
 
 /// <summary>
 /// Extension methods for code-analysis symbol interfaces to support creation of fake
@@ -166,8 +166,8 @@ internal static class SymbolExtensions
         // Preserve JS attributes, which might be referenced by the marshaler.
         foreach (AttributeData attribute in typeSymbol.GetAttributes())
         {
-            if (attribute.AttributeClass!.ContainingNamespace.Name ==
-                typeof(JSExportAttribute).Namespace)
+            if (attribute.AttributeClass!.ContainingAssembly.Name ==
+                typeof(JSExportAttribute).Assembly.GetName().Name)
             {
                 Type attributeType = attribute.AttributeClass.AsType();
                 ConstructorInfo constructor = attributeType.GetConstructor(

--- a/src/NodeApi.Generator/TypeDefinitionsGenerator.cs
+++ b/src/NodeApi.Generator/TypeDefinitionsGenerator.cs
@@ -8,8 +8,9 @@ using System.Text;
 using System.Text.RegularExpressions;
 using System.Xml.Linq;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.JavaScript.NodeApi.Interop;
 
-namespace NodeApi.Generator;
+namespace Microsoft.JavaScript.NodeApi.Generator;
 
 // An analyzer bug results in incorrect reports of CA1822 against methods in this class.
 #pragma warning disable CA1822 // Mark members as static

--- a/src/NodeApi/DotNetHost/HostFxr.cs
+++ b/src/NodeApi/DotNetHost/HostFxr.cs
@@ -5,7 +5,7 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
 
-namespace NodeApi.Hosting;
+namespace Microsoft.JavaScript.NodeApi.DotNetHost;
 
 /// <summary>
 /// P/Invoke declarations and supporting code for the CLR hosting APIs defined in

--- a/src/NodeApi/DotNetHost/NativeHost.cs
+++ b/src/NodeApi/DotNetHost/NativeHost.cs
@@ -3,10 +3,10 @@ using System;
 using System.IO;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using static NodeApi.Hosting.HostFxr;
-using static NodeApi.JSNativeApi.Interop;
+using static Microsoft.JavaScript.NodeApi.DotNetHost.HostFxr;
+using static Microsoft.JavaScript.NodeApi.JSNativeApi.Interop;
 
-namespace NodeApi.Hosting;
+namespace Microsoft.JavaScript.NodeApi.DotNetHost;
 
 /// <summary>
 /// When AOT-compiled, exposes a native entry-point that supports loading the .NET runtime
@@ -18,8 +18,8 @@ internal partial class NativeHost : IDisposable
 
     private const string NodeApiAssemblyName = "Microsoft.JavaScript.NodeApi";
     private const string ManagedHostAssemblyName = NodeApiAssemblyName + ".DotNetHost";
-    private const string ManagedHostTypeName =
-        $"{nameof(NodeApi)}.{nameof(NodeApi.Hosting)}.ManagedHost";
+    private static readonly string s_managedHostTypeName =
+        typeof(NativeHost).Namespace + ".ManagedHost";
 
     private readonly string _nodeApiHostDir;
     private hostfxr_handle _hostContextHandle;
@@ -165,7 +165,7 @@ internal partial class NativeHost : IDisposable
         CheckStatus(status, "Failed to get CLR load-assembly function.");
 
         // TODO Get the correct assembly version (and publickeytoken) somehow.
-        string managedHostTypeName = $"{ManagedHostTypeName}, {ManagedHostAssemblyName}" +
+        string managedHostTypeName = $"{s_managedHostTypeName}, {ManagedHostAssemblyName}" +
             ", Version=1.0.0.0, Culture=neutral, PublicKeyToken=null";
         Trace("    Loading managed host type: " + managedHostTypeName);
 

--- a/src/NodeApi/Interop/IJSObjectUnwrapOfT.cs
+++ b/src/NodeApi/Interop/IJSObjectUnwrapOfT.cs
@@ -1,4 +1,4 @@
-namespace NodeApi;
+namespace Microsoft.JavaScript.NodeApi.Interop;
 
 public interface IJSObjectUnwrap<T> where T : class
 {

--- a/src/NodeApi/Interop/JSAsyncScope.cs
+++ b/src/NodeApi/Interop/JSAsyncScope.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Threading;
 
-namespace NodeApi;
+namespace Microsoft.JavaScript.NodeApi.Interop;
 
 /// <summary>
 /// Helps preventing Node.JS process from exiting while we execute C# async functions.

--- a/src/NodeApi/Interop/JSCallbackDescriptor.cs
+++ b/src/NodeApi/Interop/JSCallbackDescriptor.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace NodeApi;
+namespace Microsoft.JavaScript.NodeApi.Interop;
 
 /// <summary>
 /// Descriptor for a callback not associated with an object property, for example a constructor

--- a/src/NodeApi/Interop/JSCallbackOverload.cs
+++ b/src/NodeApi/Interop/JSCallbackOverload.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
 
-namespace NodeApi;
+namespace Microsoft.JavaScript.NodeApi.Interop;
 
 /// <summary>
 /// Holds overload resolution information (parameter types) for one of multiple overloads

--- a/src/NodeApi/Interop/JSClassBuilderOfT.cs
+++ b/src/NodeApi/Interop/JSClassBuilderOfT.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Linq;
 
-namespace NodeApi;
+namespace Microsoft.JavaScript.NodeApi.Interop;
 
 public class JSClassBuilder<T>
   : JSPropertyDescriptorList<JSClassBuilder<T>, T>

--- a/src/NodeApi/Interop/JSCollectionExtensions.cs
+++ b/src/NodeApi/Interop/JSCollectionExtensions.cs
@@ -3,7 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 
-namespace NodeApi;
+namespace Microsoft.JavaScript.NodeApi.Interop;
 
 public static class JSCollectionExtensions
 {

--- a/src/NodeApi/Interop/JSCollectionProxies.cs
+++ b/src/NodeApi/Interop/JSCollectionProxies.cs
@@ -1,7 +1,7 @@
 
 using System.Collections.Generic;
 
-namespace NodeApi;
+namespace Microsoft.JavaScript.NodeApi.Interop;
 
 internal static class JSCollectionProxies
 {

--- a/src/NodeApi/Interop/JSContext.cs
+++ b/src/NodeApi/Interop/JSContext.cs
@@ -1,11 +1,11 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using static NodeApi.JSCollectionProxies;
-using static NodeApi.JSNativeApi;
-using napi_env = NodeApi.JSNativeApi.Interop.napi_env;
+using static Microsoft.JavaScript.NodeApi.Interop.JSCollectionProxies;
+using static Microsoft.JavaScript.NodeApi.JSNativeApi;
+using napi_env = Microsoft.JavaScript.NodeApi.JSNativeApi.Interop.napi_env;
 
-namespace NodeApi;
+namespace Microsoft.JavaScript.NodeApi.Interop;
 
 /// <summary>
 /// Manages JavaScript interop context for the lifetime of a module.
@@ -88,7 +88,7 @@ public sealed class JSContext : IDisposable
 
     public JSContext(napi_env env)
     {
-        Interop.Initialize();
+        JSNativeApi.Interop.Initialize();
         _env = env;
         SetInstanceData(env, this);
         SynchronizationContext = new JSSynchronizationContext();

--- a/src/NodeApi/Interop/JSInterface.cs
+++ b/src/NodeApi/Interop/JSInterface.cs
@@ -1,5 +1,5 @@
 
-namespace NodeApi;
+namespace Microsoft.JavaScript.NodeApi.Interop;
 
 /// <summary>
 /// Base class for a dynamically generated interface adapter that enables a JS object to implement

--- a/src/NodeApi/Interop/JSModuleAttribute.cs
+++ b/src/NodeApi/Interop/JSModuleAttribute.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace NodeApi;
+namespace Microsoft.JavaScript.NodeApi.Interop;
 
 /// <summary>
 /// Designates a non-static class or static method that initializes the JS module.

--- a/src/NodeApi/Interop/JSModuleBuilderOfT.cs
+++ b/src/NodeApi/Interop/JSModuleBuilderOfT.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Linq;
 
-namespace NodeApi;
+namespace Microsoft.JavaScript.NodeApi.Interop;
 
 /// <summary>
 /// Builds JS module exports.

--- a/src/NodeApi/Interop/JSPropertyDescriptorListOfT.cs
+++ b/src/NodeApi/Interop/JSPropertyDescriptorListOfT.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
 
-namespace NodeApi;
+namespace Microsoft.JavaScript.NodeApi.Interop;
 
 public abstract class JSPropertyDescriptorList<TDerived, TObject>
   where TDerived : class, IJSObjectUnwrap<TObject>

--- a/src/NodeApi/Interop/JSStructBuilderOfT.cs
+++ b/src/NodeApi/Interop/JSStructBuilderOfT.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace NodeApi;
+namespace Microsoft.JavaScript.NodeApi.Interop;
 
 public class JSStructBuilder<T> where T : struct
 {

--- a/src/NodeApi/Interop/JSSynchronizationContext.cs
+++ b/src/NodeApi/Interop/JSSynchronizationContext.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Threading;
 
-namespace NodeApi;
+namespace Microsoft.JavaScript.NodeApi.Interop;
 
 public class JSSynchronizationContext : SynchronizationContext, IDisposable
 {

--- a/src/NodeApi/Interop/JSThreadSafeFunction.cs
+++ b/src/NodeApi/Interop/JSThreadSafeFunction.cs
@@ -1,10 +1,10 @@
 using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using static NodeApi.JSNativeApi.Interop;
-using static NodeApi.JSNativeApi.NodeApiInterop;
+using static Microsoft.JavaScript.NodeApi.JSNativeApi.Interop;
+using static Microsoft.JavaScript.NodeApi.JSNativeApi.NodeApiInterop;
 
-namespace NodeApi;
+namespace Microsoft.JavaScript.NodeApi.Interop;
 
 public delegate void JSThreadSafeCallback(JSValue jsFunction, object? functionContext, object? callbackData);
 

--- a/src/NodeApi/JSArray.Enumerator.cs
+++ b/src/NodeApi/JSArray.Enumerator.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 
-namespace NodeApi;
+namespace Microsoft.JavaScript.NodeApi;
 
 public partial struct JSArray
 {

--- a/src/NodeApi/JSArray.cs
+++ b/src/NodeApi/JSArray.cs
@@ -3,7 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 
-namespace NodeApi;
+namespace Microsoft.JavaScript.NodeApi;
 
 public readonly partial struct JSArray : IList<JSValue>, IEquatable<JSValue>
 {

--- a/src/NodeApi/JSCallback.cs
+++ b/src/NodeApi/JSCallback.cs
@@ -1,5 +1,5 @@
 
-namespace NodeApi;
+namespace Microsoft.JavaScript.NodeApi;
 
 public delegate JSValue JSCallback(JSCallbackArgs args);
 

--- a/src/NodeApi/JSCallbackArgs.cs
+++ b/src/NodeApi/JSCallbackArgs.cs
@@ -1,8 +1,8 @@
 using System;
 using System.Runtime.InteropServices;
-using static NodeApi.JSNativeApi.Interop;
+using static Microsoft.JavaScript.NodeApi.JSNativeApi.Interop;
 
-namespace NodeApi;
+namespace Microsoft.JavaScript.NodeApi;
 
 public readonly ref struct JSCallbackArgs
 {

--- a/src/NodeApi/JSDate.cs
+++ b/src/NodeApi/JSDate.cs
@@ -1,7 +1,8 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
+using Microsoft.JavaScript.NodeApi.Interop;
 
-namespace NodeApi;
+namespace Microsoft.JavaScript.NodeApi;
 
 public readonly struct JSDate : IEquatable<JSValue>
 {

--- a/src/NodeApi/JSError.cs
+++ b/src/NodeApi/JSError.cs
@@ -3,11 +3,11 @@ using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
-using static NodeApi.JSNativeApi;
-using static NodeApi.JSNativeApi.Interop;
-using static NodeApi.JSNativeApi.NodeApiInterop;
+using static Microsoft.JavaScript.NodeApi.JSNativeApi;
+using static Microsoft.JavaScript.NodeApi.JSNativeApi.Interop;
+using static Microsoft.JavaScript.NodeApi.JSNativeApi.NodeApiInterop;
 
-namespace NodeApi;
+namespace Microsoft.JavaScript.NodeApi;
 
 public enum JSErrorType { Error, TypeError, RangeError, SyntaxError }
 

--- a/src/NodeApi/JSException.cs
+++ b/src/NodeApi/JSException.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace NodeApi;
+namespace Microsoft.JavaScript.NodeApi;
 
 public class JSException : Exception
 {

--- a/src/NodeApi/JSExportAttribute.cs
+++ b/src/NodeApi/JSExportAttribute.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace NodeApi;
+namespace Microsoft.JavaScript.NodeApi;
 
 /// <summary>
 /// Exports an item to JavaScript, optionally specifying the name of the export and whether

--- a/src/NodeApi/JSIterable.Enumerator.cs
+++ b/src/NodeApi/JSIterable.Enumerator.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 
-namespace NodeApi;
+namespace Microsoft.JavaScript.NodeApi;
 
 public partial struct JSIterable
 {

--- a/src/NodeApi/JSIterable.cs
+++ b/src/NodeApi/JSIterable.cs
@@ -3,7 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 
-namespace NodeApi;
+namespace Microsoft.JavaScript.NodeApi;
 
 public readonly partial struct JSIterable : IEnumerable<JSValue>, IEquatable<JSValue>
 {

--- a/src/NodeApi/JSMap.Enumerator.cs
+++ b/src/NodeApi/JSMap.Enumerator.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
 
-namespace NodeApi;
+namespace Microsoft.JavaScript.NodeApi;
 
 public partial struct JSMap
 {

--- a/src/NodeApi/JSMap.cs
+++ b/src/NodeApi/JSMap.cs
@@ -1,8 +1,9 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using Microsoft.JavaScript.NodeApi.Interop;
 
-namespace NodeApi;
+namespace Microsoft.JavaScript.NodeApi;
 
 public readonly partial struct JSMap : IDictionary<JSValue, JSValue>, IEquatable<JSValue>
 {

--- a/src/NodeApi/JSObject.Enumerator.cs
+++ b/src/NodeApi/JSObject.Enumerator.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 
-namespace NodeApi;
+namespace Microsoft.JavaScript.NodeApi;
 
 public partial struct JSObject
 {

--- a/src/NodeApi/JSObject.cs
+++ b/src/NodeApi/JSObject.cs
@@ -3,7 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 
-namespace NodeApi;
+namespace Microsoft.JavaScript.NodeApi;
 
 public readonly partial struct JSObject : IDictionary<JSValue, JSValue>, IEquatable<JSValue>
 {

--- a/src/NodeApi/JSPromise.cs
+++ b/src/NodeApi/JSPromise.cs
@@ -2,9 +2,10 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
-using static NodeApi.JSNativeApi.Interop;
+using Microsoft.JavaScript.NodeApi.Interop;
+using static Microsoft.JavaScript.NodeApi.JSNativeApi.Interop;
 
-namespace NodeApi;
+namespace Microsoft.JavaScript.NodeApi;
 
 /// <summary>
 /// Represents a JavaScript Promise object.

--- a/src/NodeApi/JSPromiseExtensions.cs
+++ b/src/NodeApi/JSPromiseExtensions.cs
@@ -1,6 +1,6 @@
 using System.Threading.Tasks;
 
-namespace NodeApi;
+namespace Microsoft.JavaScript.NodeApi;
 
 /// <summary>
 /// Extension methods for converting between .NET tasks and JS promises.

--- a/src/NodeApi/JSPropertyAttributes.cs
+++ b/src/NodeApi/JSPropertyAttributes.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace NodeApi;
+namespace Microsoft.JavaScript.NodeApi;
 
 [Flags]
 public enum JSPropertyAttributes : int

--- a/src/NodeApi/JSPropertyDescriptor.cs
+++ b/src/NodeApi/JSPropertyDescriptor.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace NodeApi;
+namespace Microsoft.JavaScript.NodeApi;
 
 public readonly struct JSPropertyDescriptor
 {

--- a/src/NodeApi/JSProxy.cs
+++ b/src/NodeApi/JSProxy.cs
@@ -2,8 +2,9 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading;
+using Microsoft.JavaScript.NodeApi.Interop;
 
-namespace NodeApi;
+namespace Microsoft.JavaScript.NodeApi;
 
 /// <summary>
 /// Enables creation of JS Proxy objects with C# handler callbacks.

--- a/src/NodeApi/JSReference.cs
+++ b/src/NodeApi/JSReference.cs
@@ -1,8 +1,9 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
-using static NodeApi.JSNativeApi.Interop;
+using Microsoft.JavaScript.NodeApi.Interop;
+using static Microsoft.JavaScript.NodeApi.JSNativeApi.Interop;
 
-namespace NodeApi;
+namespace Microsoft.JavaScript.NodeApi;
 
 /// <summary>
 /// A strong or weak reference to a JS value.

--- a/src/NodeApi/JSSet.cs
+++ b/src/NodeApi/JSSet.cs
@@ -2,8 +2,9 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using Microsoft.JavaScript.NodeApi.Interop;
 
-namespace NodeApi;
+namespace Microsoft.JavaScript.NodeApi;
 
 public readonly partial struct JSSet : ISet<JSValue>, IEquatable<JSValue>
 {

--- a/src/NodeApi/JSSymbol.cs
+++ b/src/NodeApi/JSSymbol.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace NodeApi;
+namespace Microsoft.JavaScript.NodeApi;
 
 public readonly struct JSSymbol : IEquatable<JSValue>
 {

--- a/src/NodeApi/JSTypedArray.cs
+++ b/src/NodeApi/JSTypedArray.cs
@@ -4,7 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-namespace NodeApi;
+namespace Microsoft.JavaScript.NodeApi;
 
 public readonly struct JSTypedArray<T> : IEquatable<JSValue> where T : struct
 {

--- a/src/NodeApi/JSTypedArrayType.cs
+++ b/src/NodeApi/JSTypedArrayType.cs
@@ -1,4 +1,4 @@
-namespace NodeApi;
+namespace Microsoft.JavaScript.NodeApi;
 
 // Matches to napi_typedarray_type
 public enum JSTypedArrayType : int

--- a/src/NodeApi/JSValue.cs
+++ b/src/NodeApi/JSValue.cs
@@ -2,10 +2,11 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 using System.Text;
-using static NodeApi.JSNativeApi;
-using static NodeApi.JSNativeApi.Interop;
+using Microsoft.JavaScript.NodeApi.Interop;
+using static Microsoft.JavaScript.NodeApi.JSNativeApi;
+using static Microsoft.JavaScript.NodeApi.JSNativeApi.Interop;
 
-namespace NodeApi;
+namespace Microsoft.JavaScript.NodeApi;
 
 public readonly struct JSValue : IEquatable<JSValue>
 {

--- a/src/NodeApi/JSValueScope.cs
+++ b/src/NodeApi/JSValueScope.cs
@@ -1,8 +1,9 @@
 using System;
 using System.Threading;
-using static NodeApi.JSNativeApi.Interop;
+using Microsoft.JavaScript.NodeApi.Interop;
+using static Microsoft.JavaScript.NodeApi.JSNativeApi.Interop;
 
-namespace NodeApi;
+namespace Microsoft.JavaScript.NodeApi;
 
 public enum JSValueScopeType { Handle, Escapable, Callback, Root, RootNoContext, }
 

--- a/src/NodeApi/JSValueType.cs
+++ b/src/NodeApi/JSValueType.cs
@@ -1,4 +1,4 @@
-namespace NodeApi;
+namespace Microsoft.JavaScript.NodeApi;
 
 public enum JSValueType : int
 {

--- a/src/NodeApi/Native/JSKeyCollectionMode.cs
+++ b/src/NodeApi/Native/JSKeyCollectionMode.cs
@@ -1,4 +1,4 @@
-namespace NodeApi;
+namespace Microsoft.JavaScript.NodeApi;
 
 public enum JSKeyCollectionMode : int
 {

--- a/src/NodeApi/Native/JSKeyConversion.cs
+++ b/src/NodeApi/Native/JSKeyConversion.cs
@@ -1,4 +1,4 @@
-namespace NodeApi;
+namespace Microsoft.JavaScript.NodeApi;
 
 public enum JSKeyConversion : int
 {

--- a/src/NodeApi/Native/JSKeyFilter.cs
+++ b/src/NodeApi/Native/JSKeyFilter.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace NodeApi;
+namespace Microsoft.JavaScript.NodeApi;
 
 [Flags]
 public enum JSKeyFilter : int

--- a/src/NodeApi/Native/JSNativeApi.Interop.cs
+++ b/src/NodeApi/Native/JSNativeApi.Interop.cs
@@ -5,7 +5,7 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Security;
 
-namespace NodeApi;
+namespace Microsoft.JavaScript.NodeApi;
 
 public static partial class JSNativeApi
 {

--- a/src/NodeApi/Native/JSNativeApi.NodeApiInterop.cs
+++ b/src/NodeApi/Native/JSNativeApi.NodeApiInterop.cs
@@ -1,12 +1,12 @@
-// Definitions from Node.JS node_api.h and node_api_types.h 
+// Definitions from Node.JS node_api.h and node_api_types.h
 
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Security;
-using static NodeApi.JSNativeApi.Interop;
+using static Microsoft.JavaScript.NodeApi.JSNativeApi.Interop;
 
-namespace NodeApi;
+namespace Microsoft.JavaScript.NodeApi;
 
 public static partial class JSNativeApi
 {

--- a/src/NodeApi/Native/JSNativeApi.cs
+++ b/src/NodeApi/Native/JSNativeApi.cs
@@ -4,9 +4,10 @@ using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
-using static NodeApi.JSNativeApi.Interop;
+using Microsoft.JavaScript.NodeApi.Interop;
+using static Microsoft.JavaScript.NodeApi.JSNativeApi.Interop;
 
-namespace NodeApi;
+namespace Microsoft.JavaScript.NodeApi;
 
 // Node API managed wrappers
 public static partial class JSNativeApi

--- a/test/HostedClrTests.cs
+++ b/test/HostedClrTests.cs
@@ -4,12 +4,12 @@ using System.Collections.Generic;
 using System.IO;
 using Xunit;
 
-using static NodeApi.Test.TestBuilder;
+using static Microsoft.JavaScript.NodeApi.Test.TestBuilder;
 
 // Avoid running MSBuild on the same project concurrently.
 [assembly: CollectionBehavior(DisableTestParallelization = true)]
 
-namespace NodeApi.Test;
+namespace Microsoft.JavaScript.NodeApi.Test;
 
 public class HostedClrTests
 {

--- a/test/NativeAotTests.cs
+++ b/test/NativeAotTests.cs
@@ -4,9 +4,9 @@ using System.Diagnostics;
 using System.IO;
 using Xunit;
 
-using static NodeApi.Test.TestBuilder;
+using static Microsoft.JavaScript.NodeApi.Test.TestBuilder;
 
-namespace NodeApi.Test;
+namespace Microsoft.JavaScript.NodeApi.Test;
 
 public class NativeAotTests
 {

--- a/test/TestBuilder.cs
+++ b/test/TestBuilder.cs
@@ -8,10 +8,10 @@ using Microsoft.Build.Evaluation;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Locator;
 using Microsoft.Build.Logging;
-using NodeApi.Generator;
+using Microsoft.JavaScript.NodeApi.Generator;
 using Xunit;
 
-namespace NodeApi.Test;
+namespace Microsoft.JavaScript.NodeApi.Test;
 
 /// <summary>
 /// Utility methods that assist with building and running test cases.

--- a/test/TestCases/edgejs-perf/Edge.Performance.cs
+++ b/test/TestCases/edgejs-perf/Edge.Performance.cs
@@ -1,7 +1,7 @@
 // Ported from https://github.com/agracio/edge-js/blob/master/performance/performance.cs
 
 using System;
-using NodeApi;
+using Microsoft.JavaScript.NodeApi;
 
 #pragma warning disable IDE0060 // Unused parameter 'input'
 

--- a/test/TestCases/napi-dotnet-init/ModuleInitializer.cs
+++ b/test/TestCases/napi-dotnet-init/ModuleInitializer.cs
@@ -1,6 +1,7 @@
 using System;
+using Microsoft.JavaScript.NodeApi.Interop;
 
-namespace NodeApi.TestCases;
+namespace Microsoft.JavaScript.NodeApi.TestCases;
 
 public class ModuleInitializer
 {

--- a/test/TestCases/napi-dotnet/Another.cs
+++ b/test/TestCases/napi-dotnet/Another.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace NodeApi.TestCases;
+namespace Microsoft.JavaScript.NodeApi.TestCases;
 
 #pragma warning disable CA1822 // Mark members as static
 

--- a/test/TestCases/napi-dotnet/AsyncMethods.cs
+++ b/test/TestCases/napi-dotnet/AsyncMethods.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Threading.Tasks;
 
-namespace NodeApi.TestCases;
+namespace Microsoft.JavaScript.NodeApi.TestCases;
 
 public static class AsyncMethods
 {

--- a/test/TestCases/napi-dotnet/ComplexTypes.cs
+++ b/test/TestCases/napi-dotnet/ComplexTypes.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
 
-namespace NodeApi.TestCases;
+namespace Microsoft.JavaScript.NodeApi.TestCases;
 
 /// <summary>
 /// Tests marshalling of various non-primitive types.

--- a/test/TestCases/napi-dotnet/Counter.cs
+++ b/test/TestCases/napi-dotnet/Counter.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Threading;
 
-namespace NodeApi.TestCases;
+namespace Microsoft.JavaScript.NodeApi.TestCases;
 
 /// <summary>
 /// Enables testing static state.

--- a/test/TestCases/napi-dotnet/Hello.cs
+++ b/test/TestCases/napi-dotnet/Hello.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace NodeApi.TestCases;
+namespace Microsoft.JavaScript.NodeApi.TestCases;
 
 public static class Hello
 {

--- a/test/TestCases/napi-dotnet/ModuleClass.cs
+++ b/test/TestCases/napi-dotnet/ModuleClass.cs
@@ -1,6 +1,7 @@
 using System;
+using Microsoft.JavaScript.NodeApi.Interop;
 
-namespace NodeApi.TestCases;
+namespace Microsoft.JavaScript.NodeApi.TestCases;
 
 #pragma warning disable CA1822 // Mark members as static
 

--- a/test/TestCases/napi-dotnet/ModuleExports.cs
+++ b/test/TestCases/napi-dotnet/ModuleExports.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace NodeApi.TestCases;
+namespace Microsoft.JavaScript.NodeApi.TestCases;
 
 public static class ModuleExports
 {

--- a/test/TestCases/napi-dotnet/dynamic_invoke.js
+++ b/test/TestCases/napi-dotnet/dynamic_invoke.js
@@ -15,7 +15,7 @@ assert.strictEqual(version + '.4', '1.2.3.4'); // Implicit call to .NET ToString
 const assembly = dotnet.load(assemblyPath);
 console.dir(Object.keys(assembly)); // Print all public types in the loaded assembly.
 
-const Hello = assembly['NodeApi.TestCases.Hello'];
+const Hello = assembly['Microsoft.JavaScript.NodeApi.TestCases.Hello'];
 console.dir(Object.keys(Hello)); // Print all public static members of the Hello class.
 
 const greeting = Hello.Test('assembly'); // Call a static method.

--- a/test/TestCases/node-addon-api/basic_types/array.cs
+++ b/test/TestCases/node-addon-api/basic_types/array.cs
@@ -1,6 +1,6 @@
-using NodeApi;
+using Microsoft.JavaScript.NodeApi;
 
-namespace NodeApiTest;
+namespace Microsoft.JavaScript.NodeApiTest;
 
 public class TestBasicTypesArray : TestHelper, ITestObject
 {

--- a/test/TestCases/node-addon-api/basic_types/boolean.cs
+++ b/test/TestCases/node-addon-api/basic_types/boolean.cs
@@ -1,6 +1,6 @@
-using NodeApi;
+using Microsoft.JavaScript.NodeApi;
 
-namespace NodeApiTest;
+namespace Microsoft.JavaScript.NodeApiTest;
 
 public class TestBasicTypesBoolean : TestHelper, ITestObject
 {

--- a/test/TestCases/node-addon-api/basic_types/number.cs
+++ b/test/TestCases/node-addon-api/basic_types/number.cs
@@ -1,6 +1,6 @@
-using NodeApi;
+using Microsoft.JavaScript.NodeApi;
 
-namespace NodeApiTest;
+namespace Microsoft.JavaScript.NodeApiTest;
 
 public class TestBasicTypesNumber : TestHelper, ITestObject
 {

--- a/test/TestCases/node-addon-api/basic_types/value.cs
+++ b/test/TestCases/node-addon-api/basic_types/value.cs
@@ -1,6 +1,6 @@
-using NodeApi;
+using Microsoft.JavaScript.NodeApi;
 
-namespace NodeApiTest;
+namespace Microsoft.JavaScript.NodeApiTest;
 
 public class TestBasicTypesValue : TestHelper, ITestObject
 {

--- a/test/TestCases/node-addon-api/binding.cs
+++ b/test/TestCases/node-addon-api/binding.cs
@@ -1,9 +1,10 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
-using NodeApi;
+using Microsoft.JavaScript.NodeApi;
+using Microsoft.JavaScript.NodeApi.Interop;
 
-namespace NodeApiTest;
+namespace Microsoft.JavaScript.NodeApiTest;
 
 [JSModule]
 public class Binding

--- a/test/TestCases/node-addon-api/object/delete_property.cs
+++ b/test/TestCases/node-addon-api/object/delete_property.cs
@@ -1,7 +1,7 @@
 using System;
-using NodeApi;
+using Microsoft.JavaScript.NodeApi;
 
-namespace NodeApiTest;
+namespace Microsoft.JavaScript.NodeApiTest;
 
 public partial class TestObject
 {

--- a/test/TestCases/node-addon-api/object/finalizer.cs
+++ b/test/TestCases/node-addon-api/object/finalizer.cs
@@ -1,6 +1,6 @@
-using NodeApi;
+using Microsoft.JavaScript.NodeApi;
 
-namespace NodeApiTest;
+namespace Microsoft.JavaScript.NodeApiTest;
 
 public partial class TestObject
 {

--- a/test/TestCases/node-addon-api/object/get_property.cs
+++ b/test/TestCases/node-addon-api/object/get_property.cs
@@ -1,6 +1,6 @@
-using NodeApi;
+using Microsoft.JavaScript.NodeApi;
 
-namespace NodeApiTest;
+namespace Microsoft.JavaScript.NodeApiTest;
 
 public partial class TestObject
 {

--- a/test/TestCases/node-addon-api/object/has_own_property.cs
+++ b/test/TestCases/node-addon-api/object/has_own_property.cs
@@ -1,6 +1,6 @@
-using NodeApi;
+using Microsoft.JavaScript.NodeApi;
 
-namespace NodeApiTest;
+namespace Microsoft.JavaScript.NodeApiTest;
 
 public partial class TestObject
 {

--- a/test/TestCases/node-addon-api/object/has_property.cs
+++ b/test/TestCases/node-addon-api/object/has_property.cs
@@ -1,6 +1,6 @@
-using NodeApi;
+using Microsoft.JavaScript.NodeApi;
 
-namespace NodeApiTest;
+namespace Microsoft.JavaScript.NodeApiTest;
 
 public partial class TestObject
 {

--- a/test/TestCases/node-addon-api/object/object.cs
+++ b/test/TestCases/node-addon-api/object/object.cs
@@ -1,7 +1,7 @@
 using System.Runtime.CompilerServices;
-using NodeApi;
+using Microsoft.JavaScript.NodeApi;
 
-namespace NodeApiTest;
+namespace Microsoft.JavaScript.NodeApiTest;
 
 public partial class TestObject : TestHelper, ITestObject
 {

--- a/test/TestCases/node-addon-api/object/object_freeze_seal.cs
+++ b/test/TestCases/node-addon-api/object/object_freeze_seal.cs
@@ -1,6 +1,6 @@
-using NodeApi;
+using Microsoft.JavaScript.NodeApi;
 
-namespace NodeApiTest;
+namespace Microsoft.JavaScript.NodeApiTest;
 
 public partial class TestObjectFreezeSeal : TestHelper, ITestObject
 {

--- a/test/TestCases/node-addon-api/object/set_property.cs
+++ b/test/TestCases/node-addon-api/object/set_property.cs
@@ -1,7 +1,7 @@
 using System;
-using NodeApi;
+using Microsoft.JavaScript.NodeApi;
 
-namespace NodeApiTest;
+namespace Microsoft.JavaScript.NodeApiTest;
 
 public partial class TestObject
 {

--- a/test/TestCases/node-addon-api/object/subscript_operator.cs
+++ b/test/TestCases/node-addon-api/object/subscript_operator.cs
@@ -1,6 +1,6 @@
-using NodeApi;
+using Microsoft.JavaScript.NodeApi;
 
-namespace NodeApiTest;
+namespace Microsoft.JavaScript.NodeApiTest;
 
 public partial class TestObject
 {


### PR DESCRIPTION
> [<img alt="jasongin" height="40" width="40" align="left" src="https://avatars0.githubusercontent.com/u/13093042?s=40&v=4">](/jasongin) **Authored by [jasongin](/jasongin)** on _<time datetime="2023-03-06T20:27:09Z" title="Monday, March 6th 2023, 12:27:09 pm -08:00">Mar 6, 2023</time>_, merged on _<time datetime="2023-03-06T22:43:18Z" title="Monday, March 6th 2023, 2:43:18 pm -08:00">Mar 6, 2023</time>_
Imported from _jasongin/napi-dotnet_ repo
---
 - Prepend `Microsoft.JavaScript.` to all `NodeApi` namespaces.
 - Add `Interop` namespace for that subfolder in main library.
 - Rename `Hosting` namespace to `DotNetHost`.

I am NOT creating a `Microsoft.JavaScript.NodeApi.Native` namespace yet, because that will require more refactoring. Lots of code depends on extension methods in `JSNativeApi`. I think those should be refactored to methods or extension methods in the root namespace, then `JSNativeApi` should be internal. Also maybe code within `JSNativeApi` can be organized into more separate types, since they will all be in an internal namespace.