### PR TITLE
Extract NativeLibrary polyfills to another class

### DIFF
--- a/src/NodeApi/Native/JSNativeApi.Interop.cs
+++ b/src/NodeApi/Native/JSNativeApi.Interop.cs
@@ -28,45 +28,11 @@ public static partial class JSNativeApi
 
             if (libraryHandle == default)
             {
-#if NET7_0_OR_GREATER
                 libraryHandle = NativeLibrary.GetMainProgramHandle();
-#else
-                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-                {
-                    libraryHandle = GetModuleHandleW(default);
-                }
-                else
-                {
-                    libraryHandle = dlopen(default, RTLD_LAZY);
-                }
-#endif
             }
 
             s_libraryHandle = libraryHandle;
         }
-
-#if !NET7_0_OR_GREATER
-        [DllImport("kernel32")]
-        private static extern nint GetModuleHandleW(nint moduleName);
-
-        [DllImport("libdl")]
-        private static extern nint dlopen(nint fileName, int flags);
-
-        private const int RTLD_LAZY = 1;
-#endif // !NET7_0_OR_GREATER
-
-#if NETFRAMEWORK
-        [DllImport("kernel32")]
-        private static extern nint GetProcAddress(nint hModule, string procName);
-
-        private static class NativeLibrary
-        {
-            public static nint GetExport(nint handle, string name)
-            {
-                return GetProcAddress(handle, name);
-            }
-        }
-#endif // NETFRAMEWORK
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         public delegate napi_value napi_register_module_v1(napi_env env, napi_value exports);

--- a/src/NodeApi/Native/NativeLibrary.cs
+++ b/src/NodeApi/Native/NativeLibrary.cs
@@ -1,0 +1,89 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#if !NET7_0_OR_GREATER
+
+using System.Runtime.InteropServices;
+#if !NETFRAMEWORK
+using SysNativeLibrary = System.Runtime.InteropServices.NativeLibrary;
+#endif
+
+namespace Microsoft.JavaScript.NodeApi;
+
+/// <summary>
+/// Provides APIs for managing native libraries.
+/// </summary>
+/// <remarks>
+/// The System.Runtime.InteropServices.NativeLibrary class is not available in .NET Framework,
+/// and is missing some methods before .NET 7. This fills in those APIs.
+/// </remarks>
+public static class NativeLibrary
+{
+    /// <summary>
+    /// Gets a handle that can be used with <see cref="GetExport"/> to resolve exports from the
+    /// entry point module.
+    /// </summary>
+    public static nint GetMainProgramHandle()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return GetModuleHandle(default);
+        }
+        else
+        {
+            return dlopen(default, RTLD_LAZY);
+        }
+    }
+
+    /// <summary>
+    /// Loads a native library using default flags.
+    /// </summary>
+    /// <param name="libraryName">The name of the native library to be loaded.</param>
+    /// <returns>The OS handle for the loaded native library.</returns>
+    public static nint Load(string libraryName)
+    {
+#if NETFRAMEWORK
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return LoadLibrary(libraryName);
+        }
+        else
+        {
+            return dlopen(default, RTLD_LAZY);
+        }
+#else
+        return SysNativeLibrary.Load(libraryName);
+#endif
+    }
+
+    /// <summary>
+    /// Gets the address of an exported symbol.
+    /// </summary>
+    /// <param name="handle">The native library OS handle.</param>
+    /// <param name="name">The name of the exported symbol.</param>
+    /// <returns>The address of the symbol.</returns>
+    public static nint GetExport(nint handle, string name)
+    {
+#if NETFRAMEWORK
+        return GetProcAddress(handle, name);
+#else
+        return SysNativeLibrary.GetExport(handle, name);
+#endif
+    }
+
+    [DllImport("kernel32", CharSet = CharSet.Unicode)]
+    private static extern nint GetModuleHandle(string? moduleName);
+
+    [DllImport("kernel32", CharSet = CharSet.Unicode)]
+    private static extern nint LoadLibrary(string moduleName);
+
+    [DllImport("kernel32", CharSet = CharSet.Unicode)]
+    private static extern nint GetProcAddress(nint hModule, string procName);
+
+    [DllImport("libdl")]
+    private static extern nint dlopen(nint fileName, int flags);
+
+    private const int RTLD_LAZY = 1;
+}
+
+#endif // !NET7_0_OR_GREATER

--- a/src/NodeApi/Native/NativeLibrary.cs
+++ b/src/NodeApi/Native/NativeLibrary.cs
@@ -3,6 +3,7 @@
 
 #if !NET7_0_OR_GREATER
 
+using System;
 using System.Runtime.InteropServices;
 #if !NETFRAMEWORK
 using SysNativeLibrary = System.Runtime.InteropServices.NativeLibrary;
@@ -43,14 +44,7 @@ public static class NativeLibrary
     public static nint Load(string libraryName)
     {
 #if NETFRAMEWORK
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-        {
-            return LoadLibrary(libraryName);
-        }
-        else
-        {
-            return dlopen(default, RTLD_LAZY);
-        }
+        return LoadLibrary(libraryName);
 #else
         return SysNativeLibrary.Load(libraryName);
 #endif
@@ -71,13 +65,13 @@ public static class NativeLibrary
 #endif
     }
 
-    [DllImport("kernel32", CharSet = CharSet.Unicode)]
+    [DllImport("kernel32")]
     private static extern nint GetModuleHandle(string? moduleName);
 
-    [DllImport("kernel32", CharSet = CharSet.Unicode)]
+    [DllImport("kernel32")]
     private static extern nint LoadLibrary(string moduleName);
 
-    [DllImport("kernel32", CharSet = CharSet.Unicode)]
+    [DllImport("kernel32")]
     private static extern nint GetProcAddress(nint hModule, string procName);
 
     [DllImport("libdl")]

--- a/src/NodeApi/Native/NativeLibrary.cs
+++ b/src/NodeApi/Native/NativeLibrary.cs
@@ -65,6 +65,8 @@ public static class NativeLibrary
 #endif
     }
 
+#pragma warning disable CA2101 // Specify marshaling for P/Invoke string arguments
+
     [DllImport("kernel32")]
     private static extern nint GetModuleHandle(string? moduleName);
 
@@ -78,6 +80,8 @@ public static class NativeLibrary
     private static extern nint dlopen(nint fileName, int flags);
 
     private const int RTLD_LAZY = 1;
+
+#pragma warning restore CA2101
 }
 
 #endif // !NET7_0_OR_GREATER


### PR DESCRIPTION
This makes it easier to use `NativeLibrary` methods from other classes and assemblies. We'll need it for hosting JS engines.