### PR TITLE
Enable throwing JS errors without runtime context

### DIFF
--- a/test/HostedClrTests.cs
+++ b/test/HostedClrTests.cs
@@ -58,15 +58,14 @@ public class HostedClrTests
         // packaging should orchestrate getting these files in the right places.
         string hostFilePath2 = Path.Combine(
             Path.GetDirectoryName(moduleFilePath)!, Path.GetFileName(hostFilePath));
-        File.Copy(hostFilePath, hostFilePath2, overwrite: true);
+        CopyIfNewer(hostFilePath, hostFilePath2);
         if (File.Exists(hostFilePath + ".pdb"))
         {
-            File.Copy(hostFilePath + ".pdb", hostFilePath2 + ".pdb", overwrite: true);
+            CopyIfNewer(hostFilePath + ".pdb", hostFilePath2 + ".pdb");
         }
-        File.Copy(
+        CopyIfNewer(
             hostFilePath.Replace(".node", ".runtimeconfig.json"),
-            hostFilePath2.Replace(".node", ".runtimeconfig.json"),
-            overwrite: true);
+            hostFilePath2.Replace(".node", ".runtimeconfig.json"));
         hostFilePath = hostFilePath2;
 
         // TODO: Support compiling TS files to JS.

--- a/test/TestBuilder.cs
+++ b/test/TestBuilder.cs
@@ -368,4 +368,15 @@ internal static class TestBuilder
         logWriter.Close();
         return errorOutput.Length > 0 ? errorOutput.ToString() : null;
     }
+
+    public static void CopyIfNewer(string sourceFilePath, string targetFilePath)
+    {
+        // GetLastWriteTimeUtc returns MinValue if the file doesn't exist.
+        DateTime sourceTime = File.GetLastWriteTimeUtc(sourceFilePath);
+        DateTime targetTime = File.GetLastWriteTimeUtc(targetFilePath);
+        if (sourceTime > targetTime)
+        {
+            File.Copy(sourceFilePath, targetFilePath, overwrite: true);
+        }
+    }
 }

--- a/test/TestBuilder.cs
+++ b/test/TestBuilder.cs
@@ -371,7 +371,12 @@ internal static class TestBuilder
 
     public static void CopyIfNewer(string sourceFilePath, string targetFilePath)
     {
-        // GetLastWriteTimeUtc returns MinValue if the file doesn't exist.
+        if (!File.Exists(sourceFilePath))
+        {
+            throw new FileNotFoundException("File not found: " + sourceFilePath, sourceFilePath);
+        }
+
+        // GetLastWriteTimeUtc returns MinValue if the target file doesn't exist.
         DateTime sourceTime = File.GetLastWriteTimeUtc(sourceFilePath);
         DateTime targetTime = File.GetLastWriteTimeUtc(targetFilePath);
         if (sourceTime > targetTime)


### PR DESCRIPTION
This fixes reporting of errors that may occur during initialization, before a `JSRuntimeContext` is established.

Before this, when an error was attempted to be thrown during initialization it would only report `Unhandled Exception: System.InvalidOperationException: Parent scope not found.`, and the original error message was lost.


Also, I'm fixing an occasional test failure that could happen if the target of a file copy was in use.