### PR TITLE
Add setImmediate and setTimeout to Hermes example

### DIFF
--- a/examples/hermes-engine/HermesRuntime.cs
+++ b/examples/hermes-engine/HermesRuntime.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Microsoft.JavaScript.NodeApi;
+using Microsoft.JavaScript.NodeApi.Interop;
 using static Hermes.Example.HermesApi.Interop;
 using static Microsoft.JavaScript.NodeApi.JSNativeApi.Interop;
 
@@ -8,33 +10,291 @@ namespace Hermes.Example;
 
 public sealed class HermesRuntime : IDisposable
 {
+    private object _runtimeMutex = new();
     private hermes_runtime _runtime;
-    private bool _isDisposed;
+    private JSDispatcherQueue _dispatcherQueue;
+    private JSValueScope _rootScope;
+    private TaskCompletionSource? _onRunFinish;
+    private readonly TaskCompletionSource _onClose = new();
+    private readonly Dictionary<int, ImmediateTask> _immediateTasks = new();
+    private readonly Dictionary<int, TimerTask> _timerTasks = new();
+    private int _nextTaskId;
+    private bool _shouldClose;
 
-    public HermesRuntime(HermesConfig? config)
+    public bool IsDisposed { get; private set; }
+
+    private HermesRuntime(JSDispatcherQueue dispatcherQueue)
     {
-        if (config != null)
-        {
-            hermes_create_runtime((hermes_config)config, out _runtime).ThrowIfFailed();
-        }
-        else
-        {
-            using HermesConfig tempConfig = new();
-            hermes_create_runtime((hermes_config)tempConfig, out _runtime).ThrowIfFailed();
-        }
+        _dispatcherQueue = dispatcherQueue;
+        HermesApi.Load("hermes.dll");
+        using HermesConfig tempConfig = new();
+        hermes_create_runtime((hermes_config)tempConfig, out _runtime).ThrowIfFailed();
+        _rootScope = new JSValueScope(JSValueScopeType.Root, (napi_env)this);
+        CreatePolyfills();
     }
 
-    public HermesRuntime() : this(null) { }
+    public static Task<HermesRuntime> Create(JSDispatcherQueue dispatcherQueue)
+    {
+        var taskPromise = new TaskCompletionSource<HermesRuntime>();
+        dispatcherQueue.TryEnqueue(() =>
+        {
+            taskPromise.TrySetResult(new HermesRuntime(dispatcherQueue));
+        });
+        return taskPromise.Task;
+    }
+
+    public Task RunAsync(Action action)
+    {
+        Task? result = null;
+        lock (_runtimeMutex)
+        {
+            VerifyElseThrow(_onRunFinish == null, "Previous run is not finished");
+            _onRunFinish = new TaskCompletionSource();
+            result = _onRunFinish.Task;
+        }
+
+        _dispatcherQueue.TryEnqueue(() =>
+        {
+            action();
+            TryFinishRun();
+        });
+
+        return result;
+    }
+
+    public Task CloseAsync()
+    {
+        _dispatcherQueue.TryEnqueue(() =>
+        {
+            _shouldClose = true;
+            TryClose();
+        });
+        return _onClose.Task;
+    }
 
     public void Dispose()
     {
-        if (_isDisposed) return;
-        _isDisposed = true;
+        if (IsDisposed) return;
+        VerifyElseThrow(JSDispatcherQueue.GetForCurrentThread() == _dispatcherQueue);
+        IsDisposed = true;
+        _rootScope.Dispose();
         hermes_delete_runtime(_runtime).ThrowIfFailed();
     }
 
     public static explicit operator hermes_runtime(HermesRuntime value) => value._runtime;
 
     public static explicit operator napi_env(HermesRuntime value)
-        => hermes_get_node_api_env((hermes_runtime)value, out napi_env env).ThrowIfFailed(env);
+    {
+        VerifyElseThrow(JSDispatcherQueue.GetForCurrentThread() == value._dispatcherQueue);
+        return hermes_get_node_api_env((hermes_runtime)value, out napi_env env).ThrowIfFailed(env);
+    }
+
+    public void CreatePolyfills()
+    {
+        VerifyElseThrow(JSDispatcherQueue.GetForCurrentThread() == _dispatcherQueue);
+        using var scope = new JSValueScope();
+
+        // Add global
+        JSValue global = JSValue.Global;
+        global["global"] = global;
+
+        global["setImmediate"] = (JSCallback)(args =>
+        {
+            JSValue immediateCallback = args[0];
+            VerifyElseThrow(immediateCallback.TypeOf() == JSValueType.Function,
+                "Wrong type of args[0]. Expects a function.");
+
+            int taskId = AddImmediateTask(immediateCallback);
+            return taskId;
+        });
+
+        global["clearImmediate"] = (JSCallback)(args =>
+        {
+            RemoveImmediateTask((int)args[0]);
+            return default;
+        });
+
+        global["setTimeout"] = (JSCallback)(args =>
+        {
+            JSValue timeoutCallback = args[0];
+            VerifyElseThrow(timeoutCallback.TypeOf() == JSValueType.Function,
+                "Wrong type of args[0]. Expects a function.");
+
+            int taskId = AddTimerTask(timeoutCallback, (int)args[1]);
+            return taskId;
+        });
+
+        global["clearTimeout"] = (JSCallback)(args =>
+        {
+            RemoveTimerTask((int)args[0]);
+            return default;
+        });
+
+        var console = new JSObject();
+        console["log"] = (JSCallback)(args =>
+        {
+            Console.WriteLine((string)args[0]);
+            return default;
+        });
+        global["console"] = console;
+    }
+
+    private int AddImmediateTask(JSValue callback)
+    {
+        VerifyElseThrow(JSDispatcherQueue.GetForCurrentThread() == _dispatcherQueue);
+        int taskId = ++_nextTaskId;
+        var task = new ImmediateTask(this, callback, () => RemoveImmediateTask(taskId));
+        if (_dispatcherQueue.TryEnqueue(task.Run))
+        {
+            _immediateTasks[taskId] = task;
+            return taskId;
+        }
+
+        return 0;
+    }
+
+    private int AddTimerTask(JSValue callback, int timeout)
+    {
+        VerifyElseThrow(JSDispatcherQueue.GetForCurrentThread() == _dispatcherQueue);
+        int taskId = ++_nextTaskId;
+        JSDispatcherQueueTimer timer = _dispatcherQueue.CreateTimer();
+        var task = new TimerTask(this, timer, callback, () => RemoveTimerTask(taskId));
+        _timerTasks[taskId] = task;
+        timer.IsRepeating = false;
+        timer.Interval = new TimeSpan(0, 0, 0, 0, timeout);
+        timer.Tick += task.OnTimerTick;
+        timer.Start();
+        return taskId;
+    }
+
+    private void RemoveImmediateTask(int taskId)
+    {
+        VerifyElseThrow(JSDispatcherQueue.GetForCurrentThread() == _dispatcherQueue);
+        if (_immediateTasks.TryGetValue(taskId, out ImmediateTask? task))
+        {
+            _immediateTasks.Remove(taskId);
+            task.Dispose();
+        }
+
+        TryFinishRun();
+    }
+
+    private void RemoveTimerTask(int taskId)
+    {
+        VerifyElseThrow(JSDispatcherQueue.GetForCurrentThread() == _dispatcherQueue);
+        if (_timerTasks.TryGetValue(taskId, out TimerTask? task))
+        {
+            _timerTasks.Remove(taskId);
+            task.Dispose();
+        }
+
+        TryFinishRun();
+    }
+
+    private void TryFinishRun()
+    {
+        VerifyElseThrow(JSDispatcherQueue.GetForCurrentThread() == _dispatcherQueue);
+        if (_immediateTasks.Count == 0 && _timerTasks.Count == 0)
+        {
+            TaskCompletionSource? onRunFinish = null;
+            lock (_runtimeMutex)
+            {
+                onRunFinish = _onRunFinish;
+                _onRunFinish = null;
+            }
+            onRunFinish?.TrySetResult();
+            TryClose();
+        }
+    }
+
+    private void TryClose()
+    {
+        VerifyElseThrow(JSDispatcherQueue.GetForCurrentThread() == _dispatcherQueue);
+        if (_shouldClose && _immediateTasks.Count == 0 && _timerTasks.Count == 0)
+        {
+            Dispose();
+            _onClose.TrySetResult();
+        }
+    }
+
+    private static void VerifyElseThrow(bool condition, string? message = null)
+    {
+        if (!condition)
+        {
+            throw new InvalidOperationException(message);
+        }
+    }
+
+    private class ImmediateTask : IDisposable
+    {
+        private HermesRuntime _runtime;
+        private JSReference _callback;
+        private Action _onFinalize;
+
+        public bool IsDisposed { get; private set; }
+
+        public ImmediateTask(HermesRuntime runtime, JSValue callback, Action onFinalize)
+        {
+            _runtime = runtime;
+            _callback = new JSReference(callback);
+            _onFinalize = onFinalize;
+        }
+
+        public void Dispose()
+        {
+            if (IsDisposed) return;
+            IsDisposed = true;
+            _callback.Dispose();
+            _onFinalize();
+        }
+
+        public void Run()
+        {
+            if (_callback.IsDisposed) return;
+            using var asyncScope = new JSAsyncScope();
+            JSValue? callback = _callback.GetValue();
+            callback?.Call();
+            Dispose();
+        }
+    }
+
+    private class TimerTask
+    {
+        private HermesRuntime _runtime;
+        private JSDispatcherQueueTimer _timer;
+        private JSReference _callback;
+        private Action _onFinalize;
+
+        public bool IsDisposed { get; private set; }
+
+        public TimerTask(
+            HermesRuntime runtime,
+            JSDispatcherQueueTimer timer,
+            JSValue callback,
+            Action onFinalize)
+        {
+            _runtime = runtime;
+            _timer = timer;
+            _callback = new JSReference(callback);
+            _onFinalize = onFinalize;
+        }
+
+        public void Dispose()
+        {
+            if (IsDisposed) return;
+            IsDisposed = true;
+            _callback.Dispose();
+            _timer.Stop();
+            _onFinalize();
+        }
+
+        public void OnTimerTick(object? _, EventArgs e)
+        {
+            if (IsDisposed) return;
+            using var asyncScope = new JSAsyncScope();
+            JSValue? callback = _callback.GetValue();
+            callback?.Call();
+            Dispose();
+        }
+    }
 }

--- a/examples/hermes-engine/Program.cs
+++ b/examples/hermes-engine/Program.cs
@@ -16,12 +16,12 @@ await runtime.RunAsync(() =>
 
     JSNativeApi.RunScript("""
         setTimeout(function() {
-            console.log('This printed after about 1 second');
+            console.log('This is printed after 1 second delay');
         }, 1000);
         """);
 
     JSNativeApi.RunScript("""
-        function later(delay, value) {
+        function createPromise(delay, value) {
           return new Promise(function(resolve) {
             setTimeout(function() {
               resolve(value);
@@ -29,9 +29,9 @@ await runtime.RunAsync(() =>
           });
         }
 
-        var l1 = later(100, "l1");
-        l1.then(msg => { console.log("Print:" + msg); })
-          .catch(() => { console.log("l1 canceled"); });
+        var myPromise = createPromise(100, "myPromise");
+        myPromise.then(msg => { console.log(msg + " completed"); })
+                 .catch(() => { console.log("myPromise canceled"); });
         """);
 });
 


### PR DESCRIPTION
Extended `HermesRuntime` class to support limited `setImmediate`, `setTimeout`, and `console.log` polyfills.
Changed the example code in `Program` to rely on the `await` keyword.