### PR TITLE
Improve dynamic JS import for embedding

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,11 @@ Console.WriteLine('Hello from .NET!');
 ### Minimal example - .NET calling JS
 ```C#
 // C#
-[JSImport("global", "console")]
 interface IConsole { void Log(string message); }
 
 var nodejs = new NodejsPlatform(libnodePath).CreateEnvironment();
 nodejs.Run(() => {
-    var console = nodejs.Import<IConsole>();
+    var console = nodejs.Import<IConsole>("global", "console");
     console.Log("Hello from JS!");
 });
 ```
@@ -70,15 +69,13 @@ const MyType = ExampleAssembly['Namespace.Qualified.MyType'];
 
 ### Load and call JavaScript packages from .NET
 Calling JavaScript from .NET requires hosting a JS runtime such as Node.js in the .NET app.
-Then JS packages can be loaded either by directly invoking the JS `require()` function and
-working with low-level JS values, or by declaring C# interfaces for the JS types and using
-automatic marshalling.
+Then JS packages can be imported either directly as JS values or by declaring C# interfaces for
+the JS types and using automatic marshalling.
 
 All interaction with a JavaScript environment must be from its thread, via the
 `Run()`, `RunAsync()`, or `Post()` methods on the JS environment object.
 ```C#
 // C#
-[JSImport("example-npm-package", "ExampleClass")]
 interface IExample
 {
     void ExampleMethod();
@@ -88,19 +85,15 @@ var nodejsPlatform = new NodejsPlatform(libnodePath);
 var nodejs = nodejsPlatform.CreateEnvironment();
 
 nodejs.Run(() => {
-    // Use require() to load a module, then call a function on it.
-    JSValue require = JSValue.Global["require"];
-    var example1 = require.Call(default, "example-npm-package").GetProperty("ExampleClass");
+    // Import a module property, then call a function on it.
+    var example1 = nodejs.Import("example-npm-package", "ExampleObject");
     example1.CallMethod("exampleMethod");
 
-    // Call the same function using the imported interface.
-    var example2 = nodejs.Import<IExample>();
+    // Import the module property using an interface, and call the same function.
+    var example2 = nodejs.Import<IExample>("example-npm-package", "ExampleObject");
     example2.ExampleMethod();
 });
 ```
-
-> Note: The `[JSImport]` attribute is in development. Until it is available, it is possible
-to create an interface adapter for a JS value with a little more code.
 
 In the future, it may be possible to automatically generate .NET API definitions from TypeScript
 type definitions.

--- a/examples/winui-fluid/Fluid/IFluidContainer.cs
+++ b/examples/winui-fluid/Fluid/IFluidContainer.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 
 namespace Microsoft.JavaScript.NodeApi.Examples.Fluid;
 
+[JSImport]
 public interface IFluidContainer : IDisposable
 {
     public ConnectionState ConnectionState { get; }
@@ -50,6 +51,7 @@ public enum ConnectionState
     Connected = 2,
 }
 
+[JSImport]
 public struct Connection
 {
     public string Id { get; set; }

--- a/examples/winui-fluid/Fluid/ISequenceDeltaEvent.cs
+++ b/examples/winui-fluid/Fluid/ISequenceDeltaEvent.cs
@@ -3,21 +3,24 @@
 
 namespace Microsoft.JavaScript.NodeApi.Examples.Fluid;
 
-public interface ISequenceDeltaEvent
+[JSImport]
+public struct SequenceDeltaEvent
 {
     public bool IsLocal { get; }
 
     public string ClientId { get; }
 
-    public IMergeTreeDeltaOpArgs OpArgs { get; }
+    public MergeTreeDeltaOpArgs OpArgs { get; }
 }
 
-public interface IMergeTreeDeltaOpArgs
+[JSImport]
+public struct MergeTreeDeltaOpArgs
 {
-    public IMergeTreeOp Op { get; }
+    public MergeTreeOp Op { get; }
 }
 
-public interface IMergeTreeOp
+[JSImport]
+public struct MergeTreeOp
 {
     public MergeTreeDeltaType Type { get; }
 

--- a/examples/winui-fluid/Fluid/ISharedMap.cs
+++ b/examples/winui-fluid/Fluid/ISharedMap.cs
@@ -11,9 +11,10 @@ public interface ISharedMap<T> : IDictionary<string, T>
 {
 }
 
-public interface ISharedMapValueChangedEvent
+[JSImport]
+public struct SharedMapValueChangedEvent
 {
-    public string Key { get; }
+    public string Key { get; set; }
 
-    public JSValue PreviousValue { get; }
+    public JSValue PreviousValue { get; set; }
 }

--- a/examples/winui-fluid/Fluid/ISharedString.cs
+++ b/examples/winui-fluid/Fluid/ISharedString.cs
@@ -3,6 +3,7 @@
 
 namespace Microsoft.JavaScript.NodeApi.Examples.Fluid;
 
+[JSImport]
 public interface ISharedString
 {
     public int GetLength();

--- a/examples/winui-fluid/Fluid/ITinyliciousClient.cs
+++ b/examples/winui-fluid/Fluid/ITinyliciousClient.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 
 namespace Microsoft.JavaScript.NodeApi.Examples.Fluid;
 
+[JSImport]
 public interface ITinyliciousClient
 {
     public Task<TinyliciousContainerInfo> CreateContainer(JSValue containerSchema);
@@ -13,6 +14,7 @@ public interface ITinyliciousClient
     public Task<TinyliciousContainerInfo> GetContainer(string id, JSValue containerSchema);
 }
 
+[JSImport]
 public struct TinyliciousContainerInfo
 {
     public IFluidContainer Container { get; set; }
@@ -20,12 +22,14 @@ public struct TinyliciousContainerInfo
     public ITinyliciousContainerServices Services { get; set; }
 }
 
+[JSImport]
 public interface ITinyliciousContainerServices
 {
     public ITinyliciousAudience Audience { get; set; }
 
 }
 
+[JSImport]
 public interface ITinyliciousAudience
 {
     public IDictionary<string, TinyliciousMember> GetMembers();
@@ -33,6 +37,7 @@ public interface ITinyliciousAudience
     public TinyliciousMember? GetMyself();
 }
 
+[JSImport]
 public struct TinyliciousMember
 {
     public string UserId { get; set; }
@@ -40,4 +45,37 @@ public struct TinyliciousMember
     public Connection[] Connections { get; set; }
 
     public string UserName { get; set; }
+}
+
+[JSImport]
+public struct TinyliciousClientProps
+{
+    public TinyliciousConnectionConfig? Connection { get; set; }
+
+    public TelemetryBaseLogger? Logger { get; set; }
+}
+
+[JSImport]
+public struct TinyliciousConnectionConfig
+{
+    public int? Port { get; set; } 
+
+    public string? Domain { get; set; }
+}
+
+[JSImport]
+public struct TelemetryBaseLogger
+{
+    public bool SupportsTags { get; set; }
+
+    // TODO: This should be a delegate type, when the marshaller supports it.
+    public JSValue Send { get; set; }
+}
+
+[JSImport]
+public struct TelemetryBaseEvent
+{
+    public string Category { get; set; }
+
+    public string EventName { get; set; }
 }

--- a/src/NodeApi.DotNetHost/JSRuntimeContextExtensions.cs
+++ b/src/NodeApi.DotNetHost/JSRuntimeContextExtensions.cs
@@ -1,0 +1,62 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using Microsoft.JavaScript.NodeApi.Interop;
+using Microsoft.JavaScript.NodeApi.Runtimes;
+
+namespace Microsoft.JavaScript.NodeApi.DotNetHost;
+
+/// <summary>
+/// Extension methods to support importing JavaScript types at runtime.
+/// </summary>
+public static class JSRuntimeContextExtensions
+{
+    /// <summary>
+    /// The marshaller instance can be static because it does not hold any JS values,
+    /// only expressions and delegates generated from reflection.
+    /// </summary>
+    private static readonly JSMarshaller s_marshaller = new();
+
+    /// <summary>
+    /// Imports a module or module property from JavaScript and converts it to an interface.
+    /// </summary>
+    /// <typeparam name="T">Type of the value being imported.</typeparam>
+    /// <param name="module">Name of the module being imported, or null to import a
+    /// global property. This is equivalent to the value provided to <c>import</c> or
+    /// <c>require()</c> in JavaScript. Required if <paramref name="property"/> is null.</param>
+    /// <param name="property">Name of a property on the module (or global), or null to import
+    /// the module object. Required if <paramref name="module"/> is null.</param>
+    /// <returns>The imported value.</returns>
+    /// <exception cref="ArgumentNullException">Both <paramref cref="module" /> and
+    /// <paramref cref="property" /> are null.</exception>
+    public static T Import<T>(
+        this JSRuntimeContext runtimeContext,
+        string? module,
+        string? property)
+    {
+        JSValue jsValue = runtimeContext.Import(module, property);
+        return s_marshaller.To<T>(jsValue);
+    }
+
+    /// <summary>
+    /// Imports a module or module property from JavaScript and converts it to an interface.
+    /// </summary>
+    /// <typeparam name="T">Type of the value being imported.</typeparam>
+    /// <param name="module">Name of the module being imported, or null to import a
+    /// global property. This is equivalent to the value provided to <c>import</c> or
+    /// <c>require()</c> in JavaScript. Required if <paramref name="property"/> is null.</param>
+    /// <param name="property">Name of a property on the module (or global), or null to import
+    /// the module object. Required if <paramref name="module"/> is null.</param>
+    /// <returns>The imported value.</returns>
+    /// <exception cref="ArgumentNullException">Both <paramref cref="module" /> and
+    /// <paramref cref="property" /> are null.</exception>
+    public static T Import<T>(
+        this NodejsEnvironment nodejs,
+        string? module,
+        string? property)
+    {
+        JSValueScope scope = nodejs;
+        return scope.RuntimeContext.Import<T>(module, property);
+    }
+}

--- a/src/NodeApi/Interop/JSRuntimeContext.cs
+++ b/src/NodeApi/Interop/JSRuntimeContext.cs
@@ -116,7 +116,6 @@ public sealed class JSRuntimeContext : IDisposable
 
     public JSRuntimeContext(napi_env env)
     {
-        // TODO: Move this Initialize call to the creators of JSRuntimeContext
         JSNativeApi.Interop.Initialize();
 
         _env = env;
@@ -546,14 +545,14 @@ public sealed class JSRuntimeContext : IDisposable
     /// not initialized.</exception>
     public JSValue Import(string? module, string? property = null)
     {
-        if (module == null && property == null)
+        if ((module == null || module == "global") && property == null)
         {
             throw new ArgumentNullException(nameof(property));
         }
 
         JSReference reference = _importMap.GetOrAdd((module, property), (_) =>
         {
-            if (module == null)
+            if (module == null || module == "global")
             {
                 // Importing a built-in object from `global`.
                 JSValue value = JSValue.Global[property!];

--- a/src/NodeApi/JSImportAttribute.cs
+++ b/src/NodeApi/JSImportAttribute.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+
+namespace Microsoft.JavaScript.NodeApi;
+
+/// <summary>
+/// Indicates a class or struct is imported from JavaScript.
+/// </summary>
+[AttributeUsage(
+    AttributeTargets.Interface |
+    AttributeTargets.Struct
+)]
+public sealed class JSImportAttribute : Attribute
+{
+}


### PR DESCRIPTION
This change adds some APIs for dynamically importing and converting JS types in .NET, which are then used to somewhat clean up the demo app code.

 - Add `[JSImport]` attribute. It is only used in one small way by the marshaller now (when generating a struct conversion expression) but is likely to be extended later with source-generator support.
 - Expose the `Import()` method on `NodejsEnvironment` class. It was already available on `JSRuntimeContext`, but the former makes more sense for embedding scenarios.
 - Add a generic `Import<T>()` which converts the imported JS value to a .NET type. It is an extension method in the `NodeApi.DotNetHost` assembly because that's where the dynamic marshalling functionality is.
 - Simplify initialization of `NodejsEnvironment`. (Don't create a redundant `JSSynchronizationContext`.)
 - Convert more of the code in the demo app to use .NET types (imported structs and interfaces) instead of `JSValue`.
 - Add some error handling to the demo app around initializing and connecting fluid.
 - Fix a bug in the demo app in which remote carets would not be in the right place on initial join.
 - Update related code snippets in README.

Note there is no source-generation yet for the Node.js embedding scenario. That will be possible later (and could improve startup time), but for now it is only using runtime dynamic bindings.