### PR TITLE
Fix test-results reporting for PR builds from repo forks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 # https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-net
 
-name: napi-dotnet build and test
+name: PR Verification
 
 on:
   push:
@@ -16,14 +16,14 @@ permissions:
 
 jobs:
   build:
-
-    runs-on: ${{ matrix.os }}
-
     strategy:
       matrix:
         os: [ windows-latest, macos-latest, ubuntu-latest ]
         node-version: [ 18.x ]
+        configuration: [ Release ]
       fail-fast: false  # Don't cancel other jobs when one job fails
+
+    runs-on: ${{ matrix.os }}
 
     steps:
     - uses: actions/checkout@v3
@@ -49,11 +49,11 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
 
-    - name: Build
-      run: dotnet build --configuration Release
+    - name: Build ${{ matrix.configuration }}
+      run: dotnet build --configuration ${{ matrix.configuration }}
 
     - name: Build packages
-      run: dotnet pack --configuration Release
+      run: dotnet pack --configuration ${{ matrix.configuration }}
 
     # Uncomment to enable an SSH session for debugging
     # - name: Setup tmate session
@@ -64,7 +64,7 @@ jobs:
     - name: Upload build artifacts
       uses: actions/upload-artifact@v3
       with:
-        name: ${{ runner.os }}-packages
+        name: ${{ matrix.os }}-${{ matrix.configuration }}-packages
         path: |
           out/pkg/*.nupkg
           out/pkg/*.tgz
@@ -73,37 +73,37 @@ jobs:
       if: matrix.os == 'windows-latest'
       env:
         TRACE_NODE_API_HOST: 1
-      run: dotnet test -f net472 --configuration Release --logger trx --results-directory "test-netfx47-node${{ matrix.node-version }}"
+      run: >
+        dotnet test -f net472
+        --configuration ${{ matrix.configuration }}
+        --logger trx
+        --results-directory "test-netfx47-node${{ matrix.node-version }}-${{ matrix.configuration }}"
 
     - name: Test .NET 6
       env:
         TRACE_NODE_API_HOST: 1
-      run: dotnet test -f net6.0 --configuration Release --logger trx --results-directory "test-dotnet6-node${{ matrix.node-version }}"
+      run: >
+        dotnet test -f net6.0
+        --configuration ${{ matrix.configuration }}
+        --logger trx
+        --results-directory "test-dotnet6-node${{ matrix.node-version }}-${{ matrix.configuration }}"
 
     - name: Test .NET 7
       env:
         TRACE_NODE_API_HOST: 1
-      run: dotnet test -f net7.0 --configuration Release --logger trx --results-directory "test-dotnet7-node${{ matrix.node-version }}"
+      run: >
+        dotnet test -f net7.0
+        --configuration ${{ matrix.configuration }}
+        --logger trx
+        --results-directory "test-dotnet7-node${{ matrix.node-version }}-${{ matrix.configuration }}"
 
     - name: Upload test logs
       uses: actions/upload-artifact@v3
       with:
-        name: test-logs-${{ runner.os }}-node${{ matrix.node-version }}
-        path: out/obj/Release/**/*.log
+        name: test-logs-${{ matrix.os }}-node${{ matrix.node-version }}-${{ matrix.configuration }}
+        path: out/obj/${{ matrix.configuration }}/**/*.log
       if: ${{ always() }}
-
-    - name: Publish test results
-      uses: dorny/test-reporter@v1
-      with:
-        name: test (${{ runner.os }}, node${{ matrix.node-version }})
-        path: test-dotnet*-node${{ matrix.node-version }}/*.trx
-        reporter: dotnet-trx
-      if: ${{ always() }} # Run this step even when there are test failures
 
     - name: Check formatting
       run: dotnet format --no-restore --severity info --verbosity detailed --verify-no-changes
       if: ${{ always() }} # Run this step even when there are build failures
-
-    # TODO: Publish packages
-    # - name: Publish packages
-    #   run: dotnet nuget push out/pkg/*.nupkg

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,16 +3,9 @@
 name: PR Verification
 
 on:
-  push:
-    branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
   workflow_dispatch: # Enable manually starting a build
-
-permissions:
-  checks: write
-  pull-requests: write
-  statuses: write
 
 jobs:
   build:
@@ -53,6 +46,7 @@ jobs:
       run: dotnet build --configuration ${{ matrix.configuration }}
 
     - name: Build packages
+      id: pack
       run: dotnet pack --configuration ${{ matrix.configuration }}
 
     # Uncomment to enable an SSH session for debugging
@@ -70,40 +64,44 @@ jobs:
           out/pkg/*.tgz
 
     - name: Test .NET 4.7.2
-      if: matrix.os == 'windows-latest'
+      if: matrix.os == 'windows-latest' && steps.pack.conclusion == 'success' && !cancelled()
       env:
         TRACE_NODE_API_HOST: 1
       run: >
         dotnet test -f net472
         --configuration ${{ matrix.configuration }}
         --logger trx
-        --results-directory "test-netfx47-node${{ matrix.node-version }}-${{ matrix.configuration }}"
+        --results-directory "out/test/netfx47-node${{ matrix.node-version }}-${{ matrix.configuration }}"
 
     - name: Test .NET 6
+      if: steps.pack.conclusion == 'success' && !cancelled()
       env:
         TRACE_NODE_API_HOST: 1
       run: >
         dotnet test -f net6.0
         --configuration ${{ matrix.configuration }}
         --logger trx
-        --results-directory "test-dotnet6-node${{ matrix.node-version }}-${{ matrix.configuration }}"
+        --results-directory "out/test/dotnet6-node${{ matrix.node-version }}-${{ matrix.configuration }}"
 
     - name: Test .NET 7
+      if: steps.pack.conclusion == 'success' && !cancelled()
       env:
         TRACE_NODE_API_HOST: 1
       run: >
         dotnet test -f net7.0
         --configuration ${{ matrix.configuration }}
         --logger trx
-        --results-directory "test-dotnet7-node${{ matrix.node-version }}-${{ matrix.configuration }}"
+        --results-directory "out/test/dotnet7-node${{ matrix.node-version }}-${{ matrix.configuration }}"
 
     - name: Upload test logs
+      if: always() # Update artifacts regardless if code succeeded, failed, or cancelled
       uses: actions/upload-artifact@v3
       with:
         name: test-logs-${{ matrix.os }}-node${{ matrix.node-version }}-${{ matrix.configuration }}
-        path: out/obj/${{ matrix.configuration }}/**/*.log
-      if: ${{ always() }}
+        path: |
+          out/obj/${{ matrix.configuration }}/**/*.log
+          out/test/**/*.trx
 
     - name: Check formatting
+      if: ${{ !cancelled() }} # Run this step even when there are build failures but not when cancelled
       run: dotnet format --no-restore --severity info --verbosity detailed --verify-no-changes
-      if: ${{ always() }} # Run this step even when there are build failures

--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -7,37 +7,28 @@ on:
     workflows: ['PR Verification'] # runs after 'PR Verification' workflow
     types:
       - completed
+
+permissions:
+  checks: write
+  pull-requests: write
+  statuses: write
+
 jobs:
   report:
+    strategy:
+      matrix:
+        os: [ windows-latest, macos-latest, ubuntu-latest ]
+        node-version: [ 18.x ]
+        configuration: [ Release ]
+      fail-fast: false  # Don't cancel other jobs when one job fails
+
     runs-on: ubuntu-latest
+
     steps:
-      # GitHub actions do not support loops.
-      # To report on the same machine we expand the matrix ourselves.
-      #  matrix:
-      #    os: [ windows-latest, macos-latest, ubuntu-latest ]
-      #    node-version: [ 18.x ]
-      #    configuration: [ Release ]
-
-    - name: Publish test results (windows-latest, node18.x, Release)
+    - name: Publish test results (${{ matrix.os }}, node${{ matrix.node-version }}, ${{ matrix.configuration }})
       uses: dorny/test-reporter@v1
       with:
-        artifact: test-logs-windows-latest-node18.x-Release
-        name: test (windows-latest, node18.x, Release)
-        path: test-dotnet*-node18.x-Release/*.trx
-        reporter: dotnet-trx
-
-    - name: Publish test results (macos-latest, node18.x, Release)
-      uses: dorny/test-reporter@v1
-      with:
-        artifact: test-logs-macos-latest-node18.x-Release
-        name: test (macos-latest, node18.x, Release)
-        path: test-dotnet*-node18.x-Release/*.trx
-        reporter: dotnet-trx
-
-    - name: Publish test results (ubuntu-latest, node18.x, Release)
-      uses: dorny/test-reporter@v1
-      with:
-        artifact: test-logs-ubuntu-latest-node18.x-Release
-        name: test (ubuntu-latest, node18.x, Release)
-        path: test-dotnet*-node18.x-Release/*.trx
+        artifact: test-logs-${{ matrix.os }}-node${{ matrix.node-version }}-${{ matrix.configuration }}
+        name: test results (${{ matrix.os }}, node${{ matrix.node-version }}, ${{ matrix.configuration }})
+        path: test/**/*.trx
         reporter: dotnet-trx

--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -1,0 +1,43 @@
+# https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-net
+# https://github.com/dorny/test-reporter#recommended-setup-for-public-repositories
+
+name: Test Report
+on:
+  workflow_run:
+    workflows: ['PR Verification'] # runs after 'PR Verification' workflow
+    types:
+      - completed
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    steps:
+      # GitHub actions do not support loops.
+      # To report on the same machine we expand the matrix ourselves.
+      #  matrix:
+      #    os: [ windows-latest, macos-latest, ubuntu-latest ]
+      #    node-version: [ 18.x ]
+      #    configuration: [ Release ]
+
+    - name: Publish test results (windows-latest, node18.x, Release)
+      uses: dorny/test-reporter@v1
+      with:
+        artifact: test-logs-windows-latest-node18.x-Release
+        name: test (windows-latest, node18.x, Release)
+        path: test-dotnet*-node18.x-Release/*.trx
+        reporter: dotnet-trx
+
+    - name: Publish test results (macos-latest, node18.x, Release)
+      uses: dorny/test-reporter@v1
+      with:
+        artifact: test-logs-macos-latest-node18.x-Release
+        name: test (macos-latest, node18.x, Release)
+        path: test-dotnet*-node18.x-Release/*.trx
+        reporter: dotnet-trx
+
+    - name: Publish test results (ubuntu-latest, node18.x, Release)
+      uses: dorny/test-reporter@v1
+      with:
+        artifact: test-logs-ubuntu-latest-node18.x-Release
+        name: test (ubuntu-latest, node18.x, Release)
+        path: test-dotnet*-node18.x-Release/*.trx
+        reporter: dotnet-trx


### PR DESCRIPTION
Resolves #71
The PR follows the solution described here: https://github.com/dorny/test-reporter#recommended-setup-for-public-repositories
As a part of this solution, we split up the test reporting into a separate workflow.
The build script is tested against a fork repo.

Related changes:
- Added `configuration` to the build matrix
- `runner.os` is replaced by `matrix.os` to simplify matching attribute names.
- Renamed the build workflow to 'PR Verification'.
- Do not start build workflow on push.
- Execute all tests as long as 'pack' succeeded regardless of other tests failure.
- Do not execute the most steps when build is cancelled.
