### PR TITLE
Add NPM package metadata

### DIFF
--- a/src/node-api-dotnet/generator/package.json
+++ b/src/node-api-dotnet/generator/package.json
@@ -4,9 +4,21 @@
   "description": "Node-API for .Net code generator",
   "main": "index.js",
   "bin": "index.js",
-  "author": "Microsoft",
   "license": "MIT",
+  "author": "Microsoft",
   "dependencies": {
     "node-api-dotnet": "0.1.0"
+  },
+  "keywords": [
+    "Node-API",
+    "NAPI",
+    "generator",
+    ".Net",
+    "dotnet"
+  ],
+  "repository": "github:microsoft/node-api-dotnet",
+  "homepage": "https://github.com/microsoft/node-api-dotnet#readme",
+  "bugs": {
+    "url": "https://github.com/microsoft/node-api-dotnet/issues"
   }
 }

--- a/src/node-api-dotnet/pack.js
+++ b/src/node-api-dotnet/pack.js
@@ -50,6 +50,7 @@ function packMainPackage() {
 
   // Copy script files to the staging dir.
   copyScriptFiles(packageStageDir, '.', 'init.js', 'index.d.ts');
+  copyScriptFiles(packageStageDir, '../..', 'README.md');
 
   generateTargetFrameworkScriptFiles(packageStageDir);
 
@@ -98,6 +99,7 @@ function packGeneratorPackage() {
   const buildVersion = writePackageJson(packageStageDir, packageJson);
 
   copyScriptFiles(packageStageDir, 'generator', 'index.js');
+  copyScriptFiles(packageStageDir, '../..', 'README.md');
 
   copyFrameworkSpecificBinaries(
     [ 'net6.0' ],

--- a/src/node-api-dotnet/package.json
+++ b/src/node-api-dotnet/package.json
@@ -3,9 +3,20 @@
   "version": "0.1.0",
   "description": "Node-API bindings for .Net",
   "main": "index.js",
+  "license": "MIT",
+  "author": "Microsoft",
   "scripts": {
   },
-  "author": "Microsoft",
-  "license": "MIT",
-  "types": "./index.d.ts"
+  "types": "./index.d.ts",
+  "keywords": [
+    "Node-API",
+    "NAPI",
+    ".Net",
+    "dotnet"
+  ],
+  "repository": "github:microsoft/node-api-dotnet",
+  "homepage": "https://github.com/microsoft/node-api-dotnet#readme",
+  "bugs": {
+    "url": "https://github.com/microsoft/node-api-dotnet/issues"
+  }
 }


### PR DESCRIPTION
Add README.md file to NPM packages and add more metadata to `package.json`.
I did not find Microsoft OSS recommended set of attributes for NPM packages.
Instead, I followed the [npm docs](https://docs.npmjs.com/cli/v9/configuring-npm/package-json) and [some best practices](https://github.com/mattdesl/module-best-practices#discoverability).
Common metadata matches to metadata for the NuGet packages.