### PR TITLE
Refactor context to support multiple modules

### DIFF
--- a/README-DEV.md
+++ b/README-DEV.md
@@ -28,8 +28,15 @@ directory.
 
 ## Test
 ```bash
+dotnet pack
 dotnet test
 ```
+
+Some tests reference the source-generator via the local nuget package; hence it is required to run
+`dotnet pack` before the first time running tests, or after any changes to the generator code.
+_This is unavoidable because the source-generator must run with at least .NET 6, so referencing it
+via a `<ProjectReference>` would not work for .NET 4 testing because project references always
+use the same target framework version._
 
 Use `--framework` to specify a target framework, or `--filter` to run a subset of test cases:
 ```bash

--- a/src/NodeApi.DotNetHost/JSMarshaller.cs
+++ b/src/NodeApi.DotNetHost/JSMarshaller.cs
@@ -43,6 +43,9 @@ public class JSMarshaller
     private static readonly PropertyInfo s_context =
         typeof(JSContext).GetStaticProperty(nameof(JSContext.Current))!;
 
+    private static readonly PropertyInfo s_moduleContext =
+        typeof(JSModuleContext).GetStaticProperty(nameof(JSModuleContext.Current))!;
+
     private static readonly PropertyInfo s_undefinedValue =
         typeof(JSValue).GetStaticProperty(nameof(JSValue.Undefined))!;
 
@@ -1094,7 +1097,7 @@ public class JSMarshaller
 
         if (type.GetCustomAttributes<JSModuleAttribute>().Any())
         {
-            // For a method on a module class, the .NET object is stored in module instance data.
+            // For a method on a module class, the .NET object is stored in the module context.
             // `ThisArg` is ignored for module-level methods.
 
             /*
@@ -1102,12 +1105,13 @@ public class JSMarshaller
              * if (__this == null) return JSValue.Undefined;
              */
 
-            PropertyInfo moduleProperty = typeof(JSContext).GetProperty(nameof(JSContext.Module))!;
+            PropertyInfo moduleProperty = typeof(JSModuleContext).GetProperty(
+                nameof(JSModuleContext.Module))!;
             yield return Expression.Assign(
                 thisVariable,
                 Expression.TypeAs(
                     Expression.Property(
-                        Expression.Property(null, s_context),
+                        Expression.Property(null, s_moduleContext),
                         moduleProperty),
                     type));
             yield return Expression.IfThen(

--- a/src/NodeApi.DotNetHost/JSMarshaller.cs
+++ b/src/NodeApi.DotNetHost/JSMarshaller.cs
@@ -41,7 +41,7 @@ public class JSMarshaller
     // Cache some reflected members that are frequently referenced in expressions.
 
     private static readonly PropertyInfo s_context =
-        typeof(JSContext).GetStaticProperty(nameof(JSContext.Current))!;
+        typeof(JSRuntimeContext).GetStaticProperty(nameof(JSRuntimeContext.Current))!;
 
     private static readonly PropertyInfo s_moduleContext =
         typeof(JSModuleContext).GetStaticProperty(nameof(JSModuleContext.Current))!;
@@ -69,7 +69,7 @@ public class JSMarshaller
             nameof(JSNativeApi.TryUnwrap), new[] { typeof(JSValue) })!;
 
     private static readonly MethodInfo s_getOrCreateObjectWrapper =
-        typeof(JSContext).GetInstanceMethod(nameof(JSContext.GetOrCreateObjectWrapper))!;
+        typeof(JSRuntimeContext).GetInstanceMethod(nameof(JSRuntimeContext.GetOrCreateObjectWrapper))!;
 
     private static readonly MethodInfo s_asVoidPromise =
         typeof(TaskExtensions).GetStaticMethod(
@@ -1101,7 +1101,7 @@ public class JSMarshaller
             // `ThisArg` is ignored for module-level methods.
 
             /*
-             * ObjectType? __this = JSContext.Current.Module as ObjectType;
+             * ObjectType? __this = JSRuntimeContext.Current.Module as ObjectType;
              * if (__this == null) return JSValue.Undefined;
              */
 
@@ -1517,7 +1517,7 @@ public class JSMarshaller
             {
                 /*
                  * JSInterface.GetJSValue(value) ??
-                 *     JSContext.Current.GetOrCreateObjectWrapper(value)
+                 *     JSRuntimeContext.Current.GetOrCreateObjectWrapper(value)
                  */
                 Expression.Coalesce(
                     Expression.Call(
@@ -1777,7 +1777,7 @@ public class JSMarshaller
         Expression valueExpression)
     {
         /*
-         * JSValue jsValue = JSContext.Current.CreateStruct<StructName>();
+         * JSValue jsValue = JSRuntimeContext.Current.CreateStruct<StructName>();
          * jsValue["property0"] = (JSValue)value.Property0;
          * ...
          * return jsValue;
@@ -1785,7 +1785,7 @@ public class JSMarshaller
         ParameterExpression jsValueVariable = Expression.Variable(typeof(JSValue), "jsValue");
         variables.Add(jsValueVariable);
 
-        MethodInfo createStructMethod = typeof(JSContext).GetMethod(nameof(JSContext.CreateStruct))
+        MethodInfo createStructMethod = typeof(JSRuntimeContext).GetMethod(nameof(JSRuntimeContext.CreateStruct))
             !.MakeGenericMethod(fromType);
         yield return Expression.Assign(
             jsValueVariable,
@@ -1953,11 +1953,11 @@ public class JSMarshaller
             typeDefinition == typeof(ISet<>))
         {
             /*
-             * JSContext.Current.GetOrCreateCollectionWrapper(
+             * JSRuntimeContext.Current.GetOrCreateCollectionWrapper(
              *     value, (value) => (JSValue)value, (value) => (ElementType)value);
              */
-            MethodInfo wrapMethod = typeof(JSContext).GetInstanceMethod(
-                    nameof(JSContext.GetOrCreateCollectionWrapper),
+            MethodInfo wrapMethod = typeof(JSRuntimeContext).GetInstanceMethod(
+                    nameof(JSRuntimeContext.GetOrCreateCollectionWrapper),
                     new[] { typeDefinition, typeof(JSValue.From<>), typeof(JSValue.To<>) },
                     elementType);
             yield return Expression.Call(
@@ -1973,11 +1973,11 @@ public class JSMarshaller
             typeDefinition == typeof(IAsyncEnumerable<>))
         {
             /*
-             * JSContext.Current.GetOrCreateCollectionWrapper(
+             * JSRuntimeContext.Current.GetOrCreateCollectionWrapper(
              *     value, (value) => (JSValue)value);
              */
-            MethodInfo wrapMethod = typeof(JSContext).GetInstanceMethod(
-                    nameof(JSContext.GetOrCreateCollectionWrapper),
+            MethodInfo wrapMethod = typeof(JSRuntimeContext).GetInstanceMethod(
+                    nameof(JSRuntimeContext.GetOrCreateCollectionWrapper),
                     new[] { typeDefinition, typeof(JSValue.From<>) },
                     elementType);
             yield return Expression.Call(
@@ -1989,11 +1989,11 @@ public class JSMarshaller
         else if (typeDefinition == typeof(System.Collections.ObjectModel.ReadOnlyCollection<>))
         {
             /*
-             * JSContext.Current.GetOrCreateCollectionWrapper(
+             * JSRuntimeContext.Current.GetOrCreateCollectionWrapper(
              *     (IReadOnlyCollection<T>)value, (value) => (JSValue)value);
              */
-            MethodInfo wrapMethod = typeof(JSContext).GetInstanceMethod(
-                    nameof(JSContext.GetOrCreateCollectionWrapper),
+            MethodInfo wrapMethod = typeof(JSRuntimeContext).GetInstanceMethod(
+                    nameof(JSRuntimeContext.GetOrCreateCollectionWrapper),
                     new[] { typeof(IReadOnlyCollection<>), typeof(JSValue.From<>) },
                     elementType);
             yield return Expression.Call(
@@ -2008,15 +2008,15 @@ public class JSMarshaller
             Type valueType = fromType.GenericTypeArguments[1];
 
             /*
-             * JSContext.Current.GetOrCreateCollectionWrapper(
+             * JSRuntimeContext.Current.GetOrCreateCollectionWrapper(
              *     value,
              *     (key) => (JSValue)key,
              *     (value) => (JSValue)value,
              *     (key) => (KeyType)key,
              *     (value) => (ValueType)value);
              */
-            MethodInfo wrapMethod = typeof(JSContext).GetInstanceMethod(
-                    nameof(JSContext.GetOrCreateCollectionWrapper),
+            MethodInfo wrapMethod = typeof(JSRuntimeContext).GetInstanceMethod(
+                    nameof(JSRuntimeContext.GetOrCreateCollectionWrapper),
                     new[]
                     {
                         typeDefinition,
@@ -2042,14 +2042,14 @@ public class JSMarshaller
             Type valueType = fromType.GenericTypeArguments[1];
 
             /*
-             * JSContext.Current.GetOrCreateCollectionWrapper(
+             * JSRuntimeContext.Current.GetOrCreateCollectionWrapper(
              *     value,
              *     (key) => (JSValue)key,
              *     (value) => (JSValue)value,
              *     (key) => (KeyType)key)
              */
-            MethodInfo wrapMethod = typeof(JSContext).GetInstanceMethod(
-                    nameof(JSContext.GetOrCreateCollectionWrapper),
+            MethodInfo wrapMethod = typeof(JSRuntimeContext).GetInstanceMethod(
+                    nameof(JSRuntimeContext.GetOrCreateCollectionWrapper),
                     new[]
                     {
                         typeDefinition,

--- a/src/NodeApi.DotNetHost/ManagedHost.cs
+++ b/src/NodeApi.DotNetHost/ManagedHost.cs
@@ -303,6 +303,5 @@ public sealed class ManagedHost : IDisposable
 
     public void Dispose()
     {
-        GC.SuppressFinalize(this);
     }
 }

--- a/src/NodeApi.DotNetHost/ManagedHost.cs
+++ b/src/NodeApi.DotNetHost/ManagedHost.cs
@@ -10,6 +10,7 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using static Microsoft.JavaScript.NodeApi.JSNativeApi.Interop;
+using Microsoft.JavaScript.NodeApi.Interop;
 
 #if !NETFRAMEWORK
 using System.Runtime.Loader;
@@ -104,6 +105,13 @@ public sealed class ManagedHost : IDisposable
         try
         {
             JSObject exportsObject = (JSObject)new JSValue(exports, scope);
+
+            // Save the require() function that was passed in by the init script.
+            JSValue require = exportsObject["require"];
+            if (require.IsFunction())
+            {
+                JSContext.Current.Require = require;
+            }
 
             ManagedHost host = new(exportsObject);
             exports = (napi_value)host._systemAssembly.AssemblyObject;

--- a/src/NodeApi.DotNetHost/ManagedHost.cs
+++ b/src/NodeApi.DotNetHost/ManagedHost.cs
@@ -110,7 +110,7 @@ public sealed class ManagedHost : IDisposable
             JSValue require = exportsObject["require"];
             if (require.IsFunction())
             {
-                JSContext.Current.Require = require;
+                JSRuntimeContext.Current.Require = require;
             }
 
             ManagedHost host = new(exportsObject);

--- a/src/NodeApi.DotNetHost/TypeExtensions.cs
+++ b/src/NodeApi.DotNetHost/TypeExtensions.cs
@@ -235,7 +235,7 @@ internal static class TypeExtensions
                 else
                 {
                     // This assumption only works if type arguments are alternating as in
-                    // JSContext.GetOrCreateCollectionWrapper!
+                    // JSRuntimeContext.GetOrCreateCollectionWrapper!
                     return t.MakeGenericType(typeArgs[(i + 1) % typeArgs.Length]);
                 }
             })

--- a/src/NodeApi.Generator/ModuleGenerator.cs
+++ b/src/NodeApi.Generator/ModuleGenerator.cs
@@ -118,7 +118,7 @@ public class ModuleGenerator : SourceGenerator, ISourceGenerator
                         "Module class must have public visibility.");
                 }
 
-                // TODO: Check for a public constructor that takes a single JSContext argument.
+                // TODO: Check for a public constructor that takes a single JSRuntimeContext argument.
 
                 moduleInitializers.Add(type);
             }
@@ -297,7 +297,7 @@ public class ModuleGenerator : SourceGenerator, ISourceGenerator
         s += "using var scope = new JSValueScope(JSValueScopeType.Module, env);";
         s += "try";
         s += "{";
-        s += "JSContext context = scope.Context;";
+        s += "JSRuntimeContext context = scope.RuntimeContext;";
         s += "JSValue exportsValue = new(exports, scope);";
         s++;
 
@@ -380,7 +380,7 @@ public class ModuleGenerator : SourceGenerator, ISourceGenerator
         }
         else
         {
-            s += $"exportsValue = new JSModuleBuilder<JSContext>()";
+            s += $"exportsValue = new JSModuleBuilder<JSRuntimeContext>()";
             s.IncreaseIndent();
         }
 

--- a/src/NodeApi.Generator/ModuleGenerator.cs
+++ b/src/NodeApi.Generator/ModuleGenerator.cs
@@ -491,7 +491,7 @@ public class ModuleGenerator : SourceGenerator, ISourceGenerator
         if (moduleType != null)
         {
             // Construct an instance of the custom module class when the module is initialized.
-            // IF a no-args constructor is not present then the generated code will not compile.
+            // If a no-args constructor is not present then the generated code will not compile.
             string ns = GetNamespace(moduleType);
             s += $".ExportModule(new {ns}.{moduleType.Name}(), (JSObject)exportsValue);";
         }

--- a/src/NodeApi/DotNetHost/NativeHost.cs
+++ b/src/NodeApi/DotNetHost/NativeHost.cs
@@ -44,7 +44,7 @@ internal unsafe partial class NativeHost : IDisposable
     {
         Trace($"> NativeHost.InitializeModule({env.Handle:X8}, {exports.Handle:X8})");
 
-        using JSValueScope scope = new(JSValueScopeType.RootNoContext, env);
+        using JSValueScope scope = new(JSValueScopeType.NoContext, env);
         try
         {
             JSNativeApi.Interop.Initialize();

--- a/src/NodeApi/DotNetHost/NativeHost.cs
+++ b/src/NodeApi/DotNetHost/NativeHost.cs
@@ -90,6 +90,7 @@ internal unsafe partial class NativeHost : IDisposable
 
         string targetFramework = (string)args[0];
         string managedHostPath = (string)args[1];
+        JSValue require = args[2];
         Trace($"> NativeHost.InitializeManagedHost({targetFramework}, {managedHostPath})");
 
         try
@@ -103,7 +104,7 @@ internal unsafe partial class NativeHost : IDisposable
                     int.Parse(targetFramework.Substring(4, 1)),
                     targetFramework.Length == 5 ? 0 :
                         int.Parse(targetFramework.Substring(5, 1)));
-                return InitializeFrameworkHost(frameworkVersion, managedHostPath);
+                return InitializeFrameworkHost(frameworkVersion, managedHostPath, require);
             }
             else
             {
@@ -113,7 +114,7 @@ internal unsafe partial class NativeHost : IDisposable
 #else
                 Version dotnetVersion = Version.Parse(targetFramework.AsSpan(3));
 #endif
-                return InitializeDotNetHost(dotnetVersion, managedHostPath);
+                return InitializeDotNetHost(dotnetVersion, managedHostPath, require);
             }
         }
         catch (Exception ex)
@@ -132,8 +133,12 @@ internal unsafe partial class NativeHost : IDisposable
     /// </summary>
     /// <param name="minVersion">Minimum requested .NET version.</param>
     /// <param name="managedHostPath">Path to the managed host assembly file.</param>
+    /// <param name="require">Require function passed in by the init script.</param>
     /// <returns>JS exports value from the managed host.</returns>
-    private JSValue InitializeFrameworkHost(Version minVersion, string managedHostPath)
+    private JSValue InitializeFrameworkHost(
+        Version minVersion,
+        string managedHostPath,
+        JSValue require)
     {
         Trace("    Initializing .NET Framework " + minVersion);
 
@@ -158,6 +163,8 @@ internal unsafe partial class NativeHost : IDisposable
 
             // Create an "exports" object for the managed host module initialization.
             JSValue exportsValue = JSValue.CreateObject();
+            exportsValue.SetProperty("require", require);
+
             napi_env env = (napi_env)exportsValue.Scope;
             napi_value exports = (napi_value)exportsValue;
 
@@ -195,8 +202,12 @@ internal unsafe partial class NativeHost : IDisposable
     /// </summary>
     /// <param name="minVersion">Minimum requested .NET version.</param>
     /// <param name="managedHostPath">Path to the managed host assembly file.</param>
+    /// <param name="require">Require function passed in by the init script.</param>
     /// <returns>JS exports value from the managed host.</returns>
-    private JSValue InitializeDotNetHost(Version minVersion, string managedHostPath)
+    private JSValue InitializeDotNetHost(
+        Version minVersion,
+        string managedHostPath,
+        JSValue require)
     {
         Trace("    Initializing .NET " + minVersion);
 
@@ -260,6 +271,7 @@ internal unsafe partial class NativeHost : IDisposable
 
         // Create an "exports" object for the managed host module initialization.
         var exports = JSValue.CreateObject();
+        exports.SetProperty("require", require);
 
         // Define a dispose method implemented by the native host that closes the CLR context.
         // The managed host proxy will pass through dispose calls to this callback.

--- a/src/NodeApi/Interop/JSCallbackDescriptor.cs
+++ b/src/NodeApi/Interop/JSCallbackDescriptor.cs
@@ -30,13 +30,8 @@ public readonly struct JSCallbackDescriptor
     public object? Data { get; }
 
     public JSCallbackDescriptor(JSCallback callback, object? data = null)
+        : this(callback, data, JSValueScope.Current.ModuleContext)
     {
-        JSValueScope currentScope = JSValueScope.Current ??
-            throw new InvalidOperationException("No current scope.");
-        ModuleContext = currentScope.ModuleContext;
-
-        Callback = callback ?? throw new ArgumentNullException(nameof(callback));
-        Data = data;
     }
 
     internal JSCallbackDescriptor(JSCallback callback, object? data, JSModuleContext? moduleContext)

--- a/src/NodeApi/Interop/JSClassBuilderOfT.cs
+++ b/src/NodeApi/Interop/JSClassBuilderOfT.cs
@@ -64,7 +64,7 @@ public class JSClassBuilder<T> : JSPropertyDescriptorList<JSClassBuilder<T>, T> 
             throw new InvalidOperationException("A class constructor is required.");
         }
 
-        JSContext context = JSContext.Current;
+        JSRuntimeContext context = JSRuntimeContext.Current;
         JSValue classObject;
         if (typeof(Stream).IsAssignableFrom(typeof(T)))
         {
@@ -101,7 +101,7 @@ public class JSClassBuilder<T> : JSPropertyDescriptorList<JSClassBuilder<T>, T> 
                             instance = _constructorDescriptor.Value.Callback(args);
                         }
 
-                        return JSContext.Current.InitializeObjectWrapper(args.ThisArg, instance);
+                        return JSRuntimeContext.Current.InitializeObjectWrapper(args.ThisArg, instance);
                     },
                     _constructorDescriptor.Value.Data),
                 Properties.ToArray());
@@ -110,7 +110,7 @@ public class JSClassBuilder<T> : JSPropertyDescriptorList<JSClassBuilder<T>, T> 
         if (baseClass != null && !baseClass.Value.IsUndefined())
         {
             JSValue setPrototypeFunction =
-                JSContext.Current.Import(null, "Object").GetProperty("setPrototypeOf");
+                JSRuntimeContext.Current.Import(null, "Object").GetProperty("setPrototypeOf");
             setPrototypeFunction.Call(
                 thisArg: JSValue.Undefined,
                 classObject.GetProperty("prototype"),
@@ -142,7 +142,7 @@ public class JSClassBuilder<T> : JSPropertyDescriptorList<JSClassBuilder<T>, T> 
 
         JSValue obj = JSValue.CreateObject();
         obj.DefineProperties(Properties.ToArray());
-        JSContext.Current.RegisterStaticClass(ClassName, obj);
+        JSRuntimeContext.Current.RegisterStaticClass(ClassName, obj);
         return obj;
     }
 
@@ -152,7 +152,7 @@ public class JSClassBuilder<T> : JSPropertyDescriptorList<JSClassBuilder<T>, T> 
     /// <remarks>
     /// A JS class defined this way may not be constructed directly from JS. An instance of the
     /// class may be constructed when passing a .NET object (that implements the interface) to JS
-    /// via <see cref="JSContext.GetOrCreateObjectWrapper()" />.
+    /// via <see cref="JSRuntimeContext.GetOrCreateObjectWrapper()" />.
     /// </remarks>
     public JSValue DefineInterface()
     {
@@ -169,7 +169,7 @@ public class JSClassBuilder<T> : JSPropertyDescriptorList<JSClassBuilder<T>, T> 
             }
         }
 
-        return JSContext.Current.RegisterClass<T>(JSNativeApi.DefineClass(
+        return JSRuntimeContext.Current.RegisterClass<T>(JSNativeApi.DefineClass(
             ClassName,
             new JSCallbackDescriptor((args) =>
             {
@@ -180,7 +180,7 @@ public class JSClassBuilder<T> : JSPropertyDescriptorList<JSClassBuilder<T>, T> 
 
                 // Constructing a JS instance to wrap a C# instance that implements the interface.
                 JSValue instance = args[0];
-                return JSContext.Current.InitializeObjectWrapper(args.ThisArg, instance);
+                return JSRuntimeContext.Current.InitializeObjectWrapper(args.ThisArg, instance);
             }),
             Properties.ToArray()));
     }

--- a/src/NodeApi/Interop/JSCollectionExtensions.cs
+++ b/src/NodeApi/Interop/JSCollectionExtensions.cs
@@ -262,7 +262,6 @@ internal class JSIterableEnumerable<T> : IEnumerable<T>, IEquatable<JSValue>, ID
     {
         // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
         Dispose(disposing: true);
-        GC.SuppressFinalize(this);
     }
 
     protected virtual void Dispose(bool disposing)
@@ -551,7 +550,6 @@ internal class JSMapReadOnlyDictionary<TKey, TValue> :
     {
         // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
         Dispose(disposing: true);
-        GC.SuppressFinalize(this);
     }
 
     protected virtual void Dispose(bool disposing)

--- a/src/NodeApi/Interop/JSContext.cs
+++ b/src/NodeApi/Interop/JSContext.cs
@@ -15,13 +15,13 @@ namespace Microsoft.JavaScript.NodeApi.Interop;
 /// Manages JavaScript interop context for the lifetime of the .NET Node API host.
 /// </summary>
 /// <remarks>
-/// A <see cref="JSContext"/> instance is constructed when the .NET Node API managed host is
+/// A <see cref="JSRuntimeContext"/> instance is constructed when the .NET Node API managed host is
 /// loaded, and disposed when the host is unloaded. (For AOT there is no "host" compnoent, so each
 /// AOT module has a context that matches the module lifetime.) The context tracks several kinds
 /// of JS references used internally by this assembly, so that the references can be re-used for
 /// the lifetime of the module and disposed when the context is disposed.
 /// </remarks>
-public sealed class JSContext : IDisposable
+public sealed class JSRuntimeContext : IDisposable
 {
     private readonly napi_env _env;
 
@@ -94,22 +94,22 @@ public sealed class JSContext : IDisposable
 
     public bool IsDisposed { get; private set; }
 
-    public static explicit operator napi_env(JSContext context) => context._env;
-    public static explicit operator JSContext(napi_env env)
-        => GetInstanceData(env) as JSContext
+    public static explicit operator napi_env(JSRuntimeContext context) => context._env;
+    public static explicit operator JSRuntimeContext(napi_env env)
+        => GetInstanceData(env) as JSRuntimeContext
            ?? throw new InvalidCastException("Context is not found in napi_env instance data.");
 
     /// <summary>
     /// Gets the current host context.
     /// </summary>
-    public static JSContext Current => JSValueScope.Current?.Context
+    public static JSRuntimeContext Current => JSValueScope.Current?.RuntimeContext
         ?? throw new InvalidCastException("No current scope.");
 
     public JSSynchronizationContext SynchronizationContext { get; }
 
-    public JSContext(napi_env env)
+    public JSRuntimeContext(napi_env env)
     {
-        // TODO: Move this Initialize call to the creators of JSContext
+        // TODO: Move this Initialize call to the creators of JSRuntimeContext
         JSNativeApi.Interop.Initialize();
 
         _env = env;

--- a/src/NodeApi/Interop/JSContext.cs
+++ b/src/NodeApi/Interop/JSContext.cs
@@ -635,8 +635,6 @@ public sealed class JSContext : IDisposable
         DisposeReferences(_staticClassMap);
         DisposeReferences(_structMap);
         SynchronizationContext.Dispose();
-
-        GC.SuppressFinalize(this);
     }
 
     private static void DisposeReferences<TKey>(

--- a/src/NodeApi/Interop/JSModuleBuilderOfT.cs
+++ b/src/NodeApi/Interop/JSModuleBuilderOfT.cs
@@ -9,8 +9,8 @@ namespace Microsoft.JavaScript.NodeApi.Interop;
 /// <summary>
 /// Builds JS module exports.
 /// </summary>
-/// <typeparam name="T">Either <see cref="JSContext" /> or a custom module class that
-/// wraps a <see cref="JSContext"/> instance.</typeparam>
+/// <typeparam name="T">Either <see cref="JSRuntimeContext" /> or a custom module class that
+/// wraps a <see cref="JSRuntimeContext"/> instance.</typeparam>
 public class JSModuleBuilder<T> : JSPropertyDescriptorList<JSModuleBuilder<T>, T> where T : class
 {
     public JSModuleBuilder() : base(Unwrap)

--- a/src/NodeApi/Interop/JSModuleBuilderOfT.cs
+++ b/src/NodeApi/Interop/JSModuleBuilderOfT.cs
@@ -19,7 +19,7 @@ public class JSModuleBuilder<T> : JSPropertyDescriptorList<JSModuleBuilder<T>, T
 
     private static new T? Unwrap(JSCallbackArgs _)
     {
-        return (T?)JSContext.Current.Module;
+        return (T?)JSModuleContext.Current.Module;
     }
 
     /// <summary>
@@ -33,7 +33,7 @@ public class JSModuleBuilder<T> : JSPropertyDescriptorList<JSModuleBuilder<T>, T
     /// <returns>The module exports.</returns>
     public JSValue ExportModule(T module, JSObject exports)
     {
-        JSContext.Current.Module = module;
+        JSModuleContext.Current.Module = module;
         exports.DefineProperties(Properties.ToArray());
         return exports;
     }

--- a/src/NodeApi/Interop/JSModuleContext.cs
+++ b/src/NodeApi/Interop/JSModuleContext.cs
@@ -46,7 +46,5 @@ public sealed class JSModuleContext : IDisposable
         {
             module.Dispose();
         }
-
-        GC.SuppressFinalize(this);
     }
 }

--- a/src/NodeApi/Interop/JSModuleContext.cs
+++ b/src/NodeApi/Interop/JSModuleContext.cs
@@ -17,16 +17,8 @@ public sealed class JSModuleContext : IDisposable
     /// <summary>
     /// Gets the current module context.
     /// </summary>
-    public static JSModuleContext Current
-    {
-        get
-        {
-            JSValueScope scope = JSValueScope.Current
-                ?? throw new InvalidCastException("No current scope.");
-            return scope.ModuleContext
-                ?? throw new InvalidCastException("No current module context.");
-        }
-    }
+    public static JSModuleContext Current => JSValueScope.Current.ModuleContext
+        ?? throw new InvalidCastException("No current module context.");
 
     /// <summary>
     /// Gets an instance of the class that represents the module, or null if there is no module

--- a/src/NodeApi/Interop/JSModuleContext.cs
+++ b/src/NodeApi/Interop/JSModuleContext.cs
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+
+namespace Microsoft.JavaScript.NodeApi.Interop;
+
+/// <summary>
+/// Manages JavaScript interop context for the lifetime of a .NET module.
+/// </summary>
+/// <remarks>
+/// A <see cref="JSModuleContext"/> instance is constructed when the module is loaded and disposed
+/// when the module is unloaded.
+/// </remarks>
+public sealed class JSModuleContext : IDisposable
+{
+    /// <summary>
+    /// Gets the current module context.
+    /// </summary>
+    public static JSModuleContext Current
+    {
+        get
+        {
+            JSValueScope scope = JSValueScope.Current
+                ?? throw new InvalidCastException("No current scope.");
+            return scope.ModuleContext
+                ?? throw new InvalidCastException("No current module context.");
+        }
+    }
+
+    /// <summary>
+    /// Gets an instance of the class that represents the module, or null if there is no module
+    /// class.
+    /// </summary>
+    public object? Module { get; internal set; }
+
+    public bool IsDisposed { get; private set; }
+
+    public void Dispose()
+    {
+        if (IsDisposed) return;
+
+        IsDisposed = true;
+
+        if (Module is IDisposable module)
+        {
+            module.Dispose();
+        }
+
+        GC.SuppressFinalize(this);
+    }
+}

--- a/src/NodeApi/Interop/JSRuntimeContext.cs
+++ b/src/NodeApi/Interop/JSRuntimeContext.cs
@@ -102,8 +102,7 @@ public sealed class JSRuntimeContext : IDisposable
     /// <summary>
     /// Gets the current host context.
     /// </summary>
-    public static JSRuntimeContext Current => JSValueScope.Current?.RuntimeContext
-        ?? throw new InvalidCastException("No current scope.");
+    public static JSRuntimeContext Current => JSValueScope.Current.RuntimeContext;
 
     public JSSynchronizationContext SynchronizationContext { get; }
 

--- a/src/NodeApi/Interop/JSRuntimeContext.cs
+++ b/src/NodeApi/Interop/JSRuntimeContext.cs
@@ -145,10 +145,7 @@ public sealed class JSRuntimeContext : IDisposable
         }
         set
         {
-            if (_require is not null)
-            {
-                _require.Dispose();
-            }
+            _require?.Dispose();
             _require = new JSReference(value);
         }
     }

--- a/src/NodeApi/Interop/JSStructBuilderOfT.cs
+++ b/src/NodeApi/Interop/JSStructBuilderOfT.cs
@@ -98,7 +98,7 @@ public class JSStructBuilder<T> where T : struct
         // to converted default values? Otherwise they will be initially undefined.
 
         // Note this does not use Wrap() because structs are passed by value.
-        return JSContext.Current.RegisterStruct<T>(JSNativeApi.DefineClass(
+        return JSRuntimeContext.Current.RegisterStruct<T>(JSNativeApi.DefineClass(
             StructName,
             new JSCallbackDescriptor((args) => args.ThisArg),
             Properties.ToArray()));

--- a/src/NodeApi/Interop/JSSynchronizationContext.cs
+++ b/src/NodeApi/Interop/JSSynchronizationContext.cs
@@ -29,7 +29,6 @@ public class JSSynchronizationContext : SynchronizationContext, IDisposable
     public void Dispose()
     {
         Dispose(disposing: true);
-        GC.SuppressFinalize(this);
     }
 
     public override void Post(SendOrPostCallback callback, object? state)

--- a/src/NodeApi/Interop/JSSynchronizationContext.cs
+++ b/src/NodeApi/Interop/JSSynchronizationContext.cs
@@ -6,7 +6,7 @@ using System.Threading;
 
 namespace Microsoft.JavaScript.NodeApi.Interop;
 
-public class JSSynchronizationContext : SynchronizationContext, IDisposable
+public sealed class JSSynchronizationContext : SynchronizationContext, IDisposable
 {
     private readonly JSThreadSafeFunction _tsfn;
 

--- a/src/NodeApi/Interop/JSSynchronizationContext.cs
+++ b/src/NodeApi/Interop/JSSynchronizationContext.cs
@@ -28,7 +28,13 @@ public sealed class JSSynchronizationContext : SynchronizationContext, IDisposab
 
     public void Dispose()
     {
-        Dispose(disposing: true);
+        if (IsDisposed) return;
+
+        IsDisposed = true;
+
+        // Destroy TSFN by releasing last thread use count.
+        // TSFN is deleted after this point and must not be used.
+        _tsfn.Release();
     }
 
     public override void Post(SendOrPostCallback callback, object? state)
@@ -73,16 +79,5 @@ public sealed class JSSynchronizationContext : SynchronizationContext, IDisposab
     public void CloseAsyncScope()
     {
         _tsfn.Unref();
-    }
-
-    protected virtual void Dispose(bool disposing)
-    {
-        if (IsDisposed) return;
-
-        IsDisposed = true;
-
-        // Destroy TSFN by releasing last thread use count.
-        // TSFN is deleted after this point and must not be used.
-        _tsfn.Release();
     }
 }

--- a/src/NodeApi/Interop/NodeStream.Proxy.cs
+++ b/src/NodeApi/Interop/NodeStream.Proxy.cs
@@ -63,10 +63,10 @@ public partial class NodeStream
                     JSValue options = JSValue.CreateObject();
                     options["readable"] = stream.CanRead;
                     options["writable"] = stream.CanWrite;
-                    JSValue duplexClass = JSContext.Current.Import("node:stream", "Duplex");
+                    JSValue duplexClass = JSRuntimeContext.Current.Import("node:stream", "Duplex");
                     duplexClass.Call(args.ThisArg, options);
 
-                    return JSContext.Current.InitializeObjectWrapper(args.ThisArg, instance);
+                    return JSRuntimeContext.Current.InitializeObjectWrapper(args.ThisArg, instance);
                 },
                 constructorDescriptor.Data),
             properties);
@@ -83,7 +83,7 @@ public partial class NodeStream
     {
         // https://nodejs.org/api/stream.html#api-for-stream-implementers
 
-        JSValue duplexConstructor = JSContext.Current.Import("node:stream", "Duplex");
+        JSValue duplexConstructor = JSRuntimeContext.Current.Import("node:stream", "Duplex");
         JSValue streamAdapter = GetOrCreateAdapter(stream.CanRead, stream.CanWrite);
         JSValue streamValue = duplexConstructor.CallAsConstructor(streamAdapter);
         streamValue.Wrap(stream);

--- a/src/NodeApi/JSDate.cs
+++ b/src/NodeApi/JSDate.cs
@@ -21,17 +21,17 @@ public readonly struct JSDate : IEquatable<JSValue>
 
     public JSDate()
     {
-        _value = JSContext.Current.Import(null, "Date").CallAsConstructor();
+        _value = JSRuntimeContext.Current.Import(null, "Date").CallAsConstructor();
     }
 
     public JSDate(long dateValue)
     {
-        _value = JSContext.Current.Import(null, "Date").CallAsConstructor(dateValue);
+        _value = JSRuntimeContext.Current.Import(null, "Date").CallAsConstructor(dateValue);
     }
 
     public JSDate(string dateString)
     {
-        _value = JSContext.Current.Import(null, "Date").CallAsConstructor(dateString);
+        _value = JSRuntimeContext.Current.Import(null, "Date").CallAsConstructor(dateString);
     }
 
     public long DateValue => (long)_value.CallMethod("valueOf");

--- a/src/NodeApi/JSError.cs
+++ b/src/NodeApi/JSError.cs
@@ -129,6 +129,12 @@ public struct JSError
 
     public JSError(Exception exception)
     {
+#if DEBUG
+        // .NET exception stack traces are not yet propagated to JS.
+        // For now, write the stack trace to stdout in debug builds.
+        Console.WriteLine(exception);
+#endif
+
         if (exception is JSException jsException)
         {
             JSError? error = jsException.Error;

--- a/src/NodeApi/JSMap.cs
+++ b/src/NodeApi/JSMap.cs
@@ -28,7 +28,7 @@ public readonly partial struct JSMap : IDictionary<JSValue, JSValue>, IEquatable
     /// </summary>
     public JSMap()
     {
-        _value = JSContext.Current.Import(null, "Map").CallAsConstructor();
+        _value = JSRuntimeContext.Current.Import(null, "Map").CallAsConstructor();
     }
 
     /// <summary>
@@ -37,7 +37,7 @@ public readonly partial struct JSMap : IDictionary<JSValue, JSValue>, IEquatable
     /// </summary>
     public JSMap(JSIterable iterable)
     {
-        _value = JSContext.Current.Import(null, "Map").CallAsConstructor(iterable);
+        _value = JSRuntimeContext.Current.Import(null, "Map").CallAsConstructor(iterable);
     }
 
     public int Count => (int)_value["size"];

--- a/src/NodeApi/JSPromise.cs
+++ b/src/NodeApi/JSPromise.cs
@@ -193,7 +193,7 @@ public readonly struct JSPromise : IEquatable<JSValue>
     /// </summary>
     public static JSPromise Resolve()
     {
-        return (JSPromise)JSContext.Current.Import(null, "Promise").CallMethod("resolve");
+        return (JSPromise)JSRuntimeContext.Current.Import(null, "Promise").CallMethod("resolve");
     }
 
     /// <summary>
@@ -201,7 +201,7 @@ public readonly struct JSPromise : IEquatable<JSValue>
     /// </summary>
     public static JSPromise Resolve(JSValue value)
     {
-        return (JSPromise)JSContext.Current.Import(null, "Promise").CallMethod("resolve", value);
+        return (JSPromise)JSRuntimeContext.Current.Import(null, "Promise").CallMethod("resolve", value);
     }
 
     /// <summary>
@@ -209,7 +209,7 @@ public readonly struct JSPromise : IEquatable<JSValue>
     /// </summary>
     public static JSPromise Reject(JSValue reason)
     {
-        return (JSPromise)JSContext.Current.Import(null, "Promise").CallMethod("reject", reason);
+        return (JSPromise)JSRuntimeContext.Current.Import(null, "Promise").CallMethod("reject", reason);
     }
 
     public static JSPromise All(params JSPromise[] promises) => Select("all", promises);
@@ -239,7 +239,7 @@ public readonly struct JSPromise : IEquatable<JSValue>
 
     private static JSPromise Select(string operation, JSArray promiseArray)
     {
-        return (JSPromise)JSContext.Current.Import(null, "Promise")
+        return (JSPromise)JSRuntimeContext.Current.Import(null, "Promise")
             .CallMethod(operation, promiseArray);
     }
 

--- a/src/NodeApi/JSPropertyDescriptor.cs
+++ b/src/NodeApi/JSPropertyDescriptor.cs
@@ -31,9 +31,7 @@ public readonly struct JSPropertyDescriptor
         JSPropertyAttributes attributes = JSPropertyAttributes.Default,
         object? data = null)
     {
-        JSValueScope currentScope = JSValueScope.Current ??
-            throw new InvalidOperationException("No current scope.");
-        ModuleContext = currentScope.ModuleContext;
+        ModuleContext = JSValueScope.Current.ModuleContext;
 
         Name = name;
         Method = method;

--- a/src/NodeApi/JSPropertyDescriptor.cs
+++ b/src/NodeApi/JSPropertyDescriptor.cs
@@ -2,18 +2,25 @@
 // Licensed under the MIT License.
 
 using System;
+using Microsoft.JavaScript.NodeApi.Interop;
 
 namespace Microsoft.JavaScript.NodeApi;
 
 public readonly struct JSPropertyDescriptor
 {
+    /// <summary>
+    /// Saves the module context under which the callback was defined, so that multiple .NET
+    /// modules in the same process can register callbacks for module-level functions.
+    /// </summary>
+    internal JSModuleContext? ModuleContext { get; init; }
+
     public JSValue Name { get; }
-    public JSCallback? Method { get; } = null;
-    public JSCallback? Getter { get; } = null;
-    public JSCallback? Setter { get; } = null;
-    public JSValue? Value { get; } = null;
-    public JSPropertyAttributes Attributes { get; } = JSPropertyAttributes.Default;
-    public object? Data { get; } = null;
+    public JSCallback? Method { get; }
+    public JSCallback? Getter { get; }
+    public JSCallback? Setter { get; }
+    public JSValue? Value { get; }
+    public JSPropertyAttributes Attributes { get; }
+    public object? Data { get; }
 
     public JSPropertyDescriptor(
         JSValue name,
@@ -24,6 +31,10 @@ public readonly struct JSPropertyDescriptor
         JSPropertyAttributes attributes = JSPropertyAttributes.Default,
         object? data = null)
     {
+        JSValueScope currentScope = JSValueScope.Current ??
+            throw new InvalidOperationException("No current scope.");
+        ModuleContext = currentScope.ModuleContext;
+
         Name = name;
         Method = method;
         Getter = getter;

--- a/src/NodeApi/JSProxy.cs
+++ b/src/NodeApi/JSProxy.cs
@@ -259,8 +259,6 @@ public readonly partial struct JSProxy : IEquatable<JSValue>
                     JSHandlerReference.Value.Dispose();
                 }
             }
-
-            GC.SuppressFinalize(this);
         }
 
         public override string ToString()

--- a/src/NodeApi/JSProxy.cs
+++ b/src/NodeApi/JSProxy.cs
@@ -50,7 +50,7 @@ public readonly partial struct JSProxy : IEquatable<JSValue>
             jsTarget.Wrap(target);
         }
 
-        JSValue proxyConstructor = JSContext.Current.Import(null, "Proxy");
+        JSValue proxyConstructor = JSRuntimeContext.Current.Import(null, "Proxy");
 
         if (revocable)
         {

--- a/src/NodeApi/JSReference.cs
+++ b/src/NodeApi/JSReference.cs
@@ -23,7 +23,7 @@ namespace Microsoft.JavaScript.NodeApi;
 /// </remarks>
 public class JSReference : IDisposable
 {
-    private readonly JSContext _context;
+    private readonly JSRuntimeContext _context;
     private readonly napi_ref _handle;
 
     public bool IsWeak { get; private set; }
@@ -40,7 +40,7 @@ public class JSReference : IDisposable
 
     public JSReference(napi_ref handle, bool isWeak = false)
     {
-        _context = JSContext.Current;
+        _context = JSRuntimeContext.Current;
         _handle = handle;
         IsWeak = isWeak;
     }

--- a/src/NodeApi/JSSet.cs
+++ b/src/NodeApi/JSSet.cs
@@ -33,7 +33,7 @@ public readonly partial struct JSSet : ISet<JSValue>, IEquatable<JSValue>
     /// </summary>
     public JSSet()
     {
-        _value = JSContext.Current.Import(null, "Set").CallAsConstructor();
+        _value = JSRuntimeContext.Current.Import(null, "Set").CallAsConstructor();
     }
 
     /// <summary>
@@ -41,7 +41,7 @@ public readonly partial struct JSSet : ISet<JSValue>, IEquatable<JSValue>
     /// </summary>
     public JSSet(JSIterable iterable)
     {
-        _value = JSContext.Current.Import(null, "Set").CallAsConstructor(iterable);
+        _value = JSRuntimeContext.Current.Import(null, "Set").CallAsConstructor(iterable);
     }
 
     public int Count => (int)_value["size"];

--- a/src/NodeApi/JSValue.cs
+++ b/src/NodeApi/JSValue.cs
@@ -170,7 +170,7 @@ public readonly struct JSValue : IEquatable<JSValue>
         JSValue func = CreateFunction(
             utf8Name,
             new napi_callback(
-                JSValueScope.Current?.ScopeType == JSValueScopeType.RootNoContext ?
+                JSValueScope.Current?.ScopeType == JSValueScopeType.NoContext ?
                 s_invokeJSCallbackNC : s_invokeJSCallback),
             (nint)descriptorHandle);
         func.AddGCHandleFinalizer((nint)descriptorHandle);
@@ -188,7 +188,7 @@ public readonly struct JSValue : IEquatable<JSValue>
             utf8Name,
             (nuint)utf8NameLength,
             new napi_callback(
-                JSValueScope.Current?.ScopeType == JSValueScopeType.RootNoContext ?
+                JSValueScope.Current?.ScopeType == JSValueScopeType.NoContext ?
                 s_invokeJSCallbackNC : s_invokeJSCallback),
             (nint)descriptorHandle, out napi_value result)
             .ThrowIfFailed(result);

--- a/src/NodeApi/JSValue.cs
+++ b/src/NodeApi/JSValue.cs
@@ -16,8 +16,7 @@ public readonly struct JSValue : IEquatable<JSValue>
     private readonly napi_value _handle = default;
     private readonly JSValueScope? _scope = null;
 
-    public readonly JSValueScope Scope =>
-        _scope ?? JSValueScope.Current ?? throw new InvalidOperationException("No current scope");
+    public readonly JSValueScope Scope => _scope ?? JSValueScope.Current;
 
     public JSValue() { }
 

--- a/src/NodeApi/JSValueScope.cs
+++ b/src/NodeApi/JSValueScope.cs
@@ -8,7 +8,53 @@ using static Microsoft.JavaScript.NodeApi.JSNativeApi.Interop;
 
 namespace Microsoft.JavaScript.NodeApi;
 
-public enum JSValueScopeType { Handle, Escapable, Callback, Root, RootNoContext, }
+/// <summary>
+/// Indicates the type of <see cref="JSValueScope" /> within the hiearchy of scopes.
+/// </summary>
+public enum JSValueScopeType
+{
+    /// <summary>
+    /// A limited scope without any <see cref="JSContext" /> or <see cref="JSModuleContext" />.
+    /// Used by the Node API .NET native host to set up callbacks before the managed host is
+    /// initialized.
+    /// </summary>
+    NoContext,
+
+    /// <summary>
+    /// A parent scope shared by all (non-AOT) .NET modules loaded in the same process. It has
+    /// a <see cref="JSContext" /> but no <see cref="JSModuleContext" />.
+    /// </summary>
+    /// <remarks>
+    /// AOT modules do not have any root scope, so each module scope has a separate
+    /// <see cref="JSContext"/>.
+    /// </remarks>
+    Root,
+
+    /// <summary>
+    /// A scope specific to each module. It inherits the <see cref="JSContext" /> from the root
+    /// scope, and has a unique <see cref="JSModuleContext" />.
+    /// </summary>
+    /// <remarks>
+    /// AOT modules do not have any root scope, so each module also has a separate
+    /// <see cref="JSContext"/>.
+    /// </remarks>
+    Module,
+
+    /// <summary>
+    /// Callback scope within a module; inherits context from the module.
+    /// </summary>
+    Callback,
+
+    /// <summary>
+    /// Handle scope within a callback; inherits context from the module.
+    /// </summary>
+    Handle,
+
+    /// <summary>
+    /// Escapable handle scope within a callback; inherits context from the module.
+    /// </summary>
+    Escapable,
+}
 
 public sealed class JSValueScope : IDisposable
 {
@@ -25,7 +71,9 @@ public sealed class JSValueScope : IDisposable
 
     public bool IsDisposed { get; private set; }
 
-    public JSContext ModuleContext { get; }
+    public JSContext Context { get; }
+
+    public JSModuleContext? ModuleContext { get; internal set; }
 
     public JSValueScope(
         JSValueScopeType scopeType = JSValueScopeType.Handle, napi_env env = default)
@@ -39,21 +87,31 @@ public sealed class JSValueScope : IDisposable
                ? env
                : _parentScope?._env ?? throw new ArgumentException("env is null", nameof(env));
 
-        ModuleContext = scopeType switch
+        Context = scopeType switch
         {
-            // TODO: Properly support multiple module contexts or root scopes.
-            JSValueScopeType.Root => _parentScope?.ModuleContext ?? new JSContext(_env),
-
+            JSValueScopeType.NoContext => null!,
+            JSValueScopeType.Root => _parentScope?.Context ?? new JSContext(_env),
+            JSValueScopeType.Module => _parentScope?.Context ?? new JSContext(_env),
             JSValueScopeType.Callback => (JSContext)_env,
-            JSValueScopeType.RootNoContext => null!,
-            _ => _parentScope?.ModuleContext
-                 ?? throw new InvalidOperationException("Parent scope not found"),
+            _ => _parentScope?.Context
+                 ?? throw new InvalidOperationException("Parent scope not found."),
         };
+
+        ModuleContext = _parentScope?.ModuleContext;
+        if (scopeType == JSValueScopeType.Module)
+        {
+            if (ModuleContext != null)
+            {
+                throw new InvalidOperationException("Module scope cannot be nested.");
+            }
+
+            ModuleContext = new JSModuleContext();
+        }
 
         if (scopeType == JSValueScopeType.Root || scopeType == JSValueScopeType.Callback)
         {
             _previousSyncContext = SynchronizationContext.Current;
-            SynchronizationContext.SetSynchronizationContext(ModuleContext.SynchronizationContext);
+            SynchronizationContext.SetSynchronizationContext(Context.SynchronizationContext);
         }
 
         _scopeHandle = ScopeType switch
@@ -74,9 +132,9 @@ public sealed class JSValueScope : IDisposable
         if (IsDisposed) return;
         IsDisposed = true;
 
-        if (ScopeType != JSValueScopeType.RootNoContext)
+        if (ScopeType != JSValueScopeType.NoContext)
         {
-            napi_env env = (napi_env)ModuleContext;
+            napi_env env = (napi_env)Context;
 
             switch (ScopeType)
             {

--- a/src/NodeApi/JSValueScope.cs
+++ b/src/NodeApi/JSValueScope.cs
@@ -67,7 +67,8 @@ public sealed class JSValueScope : IDisposable
 
     public JSValueScopeType ScopeType { get; }
 
-    public static JSValueScope? Current => s_currentScope;
+    public static JSValueScope Current => s_currentScope ??
+        throw new InvalidOperationException("No current scope.");
 
     public bool IsDisposed { get; private set; }
 
@@ -172,7 +173,7 @@ public sealed class JSValueScope : IDisposable
         return new JSValue(result, _parentScope);
     }
 
-    public static explicit operator napi_env(JSValueScope? scope)
+    public static explicit operator napi_env(JSValueScope scope)
     {
         if (scope is null) throw new ArgumentNullException(nameof(scope));
         return scope!._env;

--- a/src/NodeApi/Native/JSNativeApi.cs
+++ b/src/NodeApi/Native/JSNativeApi.cs
@@ -439,7 +439,7 @@ public static partial class JSNativeApi
         GCHandle descriptorHandle = GCHandle.Alloc(constructorDescriptor);
         JSValue? func = null;
         napi_callback callback = new(
-            JSValueScope.Current?.ScopeType == JSValueScopeType.RootNoContext
+            JSValueScope.Current?.ScopeType == JSValueScopeType.NoContext
             ? s_invokeJSCallbackNC : s_invokeJSCallback);
 
         nint[] handles = ToUnmanagedPropertyDescriptors(
@@ -926,24 +926,30 @@ public static partial class JSNativeApi
     private static unsafe napi_value InvokeJSMethod(napi_env env, napi_callback_info callbackInfo)
     {
         return InvokeCallback<JSPropertyDescriptor>(
-            env, callbackInfo, JSValueScopeType.Callback, (propertyDescriptor) =>
-                new(propertyDescriptor.Method!, propertyDescriptor.Data));
+            env, callbackInfo, JSValueScopeType.Callback, (propertyDescriptor) => new(
+                propertyDescriptor.Method!,
+                propertyDescriptor.Data,
+                propertyDescriptor.ModuleContext));
     }
 
     [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvCdecl) })]
     private static unsafe napi_value InvokeJSGetter(napi_env env, napi_callback_info callbackInfo)
     {
         return InvokeCallback<JSPropertyDescriptor>(
-            env, callbackInfo, JSValueScopeType.Callback, (propertyDescriptor) =>
-                new(propertyDescriptor.Getter!, propertyDescriptor.Data));
+            env, callbackInfo, JSValueScopeType.Callback, (propertyDescriptor) => new(
+                propertyDescriptor.Getter!,
+                propertyDescriptor.Data,
+                propertyDescriptor.ModuleContext));
     }
 
     [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvCdecl) })]
     private static napi_value InvokeJSSetter(napi_env env, napi_callback_info callbackInfo)
     {
         return InvokeCallback<JSPropertyDescriptor>(
-            env, callbackInfo, JSValueScopeType.Callback, (propertyDescriptor) =>
-                new(propertyDescriptor.Setter!, propertyDescriptor.Data));
+            env, callbackInfo, JSValueScopeType.Callback, (propertyDescriptor) => new(
+                propertyDescriptor.Setter!,
+                propertyDescriptor.Data,
+                propertyDescriptor.ModuleContext));
     }
 
     [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvCdecl) })]
@@ -951,31 +957,37 @@ public static partial class JSNativeApi
         napi_env env, napi_callback_info callbackInfo)
     {
         return InvokeCallback<JSCallbackDescriptor>(
-            env, callbackInfo, JSValueScopeType.RootNoContext, (descriptor) => descriptor);
+            env, callbackInfo, JSValueScopeType.NoContext, (descriptor) => descriptor);
     }
 
     [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvCdecl) })]
     private static unsafe napi_value InvokeJSMethodNoContext(napi_env env, napi_callback_info callbackInfo)
     {
         return InvokeCallback<JSPropertyDescriptor>(
-            env, callbackInfo, JSValueScopeType.RootNoContext, (propertyDescriptor) =>
-                new(propertyDescriptor.Method!, propertyDescriptor.Data));
+            env, callbackInfo, JSValueScopeType.NoContext, (propertyDescriptor) => new(
+                propertyDescriptor.Method!,
+                propertyDescriptor.Data,
+                propertyDescriptor.ModuleContext));
     }
 
     [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvCdecl) })]
     private static unsafe napi_value InvokeJSGetterNoContext(napi_env env, napi_callback_info callbackInfo)
     {
         return InvokeCallback<JSPropertyDescriptor>(
-            env, callbackInfo, JSValueScopeType.RootNoContext, (propertyDescriptor) =>
-                new(propertyDescriptor.Getter!, propertyDescriptor.Data));
+            env, callbackInfo, JSValueScopeType.NoContext, (propertyDescriptor) => new(
+                propertyDescriptor.Getter!,
+                propertyDescriptor.Data,
+                propertyDescriptor.ModuleContext));
     }
 
     [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvCdecl) })]
     private static napi_value InvokeJSSetterNoContext(napi_env env, napi_callback_info callbackInfo)
     {
         return InvokeCallback<JSPropertyDescriptor>(
-            env, callbackInfo, JSValueScopeType.RootNoContext, (propertyDescriptor) =>
-                new(propertyDescriptor.Setter!, propertyDescriptor.Data));
+            env, callbackInfo, JSValueScopeType.NoContext, (propertyDescriptor) => new(
+                propertyDescriptor.Setter!,
+                propertyDescriptor.Data,
+                propertyDescriptor.ModuleContext));
     }
 
     private static unsafe napi_value InvokeCallback<TDescriptor>(
@@ -990,6 +1002,7 @@ public static partial class JSNativeApi
             JSCallbackArgs.GetDataAndLength(env, callbackInfo, out object? data, out int length);
             Span<napi_value> args = stackalloc napi_value[length];
             JSCallbackDescriptor descriptor = getCallbackDescriptor((TDescriptor)data!);
+            scope.ModuleContext = descriptor.ModuleContext;
             return (napi_value)descriptor.Callback(
                 new JSCallbackArgs(scope, callbackInfo, args, descriptor.Data));
         }
@@ -1046,7 +1059,7 @@ public static partial class JSNativeApi
         napi_callback methodCallback;
         napi_callback getterCallback;
         napi_callback setterCallback;
-        if (JSValueScope.Current?.ScopeType == JSValueScopeType.RootNoContext)
+        if (JSValueScope.Current?.ScopeType == JSValueScopeType.NoContext)
         {
             // The NativeHost and ManagedHost set up callbacks without a current module context.
             methodCallback = new napi_callback(s_invokeJSMethodNC);

--- a/src/NodeApi/Native/JSNativeApi.cs
+++ b/src/NodeApi/Native/JSNativeApi.cs
@@ -1130,8 +1130,6 @@ public static partial class JSNativeApi
                 _memoryHandle.Dispose();
                 Owner = null;
             }
-
-            GC.SuppressFinalize(this);
         }
     }
 }

--- a/src/node-api-dotnet/init.js
+++ b/src/node-api-dotnet/init.js
@@ -22,12 +22,8 @@ function initialize(targetFramework) {
   const nativeHostPath = __dirname + `/${runtimeIdentifier}/${assemblyName}.node`;
   const managedHostPath = __dirname + `/${targetFramework}/${assemblyName}.DotNetHost.dll`
 
-  // The Node API module may need the require() function at initialization time.
-  // TODO: Pass this as a parameter to the native host initialize() method instead of a global.
-  global.require = require;
-
   const nativeHost = require(nativeHostPath);
-  return nativeHost.initialize(targetFramework, managedHostPath);
+  return nativeHost.initialize(targetFramework, managedHostPath, require);
 }
 
 function getRuntimeIdentifier() {

--- a/test/TestBuilder.cs
+++ b/test/TestBuilder.cs
@@ -328,16 +328,28 @@ internal static class TestBuilder
         {
             if (e.Data != null)
             {
-                logWriter.WriteLine(e.Data);
-                logWriter.Flush();
+                try
+                {
+                    logWriter.WriteLine(e.Data);
+                    logWriter.Flush();
+                }
+                catch (ObjectDisposedException)
+                {
+                }
             }
         };
         process.ErrorDataReceived += (_, e) =>
         {
             if (e.Data != null)
             {
-                logWriter.WriteLine(e.Data);
-                logWriter.Flush();
+                try
+                {
+                    logWriter.WriteLine(e.Data);
+                    logWriter.Flush();
+                }
+                catch (ObjectDisposedException)
+                {
+                }
                 errorOutput.AppendLine(e.Data);
             }
         };

--- a/test/TestCases/common/index.js
+++ b/test/TestCases/common/index.js
@@ -129,9 +129,9 @@ exports.loadDotnetModule = function () {
         require)
       .require(exports.dotnetModule);
   } else {
-    // The Node API module may need the require() function at initialization time; passing it as a
+    // The Node API module may need the require() function at initialization time; passing it via a
     // global is the only solution for AOT, since it cannot be obtained via any `napi_*` function.
-    global.require = require;
+    global.node_api_dotnet = { require };
 
     dotnetModule = require(exports.dotnetModule);
   }

--- a/test/TestCases/common/index.js
+++ b/test/TestCases/common/index.js
@@ -118,18 +118,21 @@ exports.dotnetModule = process.env.TEST_DOTNET_MODULE_PATH;
 exports.dotnetVersion = process.env.TEST_DOTNET_VERSION;
 
 exports.loadDotnetModule = function () {
-  // The Node API module may need the require() function at initialization time; passing it as
-  // a global is the best (only?) solution, since it cannot be obtained via any `napi_*` function.
-  global.require = require;
-
   let dotnetModule;
   if (exports.dotnetHost) {
-    // Normally the index.js script in the npm package takes care of locating the correct
+    // Normally the init.js script in the npm package takes care of locating the correct
     // native host and managed host binaries for the current environment.
     dotnetModule = require(exports.dotnetHost)
-      .initialize(exports.dotnetVersion, exports.dotnetHost.replace(/\.node$/, '.DotNetHost.dll'))
+      .initialize(
+        exports.dotnetVersion,
+        exports.dotnetHost.replace(/\.node$/, '.DotNetHost.dll'),
+        require)
       .require(exports.dotnetModule);
   } else {
+    // The Node API module may need the require() function at initialization time; passing it as a
+    // global is the only solution for AOT, since it cannot be obtained via any `napi_*` function.
+    global.require = require;
+
     dotnetModule = require(exports.dotnetModule);
   }
 

--- a/test/TestCases/napi-dotnet-init/ModuleInitializer.cs
+++ b/test/TestCases/napi-dotnet-init/ModuleInitializer.cs
@@ -9,7 +9,7 @@ namespace Microsoft.JavaScript.NodeApi.TestCases;
 public class ModuleInitializer
 {
     [JSModule]
-    public static JSValue Initialize(JSContext context, JSObject exports)
+    public static JSValue Initialize(JSRuntimeContext context, JSObject exports)
     {
         Console.WriteLine("Module.Initialize()");
 
@@ -21,7 +21,7 @@ public class ModuleInitializer
         }
 
         // Export a module with a JS property that doesn't map to any C# property.
-        JSModuleBuilder<JSContext> moduleBuilder = new();
+        JSModuleBuilder<JSRuntimeContext> moduleBuilder = new();
         moduleBuilder.AddProperty("test", JSValue.GetBoolean(true));
         return moduleBuilder.ExportModule(context, exports);
     }

--- a/test/TestCases/napi-dotnet/ModuleClass.cs
+++ b/test/TestCases/napi-dotnet/ModuleClass.cs
@@ -18,7 +18,7 @@ public class ModuleClass : IDisposable
 {
     /// <summary>
     /// The module class must have a public constructor that takes either no parameters
-    /// or a single JSContext parameter.
+    /// or a single JSRuntimeContext parameter.
     /// </summary>
     public ModuleClass()
     {

--- a/test/TestCases/napi-dotnet/ModuleClass.cs
+++ b/test/TestCases/napi-dotnet/ModuleClass.cs
@@ -26,7 +26,6 @@ public class ModuleClass : IDisposable
 
     public void Dispose()
     {
-        GC.SuppressFinalize(this);
     }
 
     public string ModuleProperty { get; set; } = "test";

--- a/test/TestCases/napi-dotnet/ModuleClass.cs
+++ b/test/TestCases/napi-dotnet/ModuleClass.cs
@@ -14,7 +14,7 @@ namespace Microsoft.JavaScript.NodeApi.TestCases;
 /// automatically exported.
 /// </summary>
 [JSModule]
-public class ModuleClass : IDisposable
+public sealed class ModuleClass : IDisposable
 {
     /// <summary>
     /// The module class must have a public constructor that takes either no parameters


### PR DESCRIPTION
As described in #55, there were problems with loading multiple (non-AOT) modules in the same process. Module-level methods could get the wrong `this` pointer (likely causing a cast exception) because each module overwrites the reference to the module object.

 - Add a new `JSModuleContext` that is specific to each module, while the existing `JSContext` is shared across all .NET modules loaded by the same host.
 - Add a `JSValueScopeType.Module` that is the scope type for module initialization. It inherits the shared `JSContext` from the host but creates a new `JSModuleContext` instance.
 - Replace the single `JSValueScope.ModuleContext` property with distinct `Context` and `ModuleContext`.
 - Pass the module context to callbacks via the descriptor: - either `JSPropertyDescriptor` or `JSCallbackDescriptor`. Then assign it to the `JSValueScope` that is initialized for the callback.

We could consider moving some additional things from `JSContext` to `JSModuleContext`, though at this point it's not obvious to me that anything needs to move: if multiple modules are passing around objects among them, then it probably makes sense to have shared object and reference tracking.

There are some small additional fixes included here:
 - Don't use `global` for passing `require()` in when initializing a .NET hosted module. (Though it is still necessary for AOT.)
 - Fix an occasional hang in the test runner when running tests.

Fixes: #55