### PR TITLE
Support JS impl of .NET interface for dynamic mode

### DIFF
--- a/src/NodeApi.DotNetHost/AssemblyExporter.cs
+++ b/src/NodeApi.DotNetHost/AssemblyExporter.cs
@@ -243,14 +243,16 @@ internal class AssemblyExporter
         {
             if (member is PropertyInfo property &&
                 property.PropertyType.Assembly == type.Assembly &&
-                IsSupportedType(property.PropertyType))
+                IsSupportedType(property.PropertyType) &&
+                !JSMarshaller.IsConvertedType(property.PropertyType))
             {
                 ExportClass(property.PropertyType);
             }
             else if (member is MethodInfo method &&
                 IsSupportedMethod(method) &&
                 method.ReturnType.Assembly == type.Assembly &&
-                IsSupportedType(method.ReturnType))
+                IsSupportedType(method.ReturnType) &&
+                !JSMarshaller.IsConvertedType(method.ReturnType))
             {
                 ExportClass(method.ReturnType);
             }

--- a/src/NodeApi.DotNetHost/AssemblyExporter.cs
+++ b/src/NodeApi.DotNetHost/AssemblyExporter.cs
@@ -456,8 +456,9 @@ internal class AssemblyExporter
         if (type.IsPointer ||
             type == typeof(Type) ||
             type.Namespace == "System.Reflection" ||
-            type.Namespace?.StartsWith("System.Collections.") == true ||
-            type.Namespace?.StartsWith("System.Threading.") == true)
+            (type.Namespace?.StartsWith("System.Collections.") == true && !type.IsGenericType) ||
+            (type.Namespace?.StartsWith("System.Threading.") == true && type != typeof(Task) &&
+            !(type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Task<>))))
         {
             return false;
         }

--- a/src/NodeApi.DotNetHost/JSInterfaceMarshaller.cs
+++ b/src/NodeApi.DotNetHost/JSInterfaceMarshaller.cs
@@ -75,7 +75,7 @@ internal class JSInterfaceMarshaller
         IEnumerable<Type> allInterfaces =
             new[] { interfaceType }.Concat(GetInterfaces(interfaceType)).Distinct();
 
-        foreach (var property in allInterfaces.SelectMany((i) => i.GetProperties())
+        foreach (PropertyInfo? property in allInterfaces.SelectMany((i) => i.GetProperties())
             .Where((p) => p.GetMethod?.IsStatic != true && p.SetMethod?.IsStatic != true))
         {
             FieldBuilder? getFieldBuilder = null;
@@ -100,7 +100,7 @@ internal class JSInterfaceMarshaller
                 marshaller);
         }
 
-        foreach (var method in allInterfaces.SelectMany((i) => i.GetMethods())
+        foreach (MethodInfo? method in allInterfaces.SelectMany((i) => i.GetMethods())
             .Where((m) => !m.IsStatic && !m.IsSpecialName))
         {
             FieldBuilder fieldBuilder = CreateDelegateField(

--- a/src/NodeApi.DotNetHost/JSInterfaceMarshaller.cs
+++ b/src/NodeApi.DotNetHost/JSInterfaceMarshaller.cs
@@ -368,37 +368,6 @@ internal class JSInterfaceMarshaller
         typeBuilder.DefineMethodOverride(methodBuilder, method);
     }
 
-    private class TestInterface : JSInterface
-    {
-        public TestInterface(JSValue value) : base(value) { }
-
-        private static Delegate? s_delegate;
-
-        public string StringProp
-        {
-            get
-            {
-                return (string)s_delegate!.DynamicInvoke(new object[] { Value })!;
-            }
-            set
-            {
-                s_delegate!.DynamicInvoke(new object[] { Value, value });
-            }
-        }
-
-        public int IntProp
-        {
-            get
-            {
-                return (int)s_delegate!.DynamicInvoke(new object[] { Value })!;
-            }
-            set
-            {
-                s_delegate!.DynamicInvoke(new object[] { Value, value });
-            }
-        }
-    }
-
     private static void BuildMethodParameters(
         MethodBuilder methodBuilder, ParameterInfo[] parameters)
     {

--- a/src/NodeApi.DotNetHost/ManagedHost.cs
+++ b/src/NodeApi.DotNetHost/ManagedHost.cs
@@ -34,7 +34,12 @@ public sealed class ManagedHost : IDisposable
     /// The marshaller dynamically generates adapter delegates for calls to & from JS,
     /// for assemblies that were not pre-built as Node API modules.
     /// </summary>
-    private readonly JSMarshaller _marshaller = new();
+    private readonly JSMarshaller _marshaller = new()
+    {
+        // Currently dynamic invocation does not use automatic camel-casing.
+        // However source-generated marshalling (for a .NET node module) does.
+        AutoCamelCase = false,
+    };
 
     private readonly Dictionary<string, JSReference> _loadedModules = new();
     private readonly Dictionary<string, AssemblyExporter> _loadedAssemblies = new();

--- a/src/NodeApi.Generator/ModuleGenerator.cs
+++ b/src/NodeApi.Generator/ModuleGenerator.cs
@@ -26,7 +26,13 @@ public class ModuleGenerator : SourceGenerator, ISourceGenerator
     private const string ModuleInitializeMethodName = "Initialize";
     private const string ModuleRegisterFunctionName = "napi_register_module_v1";
 
-    private readonly JSMarshaller _marshaller = new();
+    private readonly JSMarshaller _marshaller = new()
+    {
+        // Currently source-generated marshalling uses auto camel-casing,
+        // while dynamic invocation does not.
+        AutoCamelCase = true,
+    };
+
     private readonly Dictionary<string, LambdaExpression> _callbackAdapters = new();
     private readonly List<ITypeSymbol> _exportedInterfaces = new();
 

--- a/test/TestBuilder.cs
+++ b/test/TestBuilder.cs
@@ -327,23 +327,17 @@ internal static class TestBuilder
         {
             if (e.Data != null)
             {
-                lock (logWriter)
-                {
-                    logWriter.WriteLine(e.Data);
-                    logWriter.Flush();
-                }
+                logWriter.WriteLine(e.Data);
+                logWriter.Flush();
             }
         };
         process.ErrorDataReceived += (_, e) =>
         {
             if (e.Data != null)
             {
-                lock (logWriter)
-                {
-                    logWriter.WriteLine(e.Data);
-                    logWriter.Flush();
-                    errorOutput.AppendLine(e.Data);
-                }
+                logWriter.WriteLine(e.Data);
+                logWriter.Flush();
+                errorOutput.AppendLine(e.Data);
             }
         };
         process.BeginOutputReadLine();

--- a/test/TestCases/napi-dotnet/dynamic_invoke.js
+++ b/test/TestCases/napi-dotnet/dynamic_invoke.js
@@ -43,3 +43,20 @@ assert.strictEqual(instance2.Value, 'test');
 const TestEnum = assembly.TestEnum;
 assert.strictEqual(TestEnum.Two, 2);
 assert.strictEqual(TestEnum[2], 'Two');
+
+test();
+async function test() {
+  const interfaceObj = assembly.AsyncMethods.InterfaceTest;
+  assert.strictEqual(typeof interfaceObj, 'object');
+
+  const interfaceResult = await interfaceObj.TestAsync('buddy');
+  assert.strictEqual(interfaceResult, 'Hey buddy!');
+
+  // Invoke a C# method that calls back to a JS object that implements an interface.
+  const asyncInterfaceImpl = {
+    async TestAsync(greeting) { return `Hello, ${greeting}!`; }
+  };
+  const reverseInterfaceResult =
+    await assembly.AsyncMethods.ReverseInterfaceTest(asyncInterfaceImpl, 'buddy');
+  assert.strictEqual(reverseInterfaceResult, 'Hello, buddy!');
+}


### PR DESCRIPTION
So far, this project has enabled implementing a .NET interface in JavaScript, when the interface is exported by a .NET Node API module. That relied on compile-time source-generation to define a proxy .NET class that implements the .NET interface by forwarding the calls to JS.

With this change it is now possible to do the same with dynamic invocation. This uses `Reflection.Emit` to dynamically define the same kind of interface proxy classes. It is a little more complex than the source generation, since another level of indirection is required to hook up the marshalling expressions/delegates. And emitting IL is tedious and verbose. (I prefer to use compiled lambda expressions instead of emitting IL when possible, but it's not possible to do that directly in this case.)