### PR TITLE
Merge .NET+JS stack traces

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,8 +128,18 @@ a `Promise` returned from a .NET async method, and a JS `Promise` passed to .NET
 
 ### Error propagation
 Exceptions/errors thrown in .NET or JS are propagated across the boundary with stack traces.
-
-_Under development. More to be written..._
+An unhandled .NET exception is thrown back to a JS caller as an `Error` with a stack trace that
+includes both .NET and JS frames, and source line numbers if symbols are available. For example:
+```
+Error: Test error thrown by JS.
+    at Microsoft.JavaScript.NodeApi.TestCases.Errors.ThrowDotnetError(String message) in D:\node-api-dotnet\test\TestCases\Errors.cs:line 13
+    at Microsoft.JavaScript.NodeApi.Generated.Module.Errors_ThrowDotnetError(JSCallbackArgs __args) in napi-dotnet.NodeApi.g.cs:line 357
+    at Microsoft.JavaScript.NodeApi.JSNativeApi.InvokeCallback[TDescriptor](napi_env env, napi_callback_info callbackInfo, JSValueScopeType scopeType, Func`2 getCallbackDescriptor) in JSNativeApi.cs:line 1070
+    at catchDotnetError (D:\node-api-dotnet\test\TestCases\errors.js:14:12)
+    at Object.<anonymous> (D:\node-api-dotnet\test\TestCases\errors.js:41:1)
+```
+Similarly, an unhandled JS `Error` is thrown back to a .NET caller as a `JSException` with a
+combined stack trace.
 
 ### Develop Node.js addons with C#
 A C# class library project can use the `[JSExport]` attribute to tag (and rename) APIs that are

--- a/src/NodeApi/JSError.cs
+++ b/src/NodeApi/JSError.cs
@@ -251,7 +251,7 @@ public struct JSError
 
             // Capture the current JS stack trace as an object.
             // Defer formatting the stack as a string until requested.
-            JSObject jsStack = new JSObject();
+            JSObject jsStack = new();
             captureStackTrace.Call(default, jsStack);
 
             // Override the `stack` property of the JS Error object, and add private

--- a/src/NodeApi/JSException.cs
+++ b/src/NodeApi/JSException.cs
@@ -5,17 +5,78 @@ using System;
 
 namespace Microsoft.JavaScript.NodeApi;
 
+/// <summary>
+/// An exception that was caused by an error thrown by JavaScript code or
+/// interactions with the JavaScript engine.
+/// </summary>
 public class JSException : Exception
 {
+    /// <summary>
+    /// Creates a new instance of <see cref="JSException" /> with an exception message
+    /// and optional inner exception.
+    /// </summary>
     public JSException(string message, Exception? innerException = null)
         : base(message, innerException)
     {
     }
 
+    /// <summary>
+    /// Creates a new instance of <see cref="JSException" /> that wraps the JavaScript
+    /// error that caused it.
+    /// </summary>
     public JSException(JSError error) : base(error.Message)
     {
         Error = error;
     }
 
+    /// <summary>
+    /// Gets the JavaScript error that caused this exception, or null if the exception
+    /// was not caused by a JavaScript error.
+    /// </summary>
     public JSError? Error { get; }
+
+    /// <summary>
+    /// Gets a stack trace that may include both .NET and JavaScript stack frames.
+    /// </summary>
+    public override string? StackTrace
+    {
+        get
+        {
+            JSValue? jsError = Error?.Value;
+            if (jsError is not null)
+            {
+                string jsStack = (string)jsError.Value["stack"];
+
+                // The first line of the stack is the error type name and message,
+                // which is redundant when merged with the .NET exception.
+                int firstLineEnd = jsStack.IndexOf('\n');
+                if (firstLineEnd >= 0)
+                {
+                    jsStack = jsStack.Substring(firstLineEnd + 1);
+                }
+
+                // Normalize indentation to 3 spaces, as used by .NET.
+                // (JS traces indent with 4 spaces.)
+                if (jsStack.StartsWith("    at "))
+                {
+                    jsStack = jsStack.Replace("    at ", "   at ");
+                }
+
+                // Strip the ThrowIfFailed() line(s) from the .NET stack trace.
+                string dotnetStack = base.StackTrace?.TrimStart(new[] { '\r', '\n' }) ??
+                    string.Empty;
+                firstLineEnd = dotnetStack.IndexOf('\n');
+                while (firstLineEnd >= 0 && dotnetStack.IndexOf(
+                    "." + nameof(JSNativeApi.ThrowIfFailed), 0, firstLineEnd) >= 0)
+                {
+                    dotnetStack = dotnetStack.Substring(firstLineEnd + 1);
+                    firstLineEnd = dotnetStack.IndexOf('\n');
+                }
+
+                return jsStack + "\n" + dotnetStack;
+            }
+
+            return base.StackTrace;
+        }
+    }
 }

--- a/test/TestCases/napi-dotnet/Errors.cs
+++ b/test/TestCases/napi-dotnet/Errors.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+
+namespace Microsoft.JavaScript.NodeApi.TestCases;
+
+[JSExport]
+public static class Errors
+{
+    public static void ThrowDotnetError(string message)
+    {
+        throw new Exception(message);
+    }
+
+    public static void ThrowJSError(string message, IJSErrors jsErrors)
+    {
+        jsErrors.ThrowJSError(message);
+    }
+}
+
+[JSExport]
+public interface IJSErrors
+{
+    void ThrowJSError(string message);
+}

--- a/test/TestCases/napi-dotnet/errors.js
+++ b/test/TestCases/napi-dotnet/errors.js
@@ -32,8 +32,9 @@ function catchDotnetError() {
   assert(stack[0].startsWith(`at ${dotnetNamespacePrefix}`));
   assert(stack[0].includes('Errors.ThrowDotnetError('));
 
-  // Skip over initial .NET lines in the stack trace.
-  while (stack[0].startsWith(`at ${dotnetNamespacePrefix}`)) stack.shift();
+  // Skip over initial .NET lines in the stack trace. (Native delegates may include !<BaseAddress>)
+  while (stack[0].startsWith(`at ${dotnetNamespacePrefix}`) ||
+    stack[0].includes('!<')) stack.shift();
 
   // The first JS line of the stack trace should refer to this JS function.
   assert(stack[0].startsWith(`at ${catchDotnetError.name} `));
@@ -72,8 +73,9 @@ function catchJSError() {
   while (!stack[0].includes('Errors.ThrowJSError(')) stack.shift();
   assert(stack.length > 0);
 
-  // Skip over .NET lines in the stack trace.
-  while (stack[0].startsWith(`at ${dotnetNamespacePrefix}`)) stack.shift();
+  // Skip over .NET lines in the stack trace. (Native delegates may include !<BaseAddress>)
+  while (stack[0].startsWith(`at ${dotnetNamespacePrefix}`) ||
+    stack[0].includes('!<')) stack.shift();
 
   // The following JS line of the stack trace should refer to this JS method.
   assert(stack[0].startsWith(`at ${catchJSError.name} `));

--- a/test/TestCases/napi-dotnet/errors.js
+++ b/test/TestCases/napi-dotnet/errors.js
@@ -1,0 +1,81 @@
+const assert = require('assert');
+
+Error.stackTraceLimit = 5;
+
+/** @type {import('./napi-dotnet')} */
+const binding = require('../common').binding;
+const Errors = binding.Errors;
+
+const dotnetNamespacePrefix = "Microsoft.JavaScript.";
+
+function catchDotnetError() {
+  let error = undefined;
+  try {
+    Errors.throwDotnetError('test');
+  } catch (e) {
+    error = e;
+  }
+
+  assert(error instanceof Error);
+  assert.strictEqual(error.message, 'test');
+
+  assert(typeof error.stack === 'string');
+  console.log(error.stack);
+
+  const stack = error.stack.split('\n').map((line) => line.trim());
+
+  // The stack should be prefixed with the error type and message.
+  const firstLine = stack.shift();
+  assert.strictEqual(firstLine, 'Error: test');
+
+  // The first line of the stack trace should refer to the .NET method that threw.
+  assert(stack[0].startsWith(`at ${dotnetNamespacePrefix}`));
+  assert(stack[0].includes('Errors.ThrowDotnetError('));
+
+  // Skip over initial .NET lines in the stack trace.
+  while (stack[0].startsWith(`at ${dotnetNamespacePrefix}`)) stack.shift();
+
+  // The first JS line of the stack trace should refer to this JS function.
+  assert(stack[0].startsWith(`at ${catchDotnetError.name} `));
+}
+catchDotnetError();
+
+function throwJSError(message) { throw new Error(message) }
+
+function catchJSError() {
+  let error = undefined;
+  try {
+    Errors.throwJSError('test', { throwJSError });
+  } catch (e) {
+    error = e;
+  }
+
+  assert(error instanceof Error);
+  assert.strictEqual(error.message, 'test');
+
+  assert(typeof error.stack === 'string');
+  console.log(error.stack);
+
+  const stack = error.stack.split('\n').map((line) => line.trim());
+
+  // The stack should be prefixed with the error type and message.
+  const firstLine = stack.shift();
+  assert.strictEqual(firstLine, 'Error: test');
+
+  // The first line of the stack trace should refer to the JS function that threw.
+  assert(stack[0].startsWith(`at Object.${throwJSError.name} `));
+
+  // Skip over initial non-.NET lines in the stack trace.
+  while (!stack[0].startsWith(`at ${dotnetNamespacePrefix}`)) stack.shift();
+
+  // The .NET stack trace should include the .NET method that called the JS thrower.
+  while (!stack[0].includes('Errors.ThrowJSError(')) stack.shift();
+  assert(stack.length > 0);
+
+  // Skip over .NET lines in the stack trace.
+  while (stack[0].startsWith(`at ${dotnetNamespacePrefix}`)) stack.shift();
+
+  // The following JS line of the stack trace should refer to this JS method.
+  assert(stack[0].startsWith(`at ${catchJSError.name} `));
+}
+catchJSError();


### PR DESCRIPTION
Fixes: #54

It's not perfect: some JS stack frames may be duplicated in the case of a JS->.NET->JS call path. But that will be difficult to fix, and it should not hinder any diagnostics.