### PR TITLE
Build improvements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,9 +52,6 @@ jobs:
     - name: Build
       run: dotnet build --configuration Release
 
-    - name: Build native binaries
-      run: dotnet publish --configuration Release --framework net7.0
-
     - name: Build packages
       run: dotnet pack --configuration Release
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,13 +3,10 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Microsoft.Build" Version="17.3.2" />
-    <PackageVersion Include="Microsoft.Build.Locator" Version="1.5.5" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.3.1" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.5.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageVersion Include="Nerdbank.GitVersioning" Version="3.5.119" />
-    <PackageVersion Include="NuGet.Frameworks" Version="6.4.0" />
     <PackageVersion Include="System.Reflection.MetadataLoadContext" Version="6.0.0" />
     <PackageVersion Include="xunit" Version="2.4.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.5" />

--- a/README-DEV.md
+++ b/README-DEV.md
@@ -11,25 +11,19 @@ from re-using a previously-loaded (possibly outdated) version of the source gene
 
 ## Build Packages
 ```bash
-dotnet publish -f net7.0 -c Release
 dotnet pack -c Release
 ```
 This produces both nuget and npm packages (for the current platform only) in the `out/pkg`
-directory. Binaries for the `net7.0` target framework must be built and published first
-so that the Node API .NET native AOT host can be packaged.
+directory.
 
 ## Test
 ```bash
-dotnet publish -f net7.0
 dotnet test
 ```
 
-Binaries for the `net7.0` target framework must be built and published first
-because tests require the Node API .NET native AOT host.
-
-Use the `--filter` option to run a subset of test cases:
+Use `--framework` to specify a target framework, or `--filter` to run a subset of test cases:
 ```bash
-dotnet test --filter "DisplayName~aot"
+dotnet test --framework net7.0 --filter "DisplayName~aot"
 ```
 
 The list of test cases is automatically derived from the set of `.js` files under the

--- a/examples/aot-module/README.md
+++ b/examples/aot-module/README.md
@@ -7,7 +7,6 @@ module's APIs via the auto-generated `.d.ts` file.
 
 | Command                          | Explanation
 |----------------------------------|--------------------------------------------------
-| `dotnet publish -f net7.0 ../..` | Build NodeApi .NET native AOT host.
-| `dotnet pack ../..`              | Build NodeApi .NET & npm packages.
-| `dotnet publish`                 | Install NodeApi .NET packages into example project; build example project and compile to native binary.
+| `dotnet pack ../..`              | Build Node API .NET packages.
+| `dotnet publish`                 | Install Node API .NET packages into example project; build example project and compile to native binary.
 | `node example.js`                | Run example JS code that calls the example module.

--- a/examples/dotnet-dynamic/README.md
+++ b/examples/dotnet-dynamic/README.md
@@ -4,7 +4,6 @@ The `example.js` script loads .NET  and calls `Console.WriteLine()`.
 
 | Command                          | Explanation
 |----------------------------------|--------------------------------------------------
-| `dotnet publish -f net7.0 ../..` | Build NodeApi .NET host.
-| `dotnet pack ../..`              | Build NodeApi .NET & npm packages.
+| `dotnet pack ../..`              | Build Node API .NET packages.
 | `npm install`                    | Install `node-api-dotnet` npm package into the example project.
 | `node example.js`                | Run example JS code that uses that package to dynamically invoke a .NET API.

--- a/examples/dotnet-module/README.md
+++ b/examples/dotnet-module/README.md
@@ -6,8 +6,7 @@ doc-comments for the module's APIs via the auto-generated `.d.ts` file.
 
 | Command                          | Explanation
 |----------------------------------|--------------------------------------------------
-| `dotnet publish -f net7.0 ../..` | Build NodeApi .NET host.
-| `dotnet pack ../..`              | Build NodeApi .NET & npm packages.
-| `npm install`                    | Install NodeApi npm package into example project.
-| `dotnet build`                   | Install NodeApi .NET packages into example project; build example project.
+| `dotnet pack ../..`              | Build Node API .NET packages.
+| `npm install`                    | Install Node API .NET npm package into example project.
+| `dotnet build`                   | Install Node API .NET nuget packages into example project; build example project.
 | `node example.js`                | Run example JS code that calls the example module.

--- a/examples/semantic-kernel/README.md
+++ b/examples/semantic-kernel/README.md
@@ -14,8 +14,7 @@ Then run the following commands in sequence:
 
 | Command                          | Explanation
 |----------------------------------|--------------------------------------------------
-| `dotnet publish -f net7.0 ../..` | Build NodeApi .NET host.
-| `dotnet pack ../..`              | Build NodeApi .NET & npm packages.
+| `dotnet pack ../..`              | Build Node API .NET packages.
 | `dotnet restore`                 | Install `SemanticKernel` nuget package into the project.
 | `npm install`                    | Install `node-api-dotnet` npm package into the project.
 | `node example.js`                | Run example JS code that uses the above packages to call the Azure OpenAI service.

--- a/src/NodeApi.DotNetHost/NodeApi.DotNetHost.csproj
+++ b/src/NodeApi.DotNetHost/NodeApi.DotNetHost.csproj
@@ -12,6 +12,14 @@
     <ProjectReference Include="..\NodeApi\NodeApi.csproj" GeneratePathProperty="true" PrivateAssets="all" />
   </ItemGroup>
 
+  <Target Name="PublishNativeHost" BeforeTargets="Pack">
+    <MSBuild
+      Projects="..\NodeApi\NodeApi.csproj"
+      Targets="Publish"
+      Properties="Configuration=$(Configuration);TargetFramework=net7.0"
+    />
+  </Target>
+
   <Target Name="NpmPack"
     AfterTargets="Pack"
     Outputs="$(PackageOutputPath)node-api-dotnet-$(PackageVersion).tgz"

--- a/src/NodeApi.DotNetHost/NodeApi.DotNetHost.csproj
+++ b/src/NodeApi.DotNetHost/NodeApi.DotNetHost.csproj
@@ -12,7 +12,9 @@
     <ProjectReference Include="..\NodeApi\NodeApi.csproj" GeneratePathProperty="true" PrivateAssets="all" />
   </ItemGroup>
 
-  <Target Name="PublishNativeHost" BeforeTargets="Pack">
+  <Target Name="PublishNativeHost" BeforeTargets="Pack"
+    Condition=" '$(NoPublish)' != 'true' "
+  >
     <MSBuild
       Projects="..\NodeApi\NodeApi.csproj"
       Targets="Publish"

--- a/test/NativeAotTests.cs
+++ b/test/NativeAotTests.cs
@@ -74,21 +74,24 @@ public class NativeAotTests
             ["Configuration"] = Configuration,
         };
 
-        string? buildResult = BuildProject(
-          projectFilePath,
-          targets: new[] { "Restore", "Publish" },
-          properties,
-          returnProperty: "NativeBinary",
-          logFilePath: logFilePath,
-          verboseLog: false);
+        BuildProject(
+            projectFilePath,
+            "Publish",
+            properties,
+            logFilePath,
+            verboseLog: false);
 
-        if (string.IsNullOrEmpty(buildResult))
-        {
-            return null;
-        }
-
-        string moduleFilePath = buildResult.Replace(
-            Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
+        string moduleFilePath = Path.Combine(
+            RepoRootDirectory,
+            "out",
+            "bin",
+            Configuration,
+            "TestCases",
+            moduleName,
+            GetCurrentFrameworkTarget(),
+            GetCurrentPlatformRuntimeIdentifier(),
+            "native",
+            moduleName + ".node");
         moduleFilePath = Path.ChangeExtension(moduleFilePath, ".node");
         Assert.True(File.Exists(moduleFilePath), "Module file was not built: " + moduleFilePath);
         return moduleFilePath;

--- a/test/NodeApi.Test.csproj
+++ b/test/NodeApi.Test.csproj
@@ -15,12 +15,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build" ExcludeAssets="runtime" />
-    <PackageReference Include="Microsoft.Build.Locator" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />
-    <PackageReference Include="NuGet.Frameworks" /><!-- Necessary to resolve assembly version conflicts when loading MSBuild assemblies in test code. -->
   </ItemGroup>
 
   <ItemGroup>

--- a/test/NodeApi.Test.csproj
+++ b/test/NodeApi.Test.csproj
@@ -27,14 +27,11 @@
   </ItemGroup>
 
   <!--
-    Work around MSBuild.Locator NuGet.Frameworks version conflict.
-    https://github.com/microsoft/MSBuildLocator/issues/127
-    https://github.com/dotnet/roslyn/issues/61454
+    Pass the "no-build" flag to the tests so they can also skip the automatic build of dependencies.
   -->
-  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Copy SourceFiles="$([System.IO.Directory]::GetParent($(BundledRuntimeIdentifierGraphFile)))\NuGet.Frameworks.dll"
-          DestinationFolder="$(OutputPath)"
-          ContinueOnError="false" />
+  <Target Name="RecordTestNoBuild" BeforeTargets="VSTest">
+    <WriteLinesToFile Condition=" '$(VSTestNoBuild)' == 'true' " File="$(IntermediateOutputPath)\no-build.txt" />
+    <Delete Condition=" '$(VSTestNoBuild)' != 'true' " Files="$(IntermediateOutputPath)\no-build.txt" />
   </Target>
 
 </Project>

--- a/test/TestBuilder.cs
+++ b/test/TestBuilder.cs
@@ -157,6 +157,20 @@ internal static class TestBuilder
         return $"net{frameworkVersion.Major}.{frameworkVersion.Minor}";
     }
 
+    private static bool GetNoBuild()
+    {
+        string filePath = Path.Join(
+            RepoRootDirectory,
+            "out",
+            "obj",
+            Configuration,
+            "NodeApi.Test",
+            GetCurrentFrameworkTarget(),
+            GetCurrentPlatformRuntimeIdentifier(),
+            "no-build.txt");
+        return File.Exists(filePath);
+    }
+
     public static void BuildProject(
       string projectFilePath,
       string target,
@@ -164,6 +178,8 @@ internal static class TestBuilder
       string logFilePath,
       bool verboseLog = false)
     {
+        if (GetNoBuild()) return;
+
         StreamWriter logWriter = new(logFilePath, new FileStreamOptions
         {
             Mode = FileMode.Create,

--- a/test/TestBuilder.cs
+++ b/test/TestBuilder.cs
@@ -7,10 +7,6 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
-using Microsoft.Build.Evaluation;
-using Microsoft.Build.Framework;
-using Microsoft.Build.Locator;
-using Microsoft.Build.Logging;
 using Microsoft.JavaScript.NodeApi.Generator;
 using Xunit;
 
@@ -28,26 +24,6 @@ internal static class TestBuilder
     // (A real module would choose between one or the other, so its require code would be simpler.)
     public const string ModulePathEnvironmentVariableName = "TEST_DOTNET_MODULE_PATH";
     public const string HostPathEnvironmentVariableName = "TEST_DOTNET_HOST_PATH";
-
-    private static bool s_msbuildInitialized = false;
-
-    private static void InitializeMsbuild()
-    {
-        if (!s_msbuildInitialized)
-        {
-            // Find an istalled instance of MSBuild that matches the current runtime major version
-            // and is not a preview.
-            VisualStudioInstance[] msbuildInstances =
-                MSBuildLocator.QueryVisualStudioInstances().ToArray();
-            VisualStudioInstance msbuildInstance = msbuildInstances
-                .Where((instance) => instance.Version.Major == Environment.Version.Major &&
-                    !instance.MSBuildPath.Contains("preview"))
-                .OrderByDescending(instance => instance.Version)
-                .First();
-            MSBuildLocator.RegisterInstance(msbuildInstance);
-            s_msbuildInitialized = true;
-        }
-    }
 
     public static string Configuration { get; } =
 #if DEBUG
@@ -181,47 +157,54 @@ internal static class TestBuilder
         return $"net{frameworkVersion.Major}.{frameworkVersion.Minor}";
     }
 
-    public static string? BuildProject(
+    public static void BuildProject(
       string projectFilePath,
-      string[] targets,
+      string target,
       IDictionary<string, string> properties,
-      string returnProperty,
       string logFilePath,
       bool verboseLog = false)
     {
-        // MSBuild must be explicitly located & initialized before being loaded by the JIT,
-        // therefore any use of MSBuild types must be kept in separate methods called by this one.
-        InitializeMsbuild();
-
-        return BuildProjectInternal(
-            projectFilePath, targets, properties, returnProperty, logFilePath, verboseLog);
-    }
-
-    private static string? BuildProjectInternal(
-      string projectFilePath,
-      string[] targets,
-      IDictionary<string, string> properties,
-      string returnProperty,
-      string logFilePath,
-      bool verboseLog = false)
-    {
-        var logger = new FileLogger
+        StreamWriter logWriter = new(logFilePath, new FileStreamOptions
         {
-            Parameters = "LOGFILE=" + logFilePath,
-            Verbosity = verboseLog ? LoggerVerbosity.Diagnostic : LoggerVerbosity.Normal,
-        };
+            Mode = FileMode.Create,
+            Access = FileAccess.Write,
+            Share = FileShare.Read,
+        });
 
-        using var projectCollection = new ProjectCollection();
-
-        Project project = projectCollection.LoadProject(projectFilePath, properties, toolsVersion: null);
-        bool buildResult = project.Build(targets, new[] { logger });
-        if (!buildResult)
+        ProcessStartInfo startInfo = new("dotnet");
+        startInfo.ArgumentList.Add("build");
+        startInfo.ArgumentList.Add(projectFilePath);
+        startInfo.ArgumentList.Add("/t:" + target);
+        startInfo.ArgumentList.Add(verboseLog ? "/v:d" : "/v:n");
+        foreach (KeyValuePair<string, string> property in properties)
         {
-            return null;
+            startInfo.ArgumentList.Add($"/p:{property.Key}={property.Value}");
         }
 
-        string returnValue = project.GetPropertyValue(returnProperty);
-        return returnValue;
+        startInfo.UseShellExecute = false;
+        startInfo.RedirectStandardOutput = true;
+        startInfo.RedirectStandardError = true;
+        startInfo.WorkingDirectory = Path.GetDirectoryName(logFilePath)!;
+
+        logWriter.WriteLine($"dotnet {string.Join(" ", startInfo.ArgumentList)}");
+        logWriter.WriteLine();
+        logWriter.Flush();
+
+        Process buildProcess = Process.Start(startInfo)!;
+
+        bool hasErrorOutput = LogOutput(buildProcess, logWriter);
+
+        if (buildProcess.ExitCode != 0)
+        {
+            string failMessage = "Build process exited with code: " + buildProcess.ExitCode + ". " +
+                "Check the log for details: " + logFilePath;
+            Assert.Fail(failMessage);
+        }
+        else if (hasErrorOutput)
+        {
+            Assert.Fail("Build process produced error output. " +
+                "Check the log for details: " + logFilePath);
+        }
     }
 
     public static void BuildTypeDefinitions(string moduleName, string moduleFilePath)
@@ -242,13 +225,12 @@ internal static class TestBuilder
         // This assumes the `node` executable is on the current PATH.
         string nodeExe = "node";
 
-        StreamWriter outputWriter = new(logFilePath, new FileStreamOptions
+        StreamWriter logWriter = new(logFilePath, new FileStreamOptions
         {
             Mode = FileMode.Create,
             Access = FileAccess.Write,
             Share = FileShare.Read,
         });
-        bool hasErrorOutput = false;
 
         var startInfo = new ProcessStartInfo(nodeExe, $"--expose-gc {jsFilePath}")
         {
@@ -261,42 +243,15 @@ internal static class TestBuilder
         foreach ((string name, string value) in testEnvironmentVariables)
         {
             startInfo.Environment[name] = value;
-            outputWriter.WriteLine($"{name}={value}");
+            logWriter.WriteLine($"{name}={value}");
         }
 
-        outputWriter.WriteLine($"{nodeExe} --expose-gc {jsFilePath}");
-        outputWriter.WriteLine();
-        outputWriter.Flush();
+        logWriter.WriteLine($"{nodeExe} --expose-gc {jsFilePath}");
+        logWriter.WriteLine();
+        logWriter.Flush();
 
         Process nodeProcess = Process.Start(startInfo)!;
-        nodeProcess.OutputDataReceived += (_, e) =>
-        {
-            if (e.Data != null)
-            {
-                lock (outputWriter)
-                {
-                    outputWriter.WriteLine(e.Data);
-                    outputWriter.Flush();
-                }
-            }
-        };
-        nodeProcess.ErrorDataReceived += (_, e) =>
-        {
-            if (e.Data != null)
-            {
-                lock (outputWriter)
-                {
-                    outputWriter.WriteLine(e.Data);
-                    outputWriter.Flush();
-                    hasErrorOutput = e.Data.Trim().Length > 0;
-                }
-            }
-        };
-        nodeProcess.BeginOutputReadLine();
-        nodeProcess.BeginErrorReadLine();
-
-        nodeProcess.WaitForExit();
-        outputWriter.Close();
+        bool hasErrorOutput = LogOutput(nodeProcess, logWriter);
 
         if (nodeProcess.ExitCode != 0)
         {
@@ -325,5 +280,41 @@ internal static class TestBuilder
             Assert.Fail("Node process produced error output. " +
                 "Check the log for details: " + logFilePath);
         }
+    }
+
+    private static bool LogOutput(
+        Process process,
+        StreamWriter logWriter)
+    {
+        bool hasErrorOutput = false;
+        process.OutputDataReceived += (_, e) =>
+        {
+            if (e.Data != null)
+            {
+                lock (logWriter)
+                {
+                    logWriter.WriteLine(e.Data);
+                    logWriter.Flush();
+                }
+            }
+        };
+        process.ErrorDataReceived += (_, e) =>
+        {
+            if (e.Data != null)
+            {
+                lock (logWriter)
+                {
+                    logWriter.WriteLine(e.Data);
+                    logWriter.Flush();
+                    hasErrorOutput = e.Data.Trim().Length > 0;
+                }
+            }
+        };
+        process.BeginOutputReadLine();
+        process.BeginErrorReadLine();
+
+        process.WaitForExit();
+        logWriter.Close();
+        return hasErrorOutput;
     }
 }

--- a/test/TestCases/Directory.Build.targets
+++ b/test/TestCases/Directory.Build.targets
@@ -1,11 +1,10 @@
 <Project>
-  <!-- TODO: Put this in a .targets file that is automatically included via a package reference. -->
-	<Target Name="CopyToDotNode" AfterTargets="LinkNative">
-		<ItemGroup>
-			<NativeBinary Include="$(NativeBinary)" />
-		</ItemGroup>
-		<Copy SourceFiles="@(NativeBinary)"
-			DestinationFiles="@(NativeBinary->Replace($(NativeBinaryExt), '.node'))"
+  <Target Name="CopyToDotNode" AfterTargets="LinkNative">
+    <ItemGroup>
+      <NativeBinary Include="$(NativeBinary)" />
+    </ItemGroup>
+    <Copy SourceFiles="@(NativeBinary)"
+      DestinationFiles="@(NativeBinary->Replace($(NativeBinaryExt), '.node'))"
       UseHardlinksIfPossible="true" />
-	</Target>
+  </Target>
 </Project>


### PR DESCRIPTION
This change simplifies build steps for example projects, and improves how the test runner automatically builds dependencies.

 - Automatically run an MSBuild child task to publish the native host (for `net7.0` target framework) before packing the managed host npm package.
 - Remove the `dotnet publish` step from a few places in documentation, since it no longer needs to be called separately before `dotnet pack`.
 - Change the test runner to invoke `dotnet build` as a child process rather than driving MSBuild in-proc, when building dependencies.
 - Update to the current version of the `Microsoft.CodeAnalysis.CSharp` nuget package. The previous referenced version had a bug that broke MSBuild up-to-date checks.

The test runner change enables it to build dependencies using a different target framework than what the tests are currently targeting. It will be critical for .NET Framework 4.x testing, because that will still depend on the AOT-compiled .NET 7 native host. (#51 testing was blocked by this issue.)