### PR TITLE
Allow host module re-initialization

### DIFF
--- a/src/NodeApi/DotNetHost/NativeHost.cs
+++ b/src/NodeApi/DotNetHost/NativeHost.cs
@@ -136,6 +136,9 @@ internal unsafe partial class NativeHost : IDisposable
                 exports = InitializeDotNetHost(dotnetVersion, managedHostPath, require);
             }
 
+            // Save init parameters and result in case of re-init.
+            _targetFramework = targetFramework;
+            _managedHostPath = managedHostPath;
             _exports = new JSReference(exports);
             return exports;
         }


### PR DESCRIPTION
Fixes: #93

To resolve the issue, the `NativeHost` instance keeps track of the .NET TFM and managed host path that were used to initialize it, along with a strong reference to the `exports` object that was the result of the initialization. If the initialize function is called again with the same parameters then the same `exports` result is returned.