### PR TITLE
Marshal null as undefined

### DIFF
--- a/Docs/masrshalling-null-undefined.md
+++ b/Docs/masrshalling-null-undefined.md
@@ -1,0 +1,209 @@
+# Marshalling `null` and `undefined`
+
+Consider:
+ - JavaScript has both `null` and `undefined` primitive values, while .NET has
+   only `null`.
+ - A default/uninitialized value in JS is `undefined`, while in .NET the default
+   is `null` (for reference types and `Nullable<T>` value types).
+ - In JavaScript, `typeof undefined === 'undefined'` and `typeof null === 'object'`.
+
+So how should these inconsistencies in type systems of the two platforms be
+reconciled during automatic marshalling?
+
+> Note: Regardless of any approach taken here, .NET code has the option to fall
+back to working directly with `JSValue` and its distinct `JSValue.Null` and
+`JSValue.Undefined` values.
+
+## Marshalling .NET `null` to JavaScript
+For discussion here, `T` may any _specific_ (not `object/any`) type, including both
+marshal-by-value (number, struct, enum) and marshal-by-ref (string, class, interface)
+types.
+
+If `T` is not nullable (neither a `Nullable<T>` value type nor a nullable reference
+type), then the TypeScript projection will allow neither `null` nor `undefined`.
+However, **_marshalling must still handle null .NET reference values even when the
+type is non-nullable_**.
+
+In any case a JS `undefined` value passed to .NET is always converted to `null` by
+the marshaller.
+
+### Option A: .NET `null` -> JS `undefined`
+If .NET `null` values are marshalled as JS `undefined`, that has the following effects:
+
+| Description | C# API | JS API | JS Notes |
+|-------------|--------|--------|----------|
+| Method with optional param | `void Method(T? p = null)` | `method(p?: T): void` | `p` is `undefined` in JS if a .NET caller omitted the parameter _or_ supplied `null`;<br>`p` is never `null` in JS when called by .NET.
+| Method with nullable param | `void Method(T? p)` | `method(p: T \| undefined): void` | `p` is `undefined` in JS if a .NET caller supplied `null`.
+| Method with nullable return | `T? Method()` | `method(): T \| undefined` | Result is `undefined` in JS if .NET method returned `null`;<br>result is never `null` when returned by .NET.
+| Nullable property | `T? Property` | `property?: T` | Property value is `undefined` (_but the property exists_) in JS if the object was passed from .NET;<br>value is never `null` (or missing) on an object from .NET.
+
+### Option B: .NET `null` -> JS `null`
+Alternatively, if .NET `null` values are marshalled as JS `null`, that has the following effects:
+
+| Description | C# API | JS API | JS Notes |
+|-------------|--------|--------|----------|
+| Method with optional param | `void Method(T? p = null)` | `method(p: T \| null): void` | `p` is `null` in JS if a .NET caller omitted the parameter _or_ supplied `null`;<br>`p` is never `undefined` in JS when called by .NET.
+| Method with nullable param | `void Method(T? p)` | `method(p?: T \| null): void` | `p` is `null` in JS if a .NET caller supplied `null`.
+| Method with nullable return | `T? Method()` | `method(): T \| null` | Result is `null` in JS if .NET method returned `null`;<br>result is never `undefined` when returned by .NET.
+| Nullable property | `T? Property` | `property: T \| null` | Property value is `null` (and the property exists) in JS if the object was passed from .NET;<br>value is never `undefined` (or missing) on an object from .NET.
+
+## JavaScript `null` vs `undefined` practices
+While `null` and `undefined` are often used interchangeably, the distinction can sometimes
+be important. Let's analyze some ways in which `null` and/or `undefined` values might be
+handled differently, and how common those practices are in JavaScript.
+
+### Detecting optional parameters to a JavaScript function
+In JavaScript, there are several common ways to detect when an optional
+parameter was not supplied to a function:
+```TS
+function exampleFunction(optionalParameter?: any): void
+```
+1. Common / best practice: Check if the value type is equal to `'undefined'`.<br>
+   `if (typeof optionalParameter === 'undefined')`
+
+2. Somewhat common: Check if the value is strictly equal to `undefined`.<br>
+   `if (optionalParameter === undefined)`
+
+3. Common / best practice in TS & ES2020: Use the "nullish coalescing operator", which
+   handles both `null` and `undefined`:<br>
+   `value = optionalParameter ?? defaultValue`
+
+4. Traditional and still common (occasionally error-prone): Check if the value is falsy.<br>
+   `if (!optionalParameter)`<br>
+   `value = optionalParameter || defaultValue`
+
+5. Less common: Check the length of the `arguments` object. (Use of the special
+  `arguments` object is [discouraged](
+  https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/arguments)
+  in modern JS, in favor of rest parameters.)<br>
+   `if (arguments.length === 0)`
+
+6. Uncommon: Check if the value is null with _loose_ equality.
+It handles both `null` and `undefined` because `null == undefined`. (The
+loose equality operator is usually flagged by linters.)<br>
+   `if (optionalParameter == null)`
+
+| |A: null->undefined|B: null->null|
+|-|:----------------:|:-----------:|
+|1|✅|❌|
+|2|✅|❌|
+|3|✅|✅|
+|4|✅|✅|
+|5|❌|❌|
+|6|✅|✅|
+
+### Checking the return value of a function/method
+A JavaScript function my return `undefined`, or `null`, when it yields no result.
+There is [no strong consensus among the JS developer community](
+https://stackoverflow.com/questions/37980559/is-it-better-to-return-undefined-or-null-from-a-javascript-function)
+about when to use either one; some developers may prefer one or the other while
+others may not think very hard about the distinction. There are a few ways the
+caller might check the return value:
+```TS
+function exampleFunction(): any
+```
+1. Traditional and still common (occasionally error-prone): Check if the result value is
+   falsy.<br>
+   `if (!result)`
+2. Common: Check if the result value type is `'undefined'` or value is strictly equal
+   to `undefined`.<br>
+   `if (typeof result === 'undefined')`<br>
+   `if (result === undefined)`
+3. Uncommon: Check if the result value is null with _loose_ equality.<br>
+   `if (result == null)`
+
+| |A: null->undefined|B: null->null|
+|-|:----------------:|:-----------:|
+|1|✅|✅|
+|2|✅|❌|
+|3|✅|✅|
+
+### Detecting optional properties on a JavaScript object
+In JavaScript, there are a few ways to detect when an optional property was
+not supplied with an object:
+```TS
+interface Example {
+    optionalProperty?: any;
+}
+```
+1. Common: Use the `in` operator.<br>`if ('optionalProperty' in exampleObject)`
+2. Common: Use `hasOwnProperty` or the more modern `hasOwn` replacement.<br>
+   `if (!exampleObject.hasOwnProperty('optionalProperty'))`<br>
+   `if (!Object.hasOwn(exampleObject, 'optionalProperty'))`
+3. Traditional and still common (occasionally error-prone): Check if the property value
+   is falsy.<br>
+   `if (!exampleObject.optionalProperty)`<br>
+   `if (!exampleObject['optionalProperty'])`<br>
+   `value = exampleObject.optionalProperty || defaultValue`
+4. Less common: Check if the property value type is `'undefined'` or value is
+   strictly equal to `undefined`.<br>
+   `if (typeof exampleObject.optionalProperty === 'undefined')`<br>
+   `if (exampleObject.optionalProperty === undefined)`
+5. Less common: Use the nullish coalescing operator<br>
+   `value = exampleObject.optionalProperty ?? defaultValue`
+6. Uncommon: Check if the property value is null with _loose_ equality.<br>
+   `if (exampleObject.optionalProperty == null)`
+
+| |A: null->undefined|B: null->null|
+|-|:----------------:|:-----------:|
+|1|❌|❌|
+|2|❌|❌|
+|3|✅|✅|
+|4|✅|❌|
+|5|✅|✅|
+|6|✅|✅|
+
+Note even when marshalling `null` to `undefined`, common checks that rely on the
+_existince_ of properties can fail. And operations that enumerate the object properties
+may have differing behavior for missing properties vs ones with `undefined` value. For
+more on that subtle distinction, see [TypeScript's `--exactOptionalPropertyTypes` option](
+https://devblogs.microsoft.com/typescript/announcing-typescript-4-4-beta/#exact-optional-property-types).
+
+### Checking for strict `null` equality
+JavaScript code _can_ specifically check if a parameter, return value, or
+property value is strictly equal to null:
+```JS
+if (value === null)
+```
+|A: null->undefined|B: null->null|
+|:----------------:|:-----------:|
+|❌|✅|
+
+More experienced JavaScript developers never write such code, since
+they are aware of the pervasiveness of `undefined`. But it can be easy
+for developers coming from other languages (like C# or Java) to write
+such code while assuming `null` works the same way, or merely from
+muscle memory.
+
+### JS APIs with semantic differences between `undefined` vs `null`
+A JavaScript API _could_ assign wholly different meanings to the two values, for
+instance using `undefined` to represent an uninitialized state and `null` to
+represent an intialized-but-cleared state. Since automatic marshalling of .NET
+`null` cannot support that distinction, calling such a JS API from .NET would
+require direct use of `JSValue.Undefined` and `JSValue.Null` (or perhaps a
+JS wrapper for the targeted API) to handle the disambiguation. But such an API
+design aspect would likely confuse many JavaScript developers as well, so it
+is not a common occurrence.
+
+## Design Choice
+In the tables above, there are fewer ❌ marks in column A; this indicates
+that mapping .NET `null` to JS `undefined` is the better choice for default
+marshalling behavior.
+
+There are a few rare cases in which the default may be problematic:
+1. Omitted optional function parameters, when the JS function body checks
+`arguments.length`.
+2. Omitted optional properties of an object, when the JS code checks
+whether the object has the property, or enumerates the object properties.
+3. A nullable (not optional) value where the JS code checks for strict
+null equality.
+
+To handle these cases (and any other situations that might arise), we can add
+flags to the ([planned](https://github.com/microsoft/node-api-dotnet/issues/64))
+`[JSMarshalAs]` attribute to enable setting the null-value marshalling behavior
+of a specific .NET method parameter, return value, or property to one of three
+options:
+  - `undefined` (default)
+  - `null`
+  - omit - Exclude from the function arguments (if there are no non-omitted
+    arguments after it), or exclude from the properties of the marshalled object.

--- a/Docs/node-module.md
+++ b/Docs/node-module.md
@@ -23,9 +23,9 @@ For a minimal example of this scenario, see
     **Important**: Edit the project file so that both package reference elements include `PrivateAssets="all"`, and the generator reference includes `OutputItemType="Analyzer" ReferenceOutputAssembly="false"`:
     ```xml
     <ItemGroup>
-      <PackageReference Include="Microsoft.JavaScript.NodeApi" Version="0.1.*-*"
+      <PackageReference Include="Microsoft.JavaScript.NodeApi" Version="0.2.*-*"
         PrivateAssets="all" />
-      <PackageReference Include="Microsoft.JavaScript.NodeApi.Generator" Version="0.1.*-*"
+      <PackageReference Include="Microsoft.JavaScript.NodeApi.Generator" Version="0.2.*-*"
         PrivateAssets="all" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
     </ItemGroup>
     ```

--- a/src/NodeApi.DotNetHost/JSMarshaller.cs
+++ b/src/NodeApi.DotNetHost/JSMarshaller.cs
@@ -46,12 +46,6 @@ public class JSMarshaller
     private static readonly PropertyInfo s_moduleContext =
         typeof(JSModuleContext).GetStaticProperty(nameof(JSModuleContext.Current))!;
 
-    private static readonly PropertyInfo s_undefinedValue =
-        typeof(JSValue).GetStaticProperty(nameof(JSValue.Undefined))!;
-
-    private static readonly PropertyInfo s_nullValue =
-        typeof(JSValue).GetStaticProperty(nameof(JSValue.Null))!;
-
     private static readonly PropertyInfo s_valueItem =
         typeof(JSValue).GetIndexer(typeof(string))!;
 
@@ -895,7 +889,7 @@ public class JSMarshaller
         {
             variables = argVariables;
             statements.Add(Expression.Call(method, argVariables));
-            statements.Add(Expression.Property(null, s_undefinedValue));
+            statements.Add(Expression.Default(typeof(JSValue)));
         }
         else
         {
@@ -947,8 +941,7 @@ public class JSMarshaller
         if (method.ReturnType == typeof(void))
         {
             statements.Add(Expression.Call(thisVariable, method, argVariables));
-            statements.Add(Expression.Label(returnTarget,
-                Expression.Property(null, s_undefinedValue)));
+            statements.Add(Expression.Label(returnTarget, Expression.Default(typeof(JSValue))));
         }
         else
         {
@@ -1058,7 +1051,7 @@ public class JSMarshaller
             Expression.Assign(valueVariable,
                     BuildArgumentExpression(0, property.PropertyType)),
             Expression.Call(property.SetMethod!, valueVariable),
-            Expression.Property(null, s_undefinedValue),
+            Expression.Default(typeof(JSValue)),
         };
         return (Expression<JSCallback>)Expression.Lambda(
             delegateType: typeof(JSCallback),
@@ -1108,7 +1101,7 @@ public class JSMarshaller
         statements.Add(Expression.Assign(valueVariable,
                     BuildArgumentExpression(0, property.PropertyType)));
         statements.Add(setExpression);
-        statements.Add(Expression.Label(returnTarget, Expression.Property(null, s_undefinedValue)));
+        statements.Add(Expression.Label(returnTarget, Expression.Default(typeof(JSValue))));
 
         return (Expression<JSCallback>)Expression.Lambda(
             delegateType: typeof(JSCallback),
@@ -1148,7 +1141,7 @@ public class JSMarshaller
                     type));
             yield return Expression.IfThen(
                 Expression.Equal(thisVariable, Expression.Constant(null)),
-                Expression.Return(returnTarget, Expression.Property(null, s_undefinedValue)));
+                Expression.Return(returnTarget, Expression.Default(typeof(JSValue))));
         }
         else if (type.IsClass || type.IsInterface)
         {
@@ -1171,7 +1164,7 @@ public class JSMarshaller
                     type));
             yield return Expression.IfThen(
                 Expression.Equal(thisVariable, Expression.Constant(null)),
-                Expression.Return(returnTarget, Expression.Property(null, s_undefinedValue)));
+                Expression.Return(returnTarget, Expression.Default(typeof(JSValue))));
         }
         else if (type.IsValueType)
         {
@@ -1277,7 +1270,7 @@ public class JSMarshaller
             resultExpression = Expression.Condition(
                 Expression.Property(resultVariable, nullableType.GetProperty("HasValue")!),
                 resultExpression,
-                Expression.Property(null, s_nullValue));
+                Expression.Default(typeof(JSValue)));
         }
 
         return resultExpression;
@@ -1578,7 +1571,7 @@ public class JSMarshaller
                 Expression.Condition(
                     Expression.Property(valueParameter, nullableType.GetProperty("HasValue")!),
                     Expression.Block(typeof(JSValue), variables, statements),
-                    Expression.Property(null, s_undefinedValue)),
+                    Expression.Default(typeof(JSValue))),
             };
         }
 

--- a/src/NodeApi.Generator/TypeDefinitionsGenerator.cs
+++ b/src/NodeApi.Generator/TypeDefinitionsGenerator.cs
@@ -664,7 +664,7 @@ public class TypeDefinitionsGenerator : SourceGenerator
 
     private string GetTSParameters(ParameterInfo[] parameters)
     {
-        string GetOptionalToken(ParameterInfo parameter, ref string parameterType)
+        static string GetOptionalToken(ParameterInfo parameter, ref string parameterType)
         {
             if (parameter.IsOptional && parameterType.EndsWith(UndefinedTypeSuffix))
             {

--- a/src/NodeApi/JSValue.cs
+++ b/src/NodeApi/JSValue.cs
@@ -216,19 +216,19 @@ public readonly struct JSValue : IEquatable<JSValue>
     }
 
     public static JSValue CreateError(JSValue? code, JSValue message)
-        => napi_create_error(Env, code.AsNapiValueOrNull(), (napi_value)message,
+        => napi_create_error(Env, (napi_value)code, (napi_value)message,
             out napi_value result).ThrowIfFailed(result);
 
     public static JSValue CreateTypeError(JSValue? code, JSValue message)
-        => napi_create_type_error(Env, code.AsNapiValueOrNull(), (napi_value)message,
+        => napi_create_type_error(Env, (napi_value)code, (napi_value)message,
             out napi_value result).ThrowIfFailed(result);
 
     public static JSValue CreateRangeError(JSValue? code, JSValue message)
-        => napi_create_range_error(Env, code.AsNapiValueOrNull(), (napi_value)message,
+        => napi_create_range_error(Env, (napi_value)code, (napi_value)message,
             out napi_value result).ThrowIfFailed(result);
 
     public static JSValue CreateSyntaxError(JSValue? code, JSValue message)
-        => node_api_create_syntax_error(Env, code.AsNapiValueOrNull(), (napi_value)message,
+        => node_api_create_syntax_error(Env, (napi_value)code, (napi_value)message,
             out napi_value result).ThrowIfFailed(result);
 
     public static unsafe JSValue CreateExternal(object value)
@@ -327,25 +327,25 @@ public readonly struct JSValue : IEquatable<JSValue>
     public static implicit operator JSValue(ulong value) => CreateNumber(value);
     public static implicit operator JSValue(float value) => CreateNumber(value);
     public static implicit operator JSValue(double value) => CreateNumber(value);
-    public static implicit operator JSValue(bool? value) => ValueOrNull(value, value => GetBoolean(value));
-    public static implicit operator JSValue(sbyte? value) => ValueOrNull(value, value => CreateNumber(value));
-    public static implicit operator JSValue(byte? value) => ValueOrNull(value, value => CreateNumber(value));
-    public static implicit operator JSValue(short? value) => ValueOrNull(value, value => CreateNumber(value));
-    public static implicit operator JSValue(ushort? value) => ValueOrNull(value, value => CreateNumber(value));
-    public static implicit operator JSValue(int? value) => ValueOrNull(value, value => CreateNumber(value));
-    public static implicit operator JSValue(uint? value) => ValueOrNull(value, value => CreateNumber(value));
-    public static implicit operator JSValue(long? value) => ValueOrNull(value, value => CreateNumber(value));
-    public static implicit operator JSValue(ulong? value) => ValueOrNull(value, value => CreateNumber(value));
-    public static implicit operator JSValue(float? value) => ValueOrNull(value, value => CreateNumber(value));
-    public static implicit operator JSValue(double? value) => ValueOrNull(value, value => CreateNumber(value));
-    public static implicit operator JSValue(string value) => value == null ? JSValue.Null : CreateStringUtf16(value);
-    public static implicit operator JSValue(char[] value) => value == null ? JSValue.Null : CreateStringUtf16(value);
+    public static implicit operator JSValue(bool? value) => ValueOrDefault(value, value => GetBoolean(value));
+    public static implicit operator JSValue(sbyte? value) => ValueOrDefault(value, value => CreateNumber(value));
+    public static implicit operator JSValue(byte? value) => ValueOrDefault(value, value => CreateNumber(value));
+    public static implicit operator JSValue(short? value) => ValueOrDefault(value, value => CreateNumber(value));
+    public static implicit operator JSValue(ushort? value) => ValueOrDefault(value, value => CreateNumber(value));
+    public static implicit operator JSValue(int? value) => ValueOrDefault(value, value => CreateNumber(value));
+    public static implicit operator JSValue(uint? value) => ValueOrDefault(value, value => CreateNumber(value));
+    public static implicit operator JSValue(long? value) => ValueOrDefault(value, value => CreateNumber(value));
+    public static implicit operator JSValue(ulong? value) => ValueOrDefault(value, value => CreateNumber(value));
+    public static implicit operator JSValue(float? value) => ValueOrDefault(value, value => CreateNumber(value));
+    public static implicit operator JSValue(double? value) => ValueOrDefault(value, value => CreateNumber(value));
+    public static implicit operator JSValue(string value) => value == null ? default : CreateStringUtf16(value);
+    public static implicit operator JSValue(char[] value) => value == null ? default : CreateStringUtf16(value);
     public static implicit operator JSValue(Span<char> value) => CreateStringUtf16(value);
     public static implicit operator JSValue(ReadOnlySpan<char> value) => CreateStringUtf16(value);
-    public static implicit operator JSValue(byte[] value) => value == null ? JSValue.Null : CreateStringUtf8(value);
+    public static implicit operator JSValue(byte[] value) => value == null ? default : CreateStringUtf8(value);
     public static implicit operator JSValue(Span<byte> value) => CreateStringUtf8(value);
     public static implicit operator JSValue(ReadOnlySpan<byte> value) => CreateStringUtf8(value);
-    public static implicit operator JSValue(JSCallback callback) => CreateFunction("Unknown", callback);
+    public static implicit operator JSValue(JSCallback callback) => callback == null ? default : CreateFunction("Unknown", callback);
 
     public static explicit operator bool(JSValue value) => value.GetValueBool();
     public static explicit operator sbyte(JSValue value) => (sbyte)value.GetValueInt32();
@@ -361,29 +361,28 @@ public readonly struct JSValue : IEquatable<JSValue>
     public static explicit operator string(JSValue value) => value.IsNullOrUndefined() ? null! : value.GetValueStringUtf16();
     public static explicit operator char[](JSValue value) => value.IsNullOrUndefined() ? null! : value.GetValueStringUtf16AsCharArray();
     public static explicit operator byte[](JSValue value) => value.IsNullOrUndefined() ? null! : value.GetValueStringUtf8();
-    public static explicit operator bool?(JSValue value) => ValueOrNull(value, value => value.GetValueBool());
-    public static explicit operator sbyte?(JSValue value) => ValueOrNull(value, value => (sbyte)value.GetValueInt32());
-    public static explicit operator byte?(JSValue value) => ValueOrNull(value, value => (byte)value.GetValueUInt32());
-    public static explicit operator short?(JSValue value) => ValueOrNull(value, value => (short)value.GetValueInt32());
-    public static explicit operator ushort?(JSValue value) => ValueOrNull(value, value => (ushort)value.GetValueUInt32());
-    public static explicit operator int?(JSValue value) => ValueOrNull(value, value => value.GetValueInt32());
-    public static explicit operator uint?(JSValue value) => ValueOrNull(value, value => value.GetValueUInt32());
-    public static explicit operator long?(JSValue value) => ValueOrNull(value, value => value.GetValueInt64());
-    public static explicit operator ulong?(JSValue value) => ValueOrNull(value, value => (ulong)value.GetValueInt64());
-    public static explicit operator float?(JSValue value) => ValueOrNull(value, value => (float)value.GetValueDouble());
-    public static explicit operator double?(JSValue value) => ValueOrNull(value, value => value.GetValueDouble());
+    public static explicit operator bool?(JSValue value) => ValueOrDefault(value, value => value.GetValueBool());
+    public static explicit operator sbyte?(JSValue value) => ValueOrDefault(value, value => (sbyte)value.GetValueInt32());
+    public static explicit operator byte?(JSValue value) => ValueOrDefault(value, value => (byte)value.GetValueUInt32());
+    public static explicit operator short?(JSValue value) => ValueOrDefault(value, value => (short)value.GetValueInt32());
+    public static explicit operator ushort?(JSValue value) => ValueOrDefault(value, value => (ushort)value.GetValueUInt32());
+    public static explicit operator int?(JSValue value) => ValueOrDefault(value, value => value.GetValueInt32());
+    public static explicit operator uint?(JSValue value) => ValueOrDefault(value, value => value.GetValueUInt32());
+    public static explicit operator long?(JSValue value) => ValueOrDefault(value, value => value.GetValueInt64());
+    public static explicit operator ulong?(JSValue value) => ValueOrDefault(value, value => (ulong)value.GetValueInt64());
+    public static explicit operator float?(JSValue value) => ValueOrDefault(value, value => (float)value.GetValueDouble());
+    public static explicit operator double?(JSValue value) => ValueOrDefault(value, value => value.GetValueDouble());
 
-    public static explicit operator napi_value(JSValue value) => value.GetCheckedHandle();
     public static implicit operator JSValue(napi_value handle) => new(handle);
+    public static implicit operator JSValue?(napi_value handle) => handle.Handle != default ? new JSValue(handle) : default;
+    public static explicit operator napi_value(JSValue value) => value.GetCheckedHandle();
+    public static explicit operator napi_value(JSValue? value) => value?.GetCheckedHandle() ?? default;
 
-    public static explicit operator napi_value(JSValue? value) => value?.Handle ?? new napi_value(default);
-    public static implicit operator JSValue?(napi_value handle) => handle.Handle != default ? new JSValue(handle) : (JSValue?)null;
+    private static JSValue ValueOrDefault<T>(T? value, Func<T, JSValue> convert) where T : struct
+        => value.HasValue ? convert(value.Value) : default;
 
-    private static JSValue ValueOrNull<T>(T? value, Func<T, JSValue> convert) where T : struct
-        => value.HasValue ? convert(value.Value) : JSValue.Null;
-
-    private static T? ValueOrNull<T>(JSValue value, Func<JSValue, T> convert) where T : struct
-        => value.IsNullOrUndefined() ? null : convert(value);
+    private static T? ValueOrDefault<T>(JSValue value, Func<JSValue, T> convert) where T : struct
+        => value.IsNullOrUndefined() ? default : convert(value);
 
     /// <summary>
     /// Delegate that provides a conversion from some type to a JS value.
@@ -420,10 +419,4 @@ public readonly struct JSValue : IEquatable<JSValue>
         throw new NotSupportedException(
             "Hashing JS values is not supported. Use JSSet or JSMap instead.");
     }
-}
-
-internal static class JSValueExtensions
-{
-    public static napi_value AsNapiValueOrNull(this JSValue? value)
-        => value is not null ? (napi_value)value.Value : napi_value.Null;
 }

--- a/test/TestCases/Directory.Build.props
+++ b/test/TestCases/Directory.Build.props
@@ -24,7 +24,7 @@
     <ItemGroup>
         <ProjectReference Include="$(NodeApiSrcDir)NodeApi\NodeApi.csproj" />
         <ProjectReference Include="$(NodeApiSrcDir)NodeApi.DotNetHost\NodeApi.DotNetHost.csproj" />
-        <PackageReference Include="Microsoft.JavaScript.NodeApi.Generator" VersionOverride="0.1.*-*"
+        <PackageReference Include="Microsoft.JavaScript.NodeApi.Generator" VersionOverride="0.2.*-*"
             OutputItemType="Analyzer" ReferenceOutputAssembly="false" PrivateAssets="all" />
     </ItemGroup>
 

--- a/test/TestCases/napi-dotnet/complex_types.js
+++ b/test/TestCases/napi-dotnet/complex_types.js
@@ -9,23 +9,23 @@ const binding = require('../common').binding;
 const ComplexTypes = binding.ComplexTypes;
 assert.strictEqual(typeof ComplexTypes, 'object');
 
-assert.strictEqual(ComplexTypes.nullableInt, null);
+assert.strictEqual(ComplexTypes.nullableInt, undefined);
 ComplexTypes.nullableInt = 1;
 assert.strictEqual(ComplexTypes.nullableInt, 1);
 ComplexTypes.nullableInt = null;
-assert.strictEqual(ComplexTypes.nullableInt, null);
+assert.strictEqual(ComplexTypes.nullableInt, undefined);
 
-assert.strictEqual(ComplexTypes.nullableString, null);
+assert.strictEqual(ComplexTypes.nullableString, undefined);
 ComplexTypes.nullableString = 'test';
 assert.strictEqual(ComplexTypes.nullableString, 'test');
 ComplexTypes.nullableString = null;
-assert.strictEqual(ComplexTypes.nullableString, null);
+assert.strictEqual(ComplexTypes.nullableString, undefined);
 
 // Test an exported class.
 const ClassObject = binding.ClassObject;
 assert.strictEqual(typeof ClassObject, 'function');
 const classInstance = new ClassObject();
-assert.strictEqual(classInstance.value, null);
+assert.strictEqual(classInstance.value, undefined);
 classInstance.value = 'test';
 assert.strictEqual(classInstance.value, 'test');
 

--- a/test/TestCases/napi-dotnet/dynamic_invoke.js
+++ b/test/TestCases/napi-dotnet/dynamic_invoke.js
@@ -29,7 +29,7 @@ assert.strictEqual(greeting, 'Hello assembly!');
 const ClassObject = assembly.ClassObject;
 assert.strictEqual(typeof ClassObject, 'function');
 const instance = new ClassObject(); // Construct an instance of a class
-assert.strictEqual(instance.Value, null);
+assert.strictEqual(instance.Value, undefined);
 instance.Value = 'test';
 assert.strictEqual(instance.Value, 'test');
 


### PR DESCRIPTION
Fixes: #58

 - Write doc analyzing null/undefined marshalling considerations
 - Change `JSValue` conversions to convert to `undefined` instead of `null`
 - Change `JSMarshaller` to use `default(JSValue)` instead of `JSValue.Null` or `JSValue.Undefined`
 - Change TS generator to use `?:` or `| undefined` instead of `| null`.
 - Fix test cases that were checking for strict `null` equality.