### PR TITLE
Avoid dependency on Nerdbank.GitVersioning in published Nuget

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -37,7 +37,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Nerdbank.GitVersioning" PrivateAssets="none" />
+    <PackageReference Include="Nerdbank.GitVersioning" PrivateAssets="all" />
   </ItemGroup>
 
   <Import Project="./rid.props" />


### PR DESCRIPTION
Currently our published Nuget packages depend on the Nerdbank.GitVersioning.
This is not needed, and this PR removes this dependency.