### PR TITLE
Implement an example that uses Hermes engine.

### DIFF
--- a/examples/NuGet.config
+++ b/examples/NuGet.config
@@ -3,6 +3,7 @@
   <packageSources>
     <clear />
     <add key="local" value="../out/pkg" />
+    <add key="react-native" value="https://pkgs.dev.azure.com/ms/react-native/_packaging/react-native-public/nuget/v3/index.json" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
   <disabledPackageSources>

--- a/examples/hermes-engine/HermesApi.Interop.cs
+++ b/examples/hermes-engine/HermesApi.Interop.cs
@@ -1,0 +1,546 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Security;
+using Microsoft.JavaScript.NodeApi;
+using static Hermes.Example.HermesApi.Interop;
+using static Microsoft.JavaScript.NodeApi.JSNativeApi.Interop;
+
+namespace Hermes.Example;
+
+public static class HermesApi
+{
+    public static void Load(string hermesEnginePath)
+    {
+        nint hermesLib = NativeLibrary.Load(hermesEnginePath);
+        Interop.Initialize(hermesLib);
+        JSNativeApi.Interop.Initialize(hermesLib);
+    }
+
+    public static void ThrowIfFailed(
+        [DoesNotReturnIf(true)] this hermes_status status,
+        [CallerMemberName] string memberName = "",
+        [CallerFilePath] string sourceFilePath = "",
+        [CallerLineNumber] int sourceLineNumber = 0)
+    {
+        if (status == hermes_status.hermes_ok)
+            return;
+
+        throw new Exception($"Error in {memberName} at {sourceFilePath}:{sourceLineNumber}");
+    }
+
+    public static TResult ThrowIfFailed<TResult>(
+        [DoesNotReturnIf(true)] this hermes_status status,
+        TResult result,
+        [CallerMemberName] string memberName = "",
+        [CallerFilePath] string sourceFilePath = "",
+        [CallerLineNumber] int sourceLineNumber = 0)
+    {
+        if (status == hermes_status.hermes_ok)
+            return result;
+
+        throw new Exception($"Error in {memberName} at {sourceFilePath}:{sourceLineNumber}");
+    }
+
+    [SuppressUnmanagedCodeSecurity]
+    public static unsafe class Interop
+    {
+        private static nint s_libraryHandle;
+        private static FunctionFields s_fields = new();
+        private static bool s_initialized;
+
+        public static void Initialize(nint libraryHandle = default)
+        {
+            if (s_initialized) return;
+            s_initialized = true;
+
+            if (libraryHandle == default)
+            {
+#if NET7_0_OR_GREATER
+                libraryHandle = NativeLibrary.GetMainProgramHandle();
+#else
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                {
+                    libraryHandle = GetModuleHandleW(default);
+                }
+                else
+                {
+                    libraryHandle = dlopen(default, RTLD_LAZY);
+                }
+#endif
+            }
+
+            s_libraryHandle = libraryHandle;
+        }
+
+        private struct FunctionFields
+        {
+            // hermes_api.h APIs
+            public nint hermes_create_runtime;
+            public nint hermes_delete_runtime;
+            public nint hermes_get_node_api_env;
+            public nint hermes_dump_crash_data;
+            public nint hermes_sampling_profiler_enable;
+            public nint hermes_sampling_profiler_disable;
+            public nint hermes_sampling_profiler_add;
+            public nint hermes_sampling_profiler_remove;
+            public nint hermes_sampling_profiler_dump_to_file;
+
+            public nint hermes_create_config;
+            public nint hermes_delete_config;
+            public nint hermes_config_enable_default_crash_handler;
+            public nint hermes_config_enable_debugger;
+            public nint hermes_config_set_debugger_runtime_name;
+            public nint hermes_config_set_debugger_port;
+            public nint hermes_config_set_debugger_break_on_start;
+            public nint hermes_config_set_task_runner;
+            public nint hermes_config_set_script_cache;
+
+            public nint hermes_set_inspector;
+
+            public nint hermes_create_local_connection;
+            public nint hermes_delete_local_connection;
+            public nint hermes_local_connection_send_message;
+            public nint hermes_local_connection_disconnect;
+        }
+
+        public enum hermes_status : int
+        {
+            hermes_ok,
+            hermes_error,
+        }
+
+        public record struct hermes_config(nint Handle);
+        public record struct hermes_runtime(nint Handle);
+        public record struct hermes_local_connection(nint Handle);
+        public record struct hermes_remote_connection(nint Handle);
+
+        public record struct hermes_data_delete_cb(nint Handle)
+        {
+            public hermes_data_delete_cb(delegate* unmanaged[Cdecl]<nint, nint, void> handle)
+                : this((nint)handle) { }
+        }
+
+        //=============================================================================
+        // hermes_runtime
+        //=============================================================================
+
+        internal static hermes_status hermes_create_runtime(
+            hermes_config config, out hermes_runtime runtime)
+            => CallInterop(ref s_fields.hermes_create_runtime, config.Handle, out runtime);
+
+        internal static hermes_status hermes_delete_runtime(hermes_runtime runtime)
+            => CallInterop(ref s_fields.hermes_delete_runtime, runtime.Handle);
+
+        internal static hermes_status hermes_get_node_api_env(hermes_runtime runtime, out napi_env env)
+            => CallInterop(ref s_fields.hermes_get_node_api_env, runtime.Handle, out env);
+
+        internal static hermes_status hermes_dump_crash_data(hermes_runtime runtime, int fd)
+            => CallInterop(ref s_fields.hermes_dump_crash_data, runtime.Handle, fd);
+
+        internal static hermes_status hermes_sampling_profiler_enable()
+            => CallInterop(ref s_fields.hermes_sampling_profiler_enable);
+
+        internal static hermes_status hermes_sampling_profiler_disable()
+            => CallInterop(ref s_fields.hermes_sampling_profiler_disable);
+
+        internal static hermes_status hermes_sampling_profiler_add(hermes_runtime runtime)
+            => CallInterop(ref s_fields.hermes_sampling_profiler_add, runtime.Handle);
+
+        internal static hermes_status hermes_sampling_profiler_remove(hermes_runtime runtime)
+            => CallInterop(ref s_fields.hermes_sampling_profiler_remove, runtime.Handle);
+
+        internal static hermes_status hermes_sampling_profiler_dump_to_file(byte* filename)
+            => CallInterop(ref s_fields.hermes_sampling_profiler_dump_to_file, (nint)filename);
+
+        //=============================================================================
+        // hermes_config
+        //=============================================================================
+
+        internal static hermes_status hermes_create_config(out hermes_config config)
+            => CallInterop(ref s_fields.hermes_create_config, out config);
+
+        internal static hermes_status hermes_delete_config(hermes_config config)
+            => CallInterop(ref s_fields.hermes_delete_config, config.Handle);
+
+        internal static hermes_status hermes_config_enable_default_crash_handler(
+            hermes_config config, c_bool value)
+            => CallInterop(
+                ref s_fields.hermes_config_enable_default_crash_handler, config.Handle, value);
+
+        internal static hermes_status hermes_config_enable_debugger(hermes_config config, c_bool value)
+            => CallInterop(ref s_fields.hermes_config_enable_debugger, config.Handle, value);
+
+        internal static hermes_status hermes_config_set_debugger_runtime_name(
+            hermes_config config, byte* name)
+            => CallInterop(
+                ref s_fields.hermes_config_set_debugger_runtime_name, config.Handle, (nint)name);
+
+        internal static hermes_status hermes_config_set_debugger_port(
+            hermes_config config, ushort port)
+            => CallInterop(ref s_fields.hermes_config_set_debugger_port, config.Handle, port);
+
+        internal static hermes_status hermes_config_set_debugger_break_on_start(
+            hermes_config config, c_bool value)
+            => CallInterop(
+                ref s_fields.hermes_config_set_debugger_break_on_start, config.Handle, value);
+
+        //=============================================================================
+        // hermes_config task runner
+        //=============================================================================
+
+        // A callback to run task
+        // typedef void (NAPI_CDECL* hermes_task_run_cb) (void* task_data);
+        public record struct hermes_task_run_cb(nint Handle)
+        {
+            public hermes_task_run_cb(delegate* unmanaged[Cdecl]<nint, void> handle)
+                : this((nint)handle) { }
+        }
+
+        // A callback to post task to the task runner
+        //typedef void (NAPI_CDECL* hermes_task_runner_post_task_cb) (
+        //    void* task_runner_data,
+        //    void* task_data,
+        //    hermes_task_run_cb task_run_cb,
+        //    hermes_data_delete_cb task_data_delete_cb,
+        //    void* deleter_data);
+        public record struct hermes_task_runner_post_task_cb(nint Handle)
+        {
+            public hermes_task_runner_post_task_cb(
+                delegate* unmanaged[Cdecl]<
+                    nint, nint, hermes_task_run_cb, hermes_data_delete_cb, nint, void> handle)
+                : this((nint)handle) { }
+        }
+
+        internal static hermes_status hermes_config_set_task_runner(
+            hermes_config config,
+            nint task_runner_data,
+            hermes_task_runner_post_task_cb task_runner_post_task_cb,
+            hermes_data_delete_cb task_runner_data_delete_cb,
+            nint deleter_data)
+            => CallInterop(
+                ref s_fields.hermes_config_set_task_runner,
+                config.Handle,
+                task_runner_data,
+                task_runner_post_task_cb.Handle,
+                task_runner_data_delete_cb.Handle,
+                deleter_data);
+
+        //=============================================================================
+        // hermes_config script cache
+        //=============================================================================
+
+        public struct hermes_script_cache_metadata
+        {
+            public nint source_url;
+            public ulong source_hash;
+            public nint runtime_name;
+            public ulong runtime_version;
+            public nint tag;
+        }
+
+        //typedef void (NAPI_CDECL* hermes_script_cache_load_cb) (
+        //    void* script_cache_data,
+        //    hermes_script_cache_metadata* script_metadata,
+        //    const uint8_t** buffer,
+        //    size_t * buffer_size,
+        //    hermes_data_delete_cb * buffer_delete_cb,
+        //    void** deleter_data);
+        public record struct hermes_script_cache_load_cb(nint Handle)
+        {
+            public hermes_script_cache_load_cb(
+                delegate* unmanaged[Cdecl]<
+                    nint, hermes_script_cache_metadata*, nint, nint, nint, nint, void> handle)
+                : this((nint)handle) { }
+        }
+
+        //typedef void (NAPI_CDECL* hermes_script_cache_store_cb) (
+        //    void* script_cache_data,
+        //    hermes_script_cache_metadata* script_metadata,
+        //    const uint8_t* buffer,
+        //    size_t buffer_size,
+        //    hermes_data_delete_cb buffer_delete_cb,
+        //    void* deleter_data);
+        public record struct hermes_script_cache_store_cb(nint Handle)
+        {
+            public hermes_script_cache_store_cb(
+                delegate* unmanaged[Cdecl]<
+                    nint,
+                    hermes_script_cache_metadata*,
+                    nint,
+                    nuint,
+                    hermes_data_delete_cb,
+                    nint,
+                    void> handle)
+                : this((nint)handle) { }
+        }
+
+        internal static hermes_status hermes_config_set_script_cache(
+            hermes_config config,
+            nint script_cache_data,
+            hermes_script_cache_load_cb script_cache_load_cb,
+            hermes_script_cache_store_cb script_cache_store_cb,
+            hermes_data_delete_cb script_cache_data_delete_cb,
+            nint deleter_data)
+            => CallInterop(
+                ref s_fields.hermes_config_set_script_cache,
+                config.Handle,
+                script_cache_data,
+                script_cache_load_cb.Handle,
+                script_cache_store_cb.Handle,
+                script_cache_data_delete_cb.Handle,
+                deleter_data);
+
+        //=============================================================================
+        // Setting inspector singleton
+        //=============================================================================
+
+        //typedef int32_t(NAPI_CDECL* hermes_inspector_add_page_cb)(
+        //    const char* title,
+        //    const char* vm,
+        //    void* connectFunc);
+        public record struct hermes_inspector_add_page_cb(nint Handle)
+        {
+            public hermes_inspector_add_page_cb(
+                delegate* unmanaged[Cdecl]<nint, nint, nint, void> handle)
+                : this((nint)handle) { }
+        }
+
+        //typedef void (NAPI_CDECL* hermes_inspector_remove_page_cb) (int32_t page_id);
+        public record struct hermes_inspector_remove_page_cb(nint Handle)
+        {
+            public hermes_inspector_remove_page_cb(
+                delegate* unmanaged[Cdecl]<int, void> handle)
+                : this((nint)handle) { }
+        }
+
+        internal static hermes_status hermes_set_inspector(
+            hermes_inspector_add_page_cb add_page_cb,
+            hermes_inspector_remove_page_cb remove_page_cb)
+            => CallInterop(
+                ref s_fields.hermes_set_inspector,
+                add_page_cb.Handle,
+                remove_page_cb.Handle);
+
+        //=============================================================================
+        // Local and remote inspector connections.
+        // Local is defined in Hermes VM, Remote is defined by inspector outside of VM.
+        //=============================================================================
+
+        //typedef void (NAPI_CDECL* hermes_remote_connection_send_message_cb) (
+        //    hermes_remote_connection remote_connection,
+        //    const char* message);
+        public record struct hermes_remote_connection_send_message_cb(nint Handle)
+        {
+            public hermes_remote_connection_send_message_cb(
+                delegate* unmanaged[Cdecl]<nint, nint, void> handle)
+                : this((nint)handle) { }
+        }
+
+        //typedef void (NAPI_CDECL* hermes_remote_connection_disconnect_cb) (
+        //    hermes_remote_connection remote_connection);
+        public record struct hermes_remote_connection_disconnect_cb(nint Handle)
+        {
+            public hermes_remote_connection_disconnect_cb(
+                delegate* unmanaged[Cdecl]<nint, void> handle)
+                : this((nint)handle) { }
+        }
+
+        internal static hermes_status hermes_create_local_connection(
+            nint page_data,
+            hermes_remote_connection remote_connection,
+            hermes_remote_connection_send_message_cb on_send_message_cb,
+            hermes_remote_connection_disconnect_cb on_disconnect_cb,
+            hermes_data_delete_cb on_delete_cb,
+            nint deleter_data,
+            out hermes_local_connection local_connection)
+            => CallInterop(
+                ref s_fields.hermes_create_local_connection,
+                page_data,
+                remote_connection.Handle,
+                on_send_message_cb.Handle,
+                on_disconnect_cb.Handle,
+                on_delete_cb.Handle,
+                deleter_data,
+                out local_connection);
+
+        internal static hermes_status hermes_delete_local_connection(
+            hermes_local_connection local_connection)
+            => CallInterop(
+                ref s_fields.hermes_delete_local_connection,
+                local_connection.Handle);
+
+        internal static hermes_status hermes_local_connection_send_message(
+            hermes_local_connection local_connection,
+            byte* message)
+            => CallInterop(
+                ref s_fields.hermes_local_connection_send_message,
+                local_connection.Handle,
+                (nint)message);
+
+        internal static hermes_status hermes_local_connection_disconnect(
+            hermes_local_connection local_connection)
+            => CallInterop(
+                ref s_fields.hermes_local_connection_disconnect,
+                local_connection.Handle);
+
+        private static nint GetExport(ref nint field, [CallerMemberName] string functionName = "")
+        {
+            nint methodPtr = field;
+            if (methodPtr == default)
+            {
+                methodPtr = NativeLibrary.GetExport(s_libraryHandle, functionName);
+                field = methodPtr;
+            }
+
+            return methodPtr;
+        }
+
+        private static hermes_status CallInterop(
+            ref nint field,
+            [CallerMemberName] string functionName = "")
+        {
+            nint funcHandle = GetExport(ref field, functionName);
+            var funcDelegate = (delegate* unmanaged[Cdecl]<hermes_status>)funcHandle;
+            return funcDelegate();
+        }
+
+        private static hermes_status CallInterop(
+            ref nint field,
+            nint value1,
+            [CallerMemberName] string functionName = "")
+        {
+            nint funcHandle = GetExport(ref field, functionName);
+            var funcDelegate = (delegate* unmanaged[Cdecl]<nint, hermes_status>)funcHandle;
+            return funcDelegate(value1);
+        }
+
+        private static hermes_status CallInterop(
+            ref nint field,
+            nint value1,
+            nint value2,
+        [CallerMemberName] string functionName = "")
+        {
+            nint funcHandle = GetExport(ref field, functionName);
+            var funcDelegate = (delegate* unmanaged[Cdecl]<nint, nint, hermes_status>)funcHandle;
+            return funcDelegate(value1, value2);
+        }
+        private static hermes_status CallInterop(
+            ref nint field,
+            nint value1,
+            int value2,
+            [CallerMemberName] string functionName = "")
+        {
+            nint funcHandle = GetExport(ref field, functionName);
+            var funcDelegate = (delegate* unmanaged[Cdecl]<nint, int, hermes_status>)funcHandle;
+            return funcDelegate(value1, value2);
+        }
+
+        private static hermes_status CallInterop(
+            ref nint field,
+            nint value1,
+            ushort value2,
+            [CallerMemberName] string functionName = "")
+        {
+            nint funcHandle = GetExport(ref field, functionName);
+            var funcDelegate = (delegate* unmanaged[Cdecl]<nint, ushort, hermes_status>)funcHandle;
+            return funcDelegate(value1, value2);
+        }
+
+        private static hermes_status CallInterop(
+            ref nint field,
+            nint value1,
+            c_bool value2,
+            [CallerMemberName] string functionName = "")
+        {
+            nint funcHandle = GetExport(ref field, functionName);
+            var funcDelegate = (delegate* unmanaged[Cdecl]<nint, c_bool, hermes_status>)funcHandle;
+            return funcDelegate(value1, value2);
+        }
+
+        private static hermes_status CallInterop(
+            ref nint field,
+            nint value1,
+            nint value2,
+            nint value3,
+            nint value4,
+            nint value5,
+            [CallerMemberName] string functionName = "")
+        {
+            nint funcHandle = GetExport(ref field, functionName);
+            var funcDelegate = (delegate* unmanaged[Cdecl]<
+                nint, nint, nint, nint, nint, hermes_status>)funcHandle;
+            return funcDelegate(value1, value2, value3, value4, value5);
+        }
+
+        private static hermes_status CallInterop(
+            ref nint field,
+            nint value1,
+            nint value2,
+            nint value3,
+            nint value4,
+            nint value5,
+            nint value6,
+            [CallerMemberName] string functionName = "")
+        {
+            nint funcHandle = GetExport(ref field, functionName);
+            var funcDelegate = (delegate* unmanaged[Cdecl]<
+                nint, nint, nint, nint, nint, nint, hermes_status>)funcHandle;
+            return funcDelegate(value1, value2, value3, value4, value5, value6);
+        }
+
+        private static hermes_status CallInterop<TResult>(
+            ref nint field,
+            out TResult result,
+            [CallerMemberName] string functionName = "")
+            where TResult : unmanaged
+        {
+            nint funcHandle = GetExport(ref field, functionName);
+            var funcDelegate = (delegate* unmanaged[Cdecl]<nint, hermes_status>)funcHandle;
+            fixed (TResult* result_native = &result)
+            {
+                return funcDelegate((nint)result_native);
+            }
+        }
+
+        private static hermes_status CallInterop<TResult>(
+            ref nint field,
+            nint value1,
+            out TResult result,
+            [CallerMemberName] string functionName = "")
+            where TResult : unmanaged
+        {
+            nint funcHandle = GetExport(ref field, functionName);
+            var funcDelegate = (delegate* unmanaged[Cdecl]<nint, nint, hermes_status>)funcHandle;
+            fixed (TResult* result_native = &result)
+            {
+                return funcDelegate(value1, (nint)result_native);
+            }
+        }
+
+        private static hermes_status CallInterop<TResult>(
+            ref nint field,
+            nint value1,
+            nint value2,
+            nint value3,
+            nint value4,
+            nint value5,
+            nint value6,
+            out TResult result,
+            [CallerMemberName] string functionName = "")
+            where TResult : unmanaged
+        {
+            nint funcHandle = GetExport(ref field, functionName);
+            var funcDelegate = (delegate* unmanaged[Cdecl]<
+                nint, nint, nint, nint, nint, nint, nint, hermes_status>)funcHandle;
+            fixed (TResult* result_native = &result)
+            {
+                return funcDelegate(
+                    value1, value2, value3, value4, value5, value6, (nint)result_native);
+            }
+        }
+    }
+}

--- a/examples/hermes-engine/HermesConfig.cs
+++ b/examples/hermes-engine/HermesConfig.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using static Hermes.Example.HermesApi.Interop;
+
+namespace Hermes.Example;
+
+public sealed class HermesConfig : IDisposable
+{
+    private hermes_config _config;
+    private bool _isDisposed;
+
+    public HermesConfig()
+    {
+        hermes_create_config(out _config).ThrowIfFailed();
+    }
+
+    public void Dispose()
+    {
+        if (_isDisposed) return;
+        _isDisposed = true;
+        hermes_delete_config(_config).ThrowIfFailed();
+    }
+
+    public static explicit operator hermes_config(HermesConfig value) => value._config;
+}

--- a/examples/hermes-engine/HermesRuntime.cs
+++ b/examples/hermes-engine/HermesRuntime.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using static Hermes.Example.HermesApi.Interop;
+using static Microsoft.JavaScript.NodeApi.JSNativeApi.Interop;
+
+namespace Hermes.Example;
+
+public sealed class HermesRuntime : IDisposable
+{
+    private hermes_runtime _runtime;
+    private bool _isDisposed;
+
+    public HermesRuntime(HermesConfig? config)
+    {
+        if (config != null)
+        {
+            hermes_create_runtime((hermes_config)config, out _runtime).ThrowIfFailed();
+        }
+        else
+        {
+            using HermesConfig tempConfig = new();
+            hermes_create_runtime((hermes_config)tempConfig, out _runtime).ThrowIfFailed();
+        }
+    }
+
+    public HermesRuntime() : this(null) { }
+
+    public void Dispose()
+    {
+        if (_isDisposed) return;
+        _isDisposed = true;
+        hermes_delete_runtime(_runtime).ThrowIfFailed();
+    }
+
+    public static explicit operator hermes_runtime(HermesRuntime value) => value._runtime;
+
+    public static explicit operator napi_env(HermesRuntime value)
+        => hermes_get_node_api_env((hermes_runtime)value, out napi_env env).ThrowIfFailed(env);
+}

--- a/examples/hermes-engine/Program.cs
+++ b/examples/hermes-engine/Program.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Hermes.Example;
+using Microsoft.JavaScript.NodeApi;
+using static Microsoft.JavaScript.NodeApi.JSNativeApi.Interop;
+
+JSDispatcherQueueController controller = JSDispatcherQueueController.CreateOnDedicatedThread();
+controller.DispatcherQueue.TryEnqueue(() =>
+{
+    HermesApi.Load("hermes.dll");
+    using var runtime = new HermesRuntime();
+    using var scope = new JSValueScope(JSValueScopeType.Root, (napi_env)runtime);
+
+    JSNativeApi.RunScript("x = 2");
+    Console.WriteLine($"Result: {(int)JSValue.Global["x"]}");
+});
+
+controller.DispatcherQueue.TryEnqueue(() =>
+{
+    controller.ShutdownQueueAsync();
+});

--- a/examples/hermes-engine/hermes-engine.csproj
+++ b/examples/hermes-engine/hermes-engine.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net7.0</TargetFramework>
+    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RootNamespace>Hermes.Example</RootNamespace>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.JavaScript.NodeApi" Version="0.1.*-*" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.JavaScript.Hermes" Version="0.1.4" IncludeAssets="none" PrivateAssets="build;native;runtime" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="$(PkgMicrosoft_JavaScript_Hermes)\lib\native\win32\x64\hermes.dll" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+</Project>

--- a/examples/hermes-engine/hermes-engine.sln
+++ b/examples/hermes-engine/hermes-engine.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.33516.290
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "hermes-engine", "hermes-engine.csproj", "{EF350F77-7B60-4B5C-8634-8EB3153FB130}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{EF350F77-7B60-4B5C-8634-8EB3153FB130}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EF350F77-7B60-4B5C-8634-8EB3153FB130}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EF350F77-7B60-4B5C-8634-8EB3153FB130}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EF350F77-7B60-4B5C-8634-8EB3153FB130}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {C85AD6C1-99F4-4858-BE2C-3065E5DD7CF1}
+	EndGlobalSection
+EndGlobal

--- a/src/NodeApi/Interop/JSAsyncScope.cs
+++ b/src/NodeApi/Interop/JSAsyncScope.cs
@@ -44,7 +44,7 @@ namespace Microsoft.JavaScript.NodeApi.Interop;
 ///
 ///     // Tell Node.JS that we finished using its main loop and Node.JS process can exit
 ///     // after completing current callback.
-///     JSSynchronizationContext.Current.OpenAsyncScope();
+///     JSSynchronizationContext.Current.CloseAsyncScope();
 /// }
 /// </code>
 ///

--- a/src/NodeApi/Interop/JSRuntimeContext.cs
+++ b/src/NodeApi/Interop/JSRuntimeContext.cs
@@ -121,7 +121,7 @@ public sealed class JSRuntimeContext : IDisposable
 
         _env = env;
         SetInstanceData(env, this);
-        SynchronizationContext = new JSSynchronizationContext();
+        SynchronizationContext = JSSynchronizationContext.Create();
     }
 
     /// <summary>

--- a/src/NodeApi/Interop/JSSynchronizationContext.cs
+++ b/src/NodeApi/Interop/JSSynchronizationContext.cs
@@ -36,6 +36,7 @@ public class JSSynchronizationContext : SynchronizationContext, IDisposable
     {
         if (IsDisposed) return;
         IsDisposed = true;
+        GC.SuppressFinalize(this);
     }
 
     public virtual void OpenAsyncScope() { }

--- a/src/NodeApi/Interop/JSThreadSafeFunction.cs
+++ b/src/NodeApi/Interop/JSThreadSafeFunction.cs
@@ -22,6 +22,15 @@ public class JSThreadSafeFunction
 
     private JSThreadSafeFunction(napi_threadsafe_function tsfn) => _tsfn = tsfn;
 
+    public static bool IsAvailable
+    {
+        get
+        {
+            nint funcHandle = 0;
+            return TryGetExport(ref funcHandle, "napi_create_threadsafe_function");
+        }
+    }
+
     // This API may only be called from the main thread.
     public unsafe JSThreadSafeFunction(int maxQueueSize,
                                 int initialThreadCount,

--- a/src/NodeApi/JSDispatcherQueue.cs
+++ b/src/NodeApi/JSDispatcherQueue.cs
@@ -1,0 +1,221 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Hermes.Example;
+
+public delegate void JSTypedEventHandler<TSender, TResult>(TSender sender, TResult args);
+
+public sealed class DispatcherQueueShutdownStartingEventArgs : EventArgs
+{
+    private Func<JSDispatcherQueueDeferral> _getDeferral;
+
+    internal DispatcherQueueShutdownStartingEventArgs(Func<JSDispatcherQueueDeferral> getDeferral)
+        => _getDeferral = getDeferral;
+
+    public JSDispatcherQueueDeferral GetDeferral() => _getDeferral();
+}
+
+public sealed class JSDispatcherQueue
+{
+    private readonly object _queueMutex = new();
+    private List<Action?> _writerQueue = new(); // Queue to add new items
+    private List<Action?> _readerQueue = new(); // Queue to read items from
+    private TaskCompletionSource<int>? _onShutdownCompleted;
+    private int _threadId;
+    private int _deferralCount;
+    private bool _isShutdownCompleted;
+
+    [ThreadStatic]
+    private static JSDispatcherQueue? s_currentQueue;
+
+    public event JSTypedEventHandler<JSDispatcherQueue, object?>? ShutdownCompleted;
+    public event JSTypedEventHandler<JSDispatcherQueue, DispatcherQueueShutdownStartingEventArgs>?
+        ShutdownStarting;
+
+    public bool HasThreadAccess => _threadId == Environment.CurrentManagedThreadId;
+
+    public static JSDispatcherQueue? GetForCurrentThread() => s_currentQueue;
+
+    public bool TryEnqueue(Action callback)
+    {
+        lock (_queueMutex)
+        {
+            if (_isShutdownCompleted)
+            {
+                return false;
+            }
+
+            _writerQueue.Add(callback);
+            Monitor.PulseAll(_queueMutex);
+        }
+
+        return true;
+    }
+
+    // Run the thread function.
+    internal void Run()
+    {
+        using var currentQueueHolder = new CurrentQueueHolder(this);
+
+        // Loop until the shutdown completion breaks out of it.
+        while (true)
+        {
+            // Invoke tasks from reader queue outside of lock.
+            // The reader queue is only accessible from this thread.
+            for (int i = 0; i < _readerQueue.Count; i++)
+            {
+                _readerQueue[i]?.Invoke();
+                _readerQueue[i] = null;
+            }
+
+            // All tasks are completed. Clear the queue.
+            _readerQueue.Clear();
+
+            // Under lock see if we have more tasks, complete shutdown, or start waiting.
+            lock (_queueMutex)
+            {
+                // Swap reader and writer queues.
+                (_readerQueue, _writerQueue) = (_writerQueue, _readerQueue);
+
+                if (_readerQueue.Count > 0)
+                {
+                    // We have more work to do. Start the loop from the beginning.
+                    continue;
+                }
+
+                if (_onShutdownCompleted != null && _deferralCount == 0)
+                {
+                    // Complete the shutdown: the shutdown is already started,
+                    // there are no deferrals, and all work is completed.
+                    _isShutdownCompleted = true;
+                    break;
+                }
+
+                // Wait for more work to come.
+                Monitor.Wait(_queueMutex);
+            }
+        }
+
+        // Notify about the shutdown completion.
+        ShutdownCompleted?.Invoke(this, null);
+        _onShutdownCompleted.SetResult(0);
+    }
+
+    // Create new Deferral and increment deferral count.
+    internal JSDispatcherQueueDeferral CreateDeferral()
+    {
+        lock (_queueMutex)
+        {
+            _deferralCount++;
+        }
+
+        return new JSDispatcherQueueDeferral(() =>
+        {
+            // Decrement deferral count upon deferral completion.
+            TryEnqueue(() => _deferralCount--);
+        });
+    }
+
+    internal void Shutdown(TaskCompletionSource<int> completion)
+    {
+        // Try to start the shutdown process.
+        bool isShutdownStarted = TryEnqueue(() =>
+        {
+            if (_onShutdownCompleted != null)
+            {
+                // The shutdown is already started. Subscribe to its completion.
+                ShutdownCompleted += (_, _) => completion.SetResult(0);
+                return;
+            }
+
+            // Start the shutdown process.
+            _onShutdownCompleted = completion;
+            ShutdownStarting?.Invoke(
+                this, new DispatcherQueueShutdownStartingEventArgs(() => CreateDeferral()));
+        });
+
+        if (!isShutdownStarted)
+        {
+            // The shutdown was already completed.
+            completion.SetResult(0);
+        }
+    }
+
+    private struct CurrentQueueHolder : IDisposable
+    {
+        private readonly JSDispatcherQueue? _previousCurrentQueue;
+
+        public CurrentQueueHolder(JSDispatcherQueue queue)
+        {
+            _previousCurrentQueue = s_currentQueue;
+            s_currentQueue = queue;
+            queue._threadId = Environment.CurrentManagedThreadId;
+        }
+
+        public void Dispose()
+        {
+            if (s_currentQueue != null)
+            {
+                s_currentQueue._threadId = default;
+            }
+
+            s_currentQueue = _previousCurrentQueue;
+        }
+    }
+}
+
+
+public class JSDispatcherQueueController
+{
+    public JSDispatcherQueue DispatcherQueue { get; } = new();
+
+    public static JSDispatcherQueueController CreateOnDedicatedThread()
+    {
+        var controller = new JSDispatcherQueueController();
+        JSDispatcherQueue queue = controller.DispatcherQueue;
+        var thread = new Thread(() => queue.Run());
+        thread.Start();
+        return controller;
+    }
+
+    public Task ShutdownQueueAsync()
+    {
+        var completion = new TaskCompletionSource<int>();
+        DispatcherQueue.Shutdown(completion);
+        return completion.Task;
+    }
+}
+
+public sealed class JSDispatcherQueueDeferral : IDisposable
+{
+    private bool _isDisposed;
+    private Action _completionHandler;
+
+    public JSDispatcherQueueDeferral(Action completionHandler)
+        => _completionHandler = completionHandler;
+
+    ~JSDispatcherQueueDeferral()
+    {
+        Dispose(false);
+    }
+
+    public void Complete() => Dispose();
+
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    private void Dispose(bool _)
+    {
+        if (_isDisposed) return;
+        _isDisposed = true;
+        _completionHandler.Invoke();
+    }
+}

--- a/src/NodeApi/JSDispatcherQueue.cs
+++ b/src/NodeApi/JSDispatcherQueue.cs
@@ -12,7 +12,7 @@ public delegate void JSTypedEventHandler<TSender, TResult>(TSender sender, TResu
 
 public sealed class DispatcherQueueShutdownStartingEventArgs : EventArgs
 {
-    private Func<JSDispatcherQueueDeferral> _getDeferral;
+    private readonly Func<JSDispatcherQueueDeferral> _getDeferral;
 
     internal DispatcherQueueShutdownStartingEventArgs(Func<JSDispatcherQueueDeferral> getDeferral)
         => _getDeferral = getDeferral;
@@ -146,7 +146,7 @@ public sealed class JSDispatcherQueue
         }
     }
 
-    private struct CurrentQueueHolder : IDisposable
+    private readonly struct CurrentQueueHolder : IDisposable
     {
         private readonly JSDispatcherQueue? _previousCurrentQueue;
 
@@ -194,7 +194,7 @@ public class JSDispatcherQueueController
 public sealed class JSDispatcherQueueDeferral : IDisposable
 {
     private bool _isDisposed;
-    private Action _completionHandler;
+    private readonly Action _completionHandler;
 
     public JSDispatcherQueueDeferral(Action completionHandler)
         => _completionHandler = completionHandler;

--- a/src/NodeApi/Native/JSNativeApi.Interop.cs
+++ b/src/NodeApi/Native/JSNativeApi.Interop.cs
@@ -1355,6 +1355,26 @@ public static partial class JSNativeApi
             return methodPtr;
         }
 
+        internal static bool TryGetExport(ref nint field, [CallerMemberName] string functionName = "")
+        {
+            nint methodPtr = field;
+            if (methodPtr == default)
+            {
+                if (NativeLibrary.TryGetExport(s_libraryHandle, functionName, out methodPtr))
+                {
+                    field = methodPtr;
+                    return true;
+                }
+                else
+                {
+                    return false;
+                }
+
+            }
+
+            return true;
+        }
+
         private static napi_status CallInterop<TResult>(
             ref nint field,
             napi_env env,

--- a/src/NodeApi/Native/NativeLibrary.cs
+++ b/src/NodeApi/Native/NativeLibrary.cs
@@ -65,6 +65,16 @@ public static class NativeLibrary
 #endif
     }
 
+    public static bool TryGetExport(nint handle, string name, out nint procAddress)
+    {
+#if NETFRAMEWORK
+        procAddress = GetProcAddress(handle, name);
+        return procAddress != default;
+#else
+        return SysNativeLibrary.TryGetExport(handle, name, out procAddress);
+#endif
+    }
+
 #pragma warning disable CA2101 // Specify marshaling for P/Invoke string arguments
 
     [DllImport("kernel32")]


### PR DESCRIPTION
This is a new example that uses Hermes JavaScript engine created by Meta.
The hermes.dll from the forked hermes-windows project exports Node-API as an ABI-safe API.
The new hermes-example shows how it can be used.

The hermes.dll does not implement Node.JS-specific APIs from `node_api.h`.
In this PR we detect if the thread-safe functions are available, and if they are not, then we use the new `JSDispatcherQueue` for the `SynchronizationContext` implementation. The `JSDispatcherQueue` API design is "inspired" by the WinRT [`DispatcherQueue`](https://learn.microsoft.com/en-us/uwp/api/windows.system.dispatcherqueue?view=winrt-22621).

The example is very basic, but it works.
We can improve it or make it more interesting in the follow up PRs.

Side note: this PR is submitted from my fork. We should see if the new PR pipeline handles it correctly.