### PR TITLE
Fix structs in fluid demo

### DIFF
--- a/examples/winui-fluid/Fluid/ISequenceDeltaEvent.cs
+++ b/examples/winui-fluid/Fluid/ISequenceDeltaEvent.cs
@@ -6,29 +6,29 @@ namespace Microsoft.JavaScript.NodeApi.Examples.Fluid;
 [JSImport]
 public struct SequenceDeltaEvent
 {
-    public bool IsLocal { get; }
+    public bool IsLocal { get; set; }
 
-    public string ClientId { get; }
+    public string ClientId { get; set; }
 
-    public MergeTreeDeltaOpArgs OpArgs { get; }
+    public MergeTreeDeltaOpArgs OpArgs { get; set; }
 }
 
 [JSImport]
 public struct MergeTreeDeltaOpArgs
 {
-    public MergeTreeOp Op { get; }
+    public MergeTreeOp Op { get; set; }
 }
 
 [JSImport]
 public struct MergeTreeOp
 {
-    public MergeTreeDeltaType Type { get; }
+    public MergeTreeDeltaType Type { get; set; }
 
-    public int? Pos1 { get; }
+    public int? Pos1 { get; set; }
 
-    public int? Pos2 { get; }
+    public int? Pos2 { get; set; }
 
-    public string? Seg { get; }
+    public string? Seg { get; set; }
 }
 
 public enum MergeTreeDeltaType

--- a/examples/winui-fluid/README.md
+++ b/examples/winui-fluid/README.md
@@ -2,6 +2,14 @@
 This project is a C# WinUI application that demonstrates collaborative text editing
 using the [Fluid Framework](https://fluidframework.com/), which has a JS-only API.
 
+Before building and running this project:
+ - If necessary, [install tools for WinUI C# development](
+https://learn.microsoft.com/en-us/windows/apps/windows-app-sdk/set-up-your-development-environment
+).
+ - Download a build of `libnode.dll` that _includes Node API embedding support_. (Soon this will be
+   available as a nuget package, but for now you can contact us to get a copy.) Place it at
+   `bin\win-x64\libnode.dll` relative to the repo root (not this subdirectory).
+
 | Command                 | Explanation
 |-------------------------|--------------------------------------------------
 | `dotnet pack ../..`     | Build Node API .NET packages.
@@ -10,7 +18,8 @@ using the [Fluid Framework](https://fluidframework.com/), which has a JS-only AP
 | `npx tinylicious`       | Start the local fluid development server on port 7070.
 | `dotnet run --no-build` | Run the example project.
 
-Each instance of the application can either host or join a collaborative editing session.
+Launch two or more instances of the app to set up a collaborative editing session. Each instance of
+the application can either host or join a session.
  - To host a new session, click the **Start** button. Then **Copy** the session ID and send it
    to a guest.
  - To join an existing session, paste the session ID (obtained from a host) and click **Join**.

--- a/src/NodeApi/Interop/JSSynchronizationContext.cs
+++ b/src/NodeApi/Interop/JSSynchronizationContext.cs
@@ -176,7 +176,7 @@ public abstract class JSSynchronizationContext : SynchronizationContext, IDispos
         else
         {
             TaskCompletionSource<bool> completion = new();
-            Send(async (_) =>
+            Post(async (_) =>
             {
                 if (IsDisposed) return;
                 try
@@ -206,7 +206,7 @@ public abstract class JSSynchronizationContext : SynchronizationContext, IDispos
         else
         {
             TaskCompletionSource<T> completion = new();
-            Send(async (_) =>
+            Post(async (_) =>
             {
                 if (IsDisposed) return;
                 try


### PR DESCRIPTION
 - Fix marshalling of Fluid API structs used in the demo app. It was broken by my last update; I don't know how I missed it since I thought I tested it.
 - Use `Post()` instead of `Send()` for async methods on synchronization context.
 - Add more setup instructions to demo app readme.