### PR TITLE
Initial ADO CI implementation

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -1,0 +1,163 @@
+name: 0.0.$(Date:yyMM.d)$(Rev:rrr)
+
+# TODO: sign binaries/packages
+# TODO: publish packages to Nuget.org and npmjs
+# TODO: publish symbols
+# TODO: publish to source server
+
+trigger:
+- main
+
+parameters:
+  # x86 versions are not supported by NativeAOT
+  # win-arm64 is not supported by Node.JS as of 3/29/2023
+  # linux-arm64 must be added after we learn how to set up the cross-compilation environment.
+  # Use net7.0 as the latest stable version except for osx-arm64 which is only supported in net8.0.
+- name: buildMatrix
+  type: object
+  default:
+    - Name: win_x64
+      VMImage: windows-latest
+      TargetRuntime: win-x64
+      DotNetVersion: '7.0.x'
+      DotNetMoniker: net7.0
+    - Name: osx_x64
+      VMImage: macos-latest
+      TargetRuntime: osx-x64
+      DotNetVersion: '7.0.x'
+      DotNetMoniker: net7.0
+    - Name: osx_arm64
+      VMImage: macos-latest
+      TargetRuntime: osx-arm64
+      DotNetVersion: '8.0.x'
+      DotNetMoniker: net8.0
+    - Name: linux_x64
+      VMImage: ubuntu-latest
+      TargetRuntime: linux-x64
+      DotNetVersion: '7.0.x'
+      DotNetMoniker: net7.0
+
+jobs:
+  - ${{ each matrixEntry in parameters.buildMatrix }}:
+    - job: buildAOTBinary${{ matrixEntry.Name }}
+      displayName: Build ${{ matrixEntry.TargetRuntime }} AOT binary
+      pool:
+        vmImage: ${{ matrixEntry.VMImage }}
+
+      steps:
+        - checkout: self
+          displayName: Deep git fetch for version generation
+          fetchDepth: 0 # Use deep fetch for the version calculation by Nerdbank.GitVersioning
+          clean: false
+          submodules: false
+          lfs: false
+
+        - task: UseDotNet@2
+          displayName: Install .Net
+          inputs:
+            packageType: 'sdk'
+            version: ${{ matrixEntry.DotNetVersion }}
+            includePreviewVersions: true
+
+        - task: DeleteFiles@1 # To enable net8.0 use for osx-arm64
+          displayName: Delete 'global.json'
+          inputs:
+            Contents: 'global.json'
+          condition: eq('${{ matrixEntry.DotNetMoniker }}', 'net8.0')
+
+        - script: dotnet publish --configuration Release --runtime ${{ matrixEntry.TargetRuntime }} --no-self-contained --framework ${{ matrixEntry.DotNetMoniker }}
+          displayName: Build native binaries
+          env:
+            TargetFrameworks: ${{ matrixEntry.DotNetMoniker }}
+
+        - task: CopyFiles@2
+          displayName: Copy build artifacts to staging
+          inputs:
+            sourceFolder: $(Build.SourcesDirectory)/out/bin/Release/NodeApi/${{ matrixEntry.DotNetMoniker }}/${{ matrixEntry.TargetRuntime }}/publish
+            targetFolder: $(Build.StagingDirectory)/AOT/${{ matrixEntry.TargetRuntime }}
+            contents: Microsoft.JavaScript.NodeApi.node
+
+        - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
+          displayName: "📒 Generate Manifest: ${{ matrixEntry.TargetRuntime }}"
+          inputs:
+            BuildDropPath: $(Build.StagingDirectory)/AOT/${{ matrixEntry.TargetRuntime }}
+
+        - task: PublishPipelineArtifact@1
+          displayName: "Publish Artifacts: ${{ matrixEntry.TargetRuntime }}"
+          # Do nothing if the artifact was already published. E.g. after rerunning a past successful job attempt
+          continueOnError: true
+          inputs:
+            artifactName: ${{ matrixEntry.TargetRuntime }}
+            targetPath: $(Build.StagingDirectory)/AOT/${{ matrixEntry.TargetRuntime }}
+
+  - job: createPackages
+    displayName: Create Nuget and NPM packages
+    dependsOn:
+      - ${{ each matrixEntry in parameters.buildMatrix }}:
+        - buildAOTBinary${{ matrixEntry.Name }}
+
+    variables:
+      VMImage: windows-latest
+      TargetRuntime: win-x64
+      DotNetVersion: '7.0.x'
+      DotNetMoniker: net7.0
+      targetRuntimes:
+
+    pool:
+      vmImage: $(VMImage)
+
+    steps:
+      - checkout: self
+        displayName: Deep git fetch for version generation
+        fetchDepth: 0 # Use deep fetch for the version calculation by Nerdbank.GitVersioning
+        clean: false
+        submodules: false
+        lfs: false
+
+      - task: UseDotNet@2
+        displayName: Install .Net
+        inputs:
+          packageType: 'sdk'
+          version: $(DotNetVersion)
+          includePreviewVersions: true
+
+      - script: dotnet build --configuration Release
+        displayName: Build managed assemblies
+
+      - ${{ each matrixEntry in parameters.buildMatrix }}:
+        - task: DownloadPipelineArtifact@2
+          displayName: 'Download ${{ matrixEntry.TargetRuntime }} AOT'
+          inputs:
+            artifact: ${{ matrixEntry.TargetRuntime }}
+            path: $(Build.SourcesDirectory)/out/bin/Release/NodeApi/$(DotNetMoniker)/${{ matrixEntry.TargetRuntime }}/publish
+
+      - ${{ each matrixEntry in parameters.buildMatrix }}:
+        - powershell: |
+            Write-Host "##vso[task.setvariable variable=targetRuntimes;]$(targetRuntimes) ${{ matrixEntry.TargetRuntime }}"
+            Write-Host "targetRuntimes: $(targetRuntimes) ${{ matrixEntry.TargetRuntime }}"
+          displayName: 'Create RID list - ${{ matrixEntry.TargetRuntime }}'
+
+      - script: dotnet pack --configuration Release -p:NoPublish=true
+        displayName: Build packages
+        env:
+          RuntimeIdentifierList: $(targetRuntimes)
+
+      - task: CopyFiles@2
+        displayName: Copy packages to staging
+        inputs:
+          sourceFolder: $(Build.SourcesDirectory)/out/pkg
+          targetFolder: $(Build.StagingDirectory)/pkg
+          contents: |
+            *.nupkg
+            *.tgz
+
+      - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
+        displayName: 📒 Generate Manifest
+        inputs:
+          BuildDropPath: $(Build.StagingDirectory)/pkg
+
+      - task: PublishPipelineArtifact@1
+        displayName: "Publish final artifacts"
+        inputs:
+          targetPath: $(Build.StagingDirectory)/pkg
+          artifactName: 'Published Packages'

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -5,6 +5,7 @@ name: 0.0.$(Date:yyMM.d)$(Rev:rrr)
 # TODO: publish symbols
 # TODO: publish to source server
 
+pr: none
 trigger:
 - main
 

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -1,17 +1,21 @@
-name: 0.0.$(Date:yyMM.d)$(Rev:rrr)
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
-# TODO: sign binaries/packages
-# TODO: publish packages to Nuget.org and npmjs
 # TODO: publish symbols
 # TODO: publish to source server
+# TODO: run tests
 
+# Name of the run. It is overridden below  with the version of published binaries.
+name: 0.0.$(Date:yyMM.d)$(Rev:rrr)
+
+# This script must never be triggered from YAML settings for security reasons.
 pr: none
-trigger:
-- main
+trigger: none
 
 parameters:
-  # x86 versions are not supported by NativeAOT
-  # win-arm64 is not supported by Node.JS as of 3/29/2023
+  # Matrix with target platforms.
+  # x86 versions are not supported by Native AOT.
+  # win-arm64 is not supported by Node.JS as of 3/29/2023.
   # linux-arm64 must be added after we learn how to set up the cross-compilation environment.
   # Use net7.0 as the latest stable version except for osx-arm64 which is only supported in net8.0.
 - name: buildMatrix
@@ -22,26 +26,32 @@ parameters:
       TargetRuntime: win-x64
       DotNetVersion: '7.0.x'
       DotNetMoniker: net7.0
+      UseGlobalJson: true
     - Name: osx_x64
       VMImage: macos-latest
       TargetRuntime: osx-x64
       DotNetVersion: '7.0.x'
       DotNetMoniker: net7.0
+      UseGlobalJson: true
     - Name: osx_arm64
       VMImage: macos-latest
       TargetRuntime: osx-arm64
       DotNetVersion: '8.0.x'
       DotNetMoniker: net8.0
+      UseGlobalJson: false
     - Name: linux_x64
       VMImage: ubuntu-latest
       TargetRuntime: linux-x64
       DotNetVersion: '7.0.x'
       DotNetMoniker: net7.0
+      UseGlobalJson: true
 
 jobs:
+  # Build Native AOT .Net hosts for Node-API modules.
   - ${{ each matrixEntry in parameters.buildMatrix }}:
     - job: buildAOTBinary${{ matrixEntry.Name }}
       displayName: Build ${{ matrixEntry.TargetRuntime }} AOT binary
+
       pool:
         vmImage: ${{ matrixEntry.VMImage }}
 
@@ -54,39 +64,50 @@ jobs:
           lfs: false
 
         - task: UseDotNet@2
-          displayName: Install .Net
+          displayName: Install .Net ${{ matrixEntry.DotNetVersion }}
           inputs:
             packageType: 'sdk'
             version: ${{ matrixEntry.DotNetVersion }}
-            includePreviewVersions: true
+            includePreviewVersions: ${{ eq(matrixEntry.UseGlobalJson, false) }}
+            useGlobalJson: ${{ matrixEntry.UseGlobalJson }}
+
+        - script: env
+          displayName: Print environment
+
+        - script: dotnet --info
+          displayName: Print .Net info
 
         - task: DeleteFiles@1 # To enable net8.0 use for osx-arm64
           displayName: Delete 'global.json'
           inputs:
             Contents: 'global.json'
-          condition: eq('${{ matrixEntry.DotNetMoniker }}', 'net8.0')
+          condition: eq(${{ matrixEntry.UseGlobalJson }}, false)
 
-        - script: dotnet publish --configuration Release --runtime ${{ matrixEntry.TargetRuntime }} --no-self-contained --framework ${{ matrixEntry.DotNetMoniker }}
-          displayName: Build native binaries
+        - script: >
+            dotnet publish
+            --configuration Release
+            --runtime ${{ matrixEntry.TargetRuntime }}
+            --no-self-contained
+            --framework ${{ matrixEntry.DotNetMoniker }}
+          displayName: Build Native AOT binaries
           env:
             TargetFrameworks: ${{ matrixEntry.DotNetMoniker }}
 
         - task: CopyFiles@2
-          displayName: Copy build artifacts to staging
+          displayName: Copy Native AOT binaries to staging
           inputs:
-            sourceFolder: $(Build.SourcesDirectory)/out/bin/Release/NodeApi/${{ matrixEntry.DotNetMoniker }}/${{ matrixEntry.TargetRuntime }}/publish
+            sourceFolder: "$(Build.SourcesDirectory)/out/bin/Release/NodeApi/\
+              ${{ matrixEntry.DotNetMoniker }}/${{ matrixEntry.TargetRuntime }}/publish"
             targetFolder: $(Build.StagingDirectory)/AOT/${{ matrixEntry.TargetRuntime }}
             contents: Microsoft.JavaScript.NodeApi.node
 
         - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
-          displayName: "📒 Generate Manifest: ${{ matrixEntry.TargetRuntime }}"
+          displayName: "📒 Generate artifact manifest: ${{ matrixEntry.TargetRuntime }}"
           inputs:
             BuildDropPath: $(Build.StagingDirectory)/AOT/${{ matrixEntry.TargetRuntime }}
 
         - task: PublishPipelineArtifact@1
-          displayName: "Publish Artifacts: ${{ matrixEntry.TargetRuntime }}"
-          # Do nothing if the artifact was already published. E.g. after rerunning a past successful job attempt
-          continueOnError: true
+          displayName: "Publish Native AOT artifact: ${{ matrixEntry.TargetRuntime }}"
           inputs:
             artifactName: ${{ matrixEntry.TargetRuntime }}
             targetPath: $(Build.StagingDirectory)/AOT/${{ matrixEntry.TargetRuntime }}
@@ -102,7 +123,8 @@ jobs:
       TargetRuntime: win-x64
       DotNetVersion: '7.0.x'
       DotNetMoniker: net7.0
-      targetRuntimes:
+      UseGlobalJson: true
+      TargetRuntimeList:
 
     pool:
       vmImage: $(VMImage)
@@ -116,32 +138,120 @@ jobs:
         lfs: false
 
       - task: UseDotNet@2
-        displayName: Install .Net
+        displayName: Install .Net 6.0.x
+        inputs:
+          packageType: 'sdk'
+          version: '6.0.x'
+
+      - task: UseDotNet@2
+        displayName: Install .Net $(DotNetVersion)
         inputs:
           packageType: 'sdk'
           version: $(DotNetVersion)
-          includePreviewVersions: true
+          useGlobalJson: true
+
+      - script: env
+        displayName: Print environment
+
+      - script: dotnet --info
+        displayName: Print .Net info
 
       - script: dotnet build --configuration Release
         displayName: Build managed assemblies
 
       - ${{ each matrixEntry in parameters.buildMatrix }}:
         - task: DownloadPipelineArtifact@2
-          displayName: 'Download ${{ matrixEntry.TargetRuntime }} AOT'
+          displayName: Download ${{ matrixEntry.TargetRuntime }} AOT
           inputs:
             artifact: ${{ matrixEntry.TargetRuntime }}
-            path: $(Build.SourcesDirectory)/out/bin/Release/NodeApi/$(DotNetMoniker)/${{ matrixEntry.TargetRuntime }}/publish
+            path: "$(Build.SourcesDirectory)/out/bin/Release/NodeApi/\
+              $(DotNetMoniker)/${{ matrixEntry.TargetRuntime }}/publish"
 
       - ${{ each matrixEntry in parameters.buildMatrix }}:
-        - powershell: |
-            Write-Host "##vso[task.setvariable variable=targetRuntimes;]$(targetRuntimes) ${{ matrixEntry.TargetRuntime }}"
-            Write-Host "targetRuntimes: $(targetRuntimes) ${{ matrixEntry.TargetRuntime }}"
-          displayName: 'Create RID list - ${{ matrixEntry.TargetRuntime }}'
+        - powershell: >
+            Write-Host
+            "##vso[task.setvariable variable=TargetRuntimeList;]$(TargetRuntimeList)
+            ${{ matrixEntry.TargetRuntime }}"
+          displayName: "Create RID list: ${{ matrixEntry.TargetRuntime }}"
 
-      - script: dotnet pack --configuration Release -p:NoPublish=true
-        displayName: Build packages
+      - script: echo $(TargetRuntimeList)
+        displayName: Show RID list
+
+      - task: DeleteFiles@1 # Code signing utility requires net6.0 runtime
+        displayName: Delete 'global.json' for CodeSign
+        inputs:
+          Contents: 'global.json'
+
+      - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@2
+        displayName: CodeSign Binaries
+        inputs:
+          ConnectedServiceName: ESRP-JsHost
+          FolderPath: $(Build.SourcesDirectory)/out/bin/Release
+          # Recursively finds files matching these patterns:
+          Pattern: |
+            **/Microsoft.JavaScript.NodeApi.dll
+            **/win-x64/publish/Microsoft.JavaScript.NodeApi.node
+            **/Microsoft.JavaScript.NodeApi.DotNetHost.dll
+            **/Microsoft.JavaScript.NodeApi.Generator.dll
+            **/Microsoft.JavaScript.NodeApi.Generator.exe
+          UseMinimatch: true
+          signConfigType: inlineSignParams
+          inlineOperation: |
+            [
+              {
+                "KeyCode" : "CP-230012",
+                "OperationCode" : "SigntoolSign",
+                "Parameters" : {
+                    "OpusName" : "Microsoft",
+                    "OpusInfo" : "http://www.microsoft.com",
+                    "FileDigest" : "/fd \"SHA256\"",
+                    "PageHash" : "/NPH",
+                    "TimeStamp" : "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
+                },
+                "ToolName" : "sign",
+                "ToolVersion" : "1.0"
+              },
+              {
+                  "KeyCode" : "CP-230012",
+                  "OperationCode" : "SigntoolVerify",
+                  "Parameters" : {},
+                  "ToolName" : "sign",
+                  "ToolVersion" : "1.0"
+              }
+            ]
+
+      # Do not build or publish assemblies to avoid overriding signed binaries.
+      - script: dotnet pack --configuration Release --no-build -p:NoPublish=true
+        displayName: Create Nuget and NPM packages
         env:
-          RuntimeIdentifierList: $(targetRuntimes)
+          RuntimeIdentifierList: $(TargetRuntimeList)
+
+      - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@2
+        displayName: CodeSign NuGets
+        inputs:
+          ConnectedServiceName: ESRP-JsHost
+          FolderPath: $(Build.SourcesDirectory)/out/pkg
+          Pattern: |
+            **/Microsoft.JavaScript.NodeApi.*.nupkg
+          UseMinimatch: true
+          signConfigType: inlineSignParams
+          inlineOperation: |
+            [
+              {
+                  "KeyCode" : "CP-401405",
+                  "OperationCode" : "NuGetSign",
+                  "Parameters" : {},
+                  "ToolName" : "sign",
+                  "ToolVersion" : "1.0"
+              },
+              {
+                  "KeyCode" : "CP-401405",
+                  "OperationCode" : "NuGetVerify",
+                  "Parameters" : {},
+                  "ToolName" : "sign",
+                  "ToolVersion" : "1.0"
+              }
+            ]
 
       - task: CopyFiles@2
         displayName: Copy packages to staging
@@ -153,12 +263,12 @@ jobs:
             *.tgz
 
       - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
-        displayName: 📒 Generate Manifest
+        displayName: 📒 Generate artifact manifest
         inputs:
           BuildDropPath: $(Build.StagingDirectory)/pkg
 
       - task: PublishPipelineArtifact@1
-        displayName: "Publish final artifacts"
+        displayName: Publish artifact with packages
         inputs:
           targetPath: $(Build.StagingDirectory)/pkg
           artifactName: 'Published Packages'

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(TargetFrameworks)' == '' ">net7.0;net6.0</TargetFrameworks>
     <LangVersion>10</LangVersion>
     <Nullable>enable</Nullable>
     <Configuration Condition="'$(Configuration)'==''">Debug</Configuration>

--- a/examples/NuGet.config
+++ b/examples/NuGet.config
@@ -1,7 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
+    <clear />
     <add key="local" value="../out/pkg" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
+  <disabledPackageSources>
+    <clear />
+  </disabledPackageSources>
 </configuration>

--- a/src/NodeApi.DotNetHost/NodeApi.DotNetHost.csproj
+++ b/src/NodeApi.DotNetHost/NodeApi.DotNetHost.csproj
@@ -27,8 +27,10 @@
   >
     <PropertyGroup>
       <NodeApiPackScript>$(MSBuildThisFileDirectory)..\node-api-dotnet\pack.js</NodeApiPackScript>
+      <RuntimeIdentifierList Condition=" '$(RuntimeIdentifierList)' == '' ">$(RuntimeIdentifier)</RuntimeIdentifierList>
     </PropertyGroup>
-    <Exec Command="node $(NodeApiPackScript) $(Configuration) $(RuntimeIdentifier)" />
+    <Message Importance="High" Text="RuntimeIdentifierList=$(RuntimeIdentifierList)" />
+    <Exec Command="node $(NodeApiPackScript) $(Configuration) $(RuntimeIdentifierList)" />
   </Target>
 
 </Project>

--- a/src/NodeApi.DotNetHost/NodeApi.DotNetHost.csproj
+++ b/src/NodeApi.DotNetHost/NodeApi.DotNetHost.csproj
@@ -29,7 +29,7 @@
       <NodeApiPackScript>$(MSBuildThisFileDirectory)..\node-api-dotnet\pack.js</NodeApiPackScript>
       <RuntimeIdentifierList Condition=" '$(RuntimeIdentifierList)' == '' ">$(RuntimeIdentifier)</RuntimeIdentifierList>
     </PropertyGroup>
-    <Message Importance="High" Text="RuntimeIdentifierList=$(RuntimeIdentifierList)" />
+    <Message Importance="High" Text="node $(NodeApiPackScript) $(Configuration) $(RuntimeIdentifierList)" />
     <Exec Command="node $(NodeApiPackScript) $(Configuration) $(RuntimeIdentifierList)" />
   </Target>
 

--- a/src/NodeApi/NodeApi.csproj
+++ b/src/NodeApi/NodeApi.csproj
@@ -8,7 +8,7 @@
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net7.0' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net7.0' or '$(TargetFramework)' == 'net8.0' ">
     <PublishAot>true</PublishAot>
     <StripSymbols>true</StripSymbols>
     <PublishNodeModule>true</PublishNodeModule>

--- a/src/node-api-dotnet/generator/package.json
+++ b/src/node-api-dotnet/generator/package.json
@@ -1,10 +1,10 @@
 {
   "name": "node-api-dotnet-generator",
   "version": "0.1.0",
-  "description": "",
+  "description": "Node-API for .Net code generator",
   "main": "index.js",
   "bin": "index.js",
-  "author": "",
+  "author": "Microsoft",
   "license": "MIT",
   "dependencies": {
     "node-api-dotnet": "0.1.0"

--- a/src/node-api-dotnet/pack.js
+++ b/src/node-api-dotnet/pack.js
@@ -79,7 +79,7 @@ function packGeneratorPackage() {
   const packageStageDir = path.join(outPkgDir, packageName);
   mkdirClean(packageStageDir);
 
-  // Crate a node_modules link so the dependency can be resolved when linked for development.
+  // Create a node_modules link so the dependency can be resolved when linked for development.
   const dependencyPath = path.join(outPkgDir, 'node-api-dotnet');
   const linkPath = path.join(packageStageDir, 'node_modules', 'node-api-dotnet');
   if (!fs.existsSync(path.dirname(linkPath))) fs.mkdirSync(path.dirname(linkPath));

--- a/src/node-api-dotnet/package.json
+++ b/src/node-api-dotnet/package.json
@@ -1,11 +1,11 @@
 {
   "name": "node-api-dotnet",
   "version": "0.1.0",
-  "description": "",
+  "description": "Node-API bindings for .Net",
   "main": "index.js",
   "scripts": {
   },
-  "author": "",
+  "author": "Microsoft",
   "license": "MIT",
   "types": "./index.d.ts"
 }


### PR DESCRIPTION
To publish Nuget and NPM packages we must sign them. The signing requires the use of ADO pipeline.
In this PR we implement the initial ADO CI pipeline which still misses a lot of features including the signing.
The signing and other features will be added in the follow up PRs.
The key parts of the PR:
- We build Native AOT binaries for win-x64, osx-x64, osx-arm64, and linux-x64.
  - The x86 platforms are not supported by AOT compilation.
  - The win-arm64 is not supported by Node.JS yet.
  - The linux-arm64 will be added later when we figure out how to do the cross compilation.
  - The osx-arm64 compiled with .Net 8.0. It is not supported by .Net 7.0.
  
In the end we upload all the Nuget and NPM packages as ADO artifacts.
A separate internal pipeline will take care of pushing them to the Nuget and NPM servers.

Related changes:
- Allow to override `$(TargetFrameworks)` by an environment variable. It is needed for the OSX .Net 8.0 support.
- `Nuget.config` were required to have `<clear/>` tag by the security scan.
- Added the use of `$(RuntimeIdentifierList)` environment variable to package multiple platform AOT complied files into the same NPM.
- Added more info to `package.json` files.