### PR TITLE
Fix NuGet.config for ADO pipeline

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -1,6 +1,9 @@
 <configuration>
-	<packageSources>
-		<clear />
-		<add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-	</packageSources>
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+  <disabledPackageSources>
+    <clear />
+  </disabledPackageSources>
 </configuration>

--- a/test/TestCases/NuGet.config
+++ b/test/TestCases/NuGet.config
@@ -1,7 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
+    <clear />
     <add key="local" value="../../out/pkg" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
+  <disabledPackageSources>
+    <clear />
+  </disabledPackageSources>
 </configuration>


### PR DESCRIPTION
The ADO pipeline requires `<clear/>` tag in the NuGet.config file.
Otherwise, it fails the build.