### PR TITLE
Fix and bypass marshalling issues for SK

### DIFF
--- a/examples/semantic-kernel/example.js
+++ b/examples/semantic-kernel/example.js
@@ -8,7 +8,7 @@ const kernel = SK.Kernel.Builder.Build();
 // The JS marshaller does not yet support extension methods.
 SK.KernelConfigExtensions.AddAzureOpenAITextCompletion(
   kernel.Config,
-  'davinci-backend',
+  'davinci-azure',
   process.env['OPENAI_DEPLOYMENT'],
   process.env['OPENAI_ENDPOINT'],
   process.env['OPENAI_KEY'],

--- a/examples/semantic-kernel/semantic-kernel.csproj
+++ b/examples/semantic-kernel/semantic-kernel.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SemanticKernel" Version="0.9.61.1-preview" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
   </ItemGroup>
 
 </Project>

--- a/examples/semantic-kernel/semantic-kernel.js
+++ b/examples/semantic-kernel/semantic-kernel.js
@@ -10,8 +10,10 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const pkgDir = path.join(__dirname, 'pkg');
 
-const laVersion = fs.readdirSync(path.join(pkgDir, 'microsoft.extensions.logging.abstractions'))[0];
-const skVersion = fs.readdirSync(path.join(pkgDir, 'microsoft.semantickernel'))[0];
+// Find the latest installed version of the packages. (That might not be the correct version if
+// the dotnet project packages have not been restored. )
+const laVersion = fs.readdirSync(path.join(pkgDir, 'microsoft.extensions.logging.abstractions')).reverse()[0];
+const skVersion = fs.readdirSync(path.join(pkgDir, 'microsoft.semantickernel')).reverse()[0];
 
 // The dependency needs to be loaded explicitly because it's in a different directory.
 dotnet.load(path.join(pkgDir,

--- a/examples/semantic-kernel/semantic-kernel.js
+++ b/examples/semantic-kernel/semantic-kernel.js
@@ -10,14 +10,22 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const pkgDir = path.join(__dirname, 'pkg');
 
-// Find the latest installed version of the packages. (That might not be the correct version if
-// the dotnet project packages have not been restored. )
-const laVersion = fs.readdirSync(path.join(pkgDir, 'microsoft.extensions.logging.abstractions')).reverse()[0];
-const skVersion = fs.readdirSync(path.join(pkgDir, 'microsoft.semantickernel')).reverse()[0];
+const dependencies = [
+  'Microsoft.Extensions.Logging.Abstractions',
+  'System.Text.Json',
+  'Microsoft.Bcl.AsyncInterfaces',
+  'System.Text.Encodings.Web',
+  'System.Runtime.CompilerServices.Unsafe',
+];
 
-// The dependency needs to be loaded explicitly because it's in a different directory.
-dotnet.load(path.join(pkgDir,
-  `microsoft.extensions.logging.abstractions/${laVersion}/lib/netstandard2.0/Microsoft.Extensions.Logging.Abstractions.dll`));
+dependencies.forEach((assembly) => {
+  // Find the latest installed version of the packages. (That might not be the correct version if
+  // the dotnet project packages have not been restored. )
+  const version = fs.readdirSync(path.join(pkgDir, assembly)).reverse()[0];
+  dotnet.load(path.join(pkgDir, `${assembly}/${version}/lib/netstandard2.0/${assembly}.dll`));
+});
+
+const skVersion = fs.readdirSync(path.join(pkgDir, 'microsoft.semantickernel')).reverse()[0];
 
 /** @type import('./Microsoft.SemanticKernel') */
 const SK = dotnet.load(path.join(pkgDir,

--- a/src/NodeApi.DotNetHost/AssemblyExporter.cs
+++ b/src/NodeApi.DotNetHost/AssemblyExporter.cs
@@ -494,6 +494,7 @@ internal class AssemblyExporter
     {
         return !method.IsGenericMethodDefinition &&
             method.CallingConvention != CallingConventions.VarArgs &&
+            method.Name != nameof(System.Collections.IEnumerable.GetEnumerator) &&
             method.GetParameters().All(IsSupportedParameter) &&
             IsSupportedParameter(method.ReturnParameter);
     }

--- a/src/node-api-dotnet/pack.js
+++ b/src/node-api-dotnet/pack.js
@@ -148,7 +148,11 @@ function copyFrameworkSpecificBinaries(targetFrameworks, packageStageDir, ...bin
       const [projectName, binFileName] = binFile.split('/', 2);
 
       // "System." assemblies like System.Memory are only needed for .NET 4.x
-      if (tfm.includes('.') && binFileName.startsWith('System.')) return;
+      if (
+        tfm.includes('.') &&
+        binFileName.startsWith('System.') &&
+        !binFileName.includes('MetadataLoadContext')
+      ) return;
 
       const binPath = path.join(outBinDir, projectName, tfm, rids[0], binFileName);
       copyFile(binPath, path.join(tfmStageDir, binFileName));


### PR DESCRIPTION
 - Fix dynamic interface implementation class generation to handle cases when members of the interface recursively reference the same interface.
 - Fix marshalling method expression generator to handle >2 parameters and void return type.
 - Skip `GetEnumerator()` methods. The generic `IEnumerator<>` isn't supported, and anyway it should be mapped to "iterable" in JS.
 - Fix `pack.js` script to not exclude `System.Reflection.MetdataLoadContext.dll`; it is required in the generator package for all target frameworks.
 - Load additional dependency assemblies