### PR TITLE
Add assembly resolve callback, update SK demo

### DIFF
--- a/examples/semantic-kernel/README.md
+++ b/examples/semantic-kernel/README.md
@@ -20,8 +20,14 @@ Then run the following commands in sequence:
 | `node example.js`                | Run example JS code that uses the above packages to call the Azure OpenAI service.
 
 #### Type Definitions (Optional)
-To generate type definitions for the example JavaScript code, run the following command:
+To generate type definitions for the example JavaScript code, run the following commands:
 ```
-npm exec node-api-dotnet-generator -- -t Microsoft.SemanticKernel.d.ts -a pkg/microsoft.semantickernel/0.9.61.1-preview/lib/netstandard2.1/Microsoft.SemanticKernel.dll -r pkg/microsoft.extensions.logging.abstractions/7.0.0/lib/netstandard2.0/Microsoft.Extensions.Logging.Abstractions.dll
+npm exec node-api-dotnet-generator -- -t Microsoft.SemanticKernel.Core.d.ts -a ./pkg/microsoft.semantickernel.core/0.12.207.1-preview/lib/netstandard2.0/Microsoft.SemanticKernel.Core.dll -r ./pkg/microsoft.semantickernel.abstractions/0.12.207.1-preview/lib/netstandard2.0/Microsoft.SemanticKernel.Abstractions.dll -r ./pkg/microsoft.extensions.logging.abstractions/6.0.0/lib/netstandard2.0/Microsoft.Extensions.Logging.Abstractions.dll -r ./pkg/microsoft.bcl.asyncinterfaces/6.0.0/lib/netstandard2.0/Microsoft.Bcl.AsyncInterfaces.dll
+
+npm exec node-api-dotnet-generator -- -t Microsoft.SemanticKernel.Abstractions.d.ts -a .\pkg\microsoft.semantickernel.abstractions\0.12.207.1-preview\lib\netstandard2.0\Microsoft.SemanticKernel.Abstractions.dll -r .\pkg\microsoft.extensions.logging.abstractions\6.0.0\lib\netstandard2.0\Microsoft.Extensions.Logging.Abstractions.dll -r .\pkg\microsoft.bcl.asyncinterfaces\6.0.0\lib\netstandard2.0\Microsoft.Bcl.AsyncInterfaces.dll
+
+npm exec node-api-dotnet-generator -- -t Microsoft.SemanticKernel.Connectors.AI.OpenAI.d.ts -a ./pkg/microsoft.semantickernel.connectors.ai.openai/0.12.207.1-preview/lib/netstandard2.0/Microsoft.SemanticKernel.Connectors.AI.OpenAI.dll -r ./pkg/microsoft.semantickernel.abstractions/0.12.207.1-preview/lib/netstandard2.0/Microsoft.SemanticKernel.Abstractions.dll -r ./pkg/azure.core/1.30.0/lib/netstandard2.0/Azure.Core.dll -r ./pkg/microsoft.extensions.logging.abstractions/6.0.0/lib/netstandard2.0/Microsoft.Extensions.Logging.Abstractions.dll
 ```
-(Ignore the warnings about unsupported types. Those will be addressed in the future.)
+MSBuild scripts will eventually automate these complex commands.
+
+(Ignore the warnings about unsupported types. Those will also be addressed in the future.)

--- a/examples/semantic-kernel/example.js
+++ b/examples/semantic-kernel/example.js
@@ -1,12 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import SK from './semantic-kernel.js';
+import { SK, SKOpenAI } from './semantic-kernel.js';
 
 const kernel = SK.Kernel.Builder.Build();
 
 // The JS marshaller does not yet support extension methods.
-SK.KernelConfigExtensions.AddAzureOpenAITextCompletion(
+SKOpenAI.KernelConfigOpenAIExtensions.AddAzureTextCompletionService(
   kernel.Config,
   'davinci-azure',
   process.env['OPENAI_DEPLOYMENT'],
@@ -35,5 +35,5 @@ does not conflict with the First or Second Law.
 const tldrFunction = SK.InlineFunctionsDefinitionExtension
   .CreateSemanticFunction(kernel, skPrompt);
 
-const summary = await kernel.RunAsync(textToSummarize, [tldrFunction]);
+const summary = await tldrFunction.InvokeAsync(textToSummarize);
 console.log(summary.toString());

--- a/examples/semantic-kernel/semantic-kernel.csproj
+++ b/examples/semantic-kernel/semantic-kernel.csproj
@@ -9,8 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SemanticKernel" Version="0.9.61.1-preview" />
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
+    <PackageReference Include="Microsoft.SemanticKernel" Version="0.12.207.1-preview" />
   </ItemGroup>
 
 </Project>

--- a/examples/semantic-kernel/semantic-kernel.js
+++ b/examples/semantic-kernel/semantic-kernel.js
@@ -16,11 +16,16 @@ const skVersion = fs.readdirSync(path.join(pkgDir, skAssemblyName.toLowerCase())
 
 function resolveAssembly(name, version) {
   if (/\d+\.\d+\.\d+\.0/.test(version)) version = version.substring(0, version.length - 2);
-  const versions = fs.readdirSync(path.join(pkgDir, name.toLowerCase()));
-  version = versions.find((v) => v.startsWith(version)) ?? version;
-  const filePath = path.join(
-    pkgDir, name.toLowerCase(), version, 'lib', 'netstandard2.0', name + '.dll');
-  return filePath;
+  try {
+    const versions = fs.readdirSync(path.join(pkgDir, name.toLowerCase()));
+    version = versions.find((v) => v.startsWith(version)) ?? versions[versions.length - 1];
+    const filePath = path.join(
+      pkgDir, name.toLowerCase(), version, 'lib', 'netstandard2.0', name + '.dll');
+    return filePath;
+  } catch (e) {
+    console.error(e.message);
+    return null;
+  }
 }
 
 dotnet.addListener('resolving', (name, version) => {

--- a/examples/semantic-kernel/semantic-kernel.js
+++ b/examples/semantic-kernel/semantic-kernel.js
@@ -15,7 +15,7 @@ const skOpenAIAssemblyName = 'Microsoft.SemanticKernel.Connectors.AI.OpenAI';
 const skVersion = fs.readdirSync(path.join(pkgDir, skAssemblyName.toLowerCase())).reverse()[0];
 
 function resolveAssembly(name, version) {
-  if (/\d+\.\d+\.\d+\.0/.test(version)) version = version.substr(0, version.length - 2);
+  if (/\d+\.\d+\.\d+\.0/.test(version)) version = version.substring(0, version.length - 2);
   const versions = fs.readdirSync(path.join(pkgDir, name.toLowerCase()));
   version = versions.find((v) => v.startsWith(version)) ?? version;
   const filePath = path.join(
@@ -23,9 +23,14 @@ function resolveAssembly(name, version) {
   return filePath;
 }
 
+dotnet.addListener('resolving', (name, version) => {
+  const filePath = resolveAssembly(name, version);
+  if (fs.existsSync(filePath)) dotnet.load(filePath);
+});
+
 /** @type import('./Microsoft.SemanticKernel.Core') */
-const SK = dotnet.load(resolveAssembly(skAssemblyName, skVersion), resolveAssembly);
+const SK = dotnet.load(resolveAssembly(skAssemblyName, skVersion));
 /** @type import('./Microsoft.SemanticKernel.Connectors.AI.OpenAI') */
-const SKOpenAI = dotnet.load(resolveAssembly(skOpenAIAssemblyName, skVersion), resolveAssembly);
+const SKOpenAI = dotnet.load(resolveAssembly(skOpenAIAssemblyName, skVersion));
 
 export { SK, SKOpenAI };

--- a/src/NodeApi.DotNetHost/AssemblyExporter.cs
+++ b/src/NodeApi.DotNetHost/AssemblyExporter.cs
@@ -246,6 +246,9 @@ internal class AssemblyExporter
         {
             if (member is PropertyInfo property &&
                 property.PropertyType.Assembly.GetName().Name?.StartsWith("System.") == false &&
+#if NETFRAMEWORK
+                property.PropertyType.Assembly.GetName().Name != "mscorlib" &&
+#endif
                 IsSupportedType(property.PropertyType) &&
                 !JSMarshaller.IsConvertedType(property.PropertyType))
             {
@@ -254,6 +257,9 @@ internal class AssemblyExporter
             else if (member is MethodInfo method &&
                 IsSupportedMethod(method) &&
                 method.ReturnType.Assembly.GetName().Name?.StartsWith("System.") == false &&
+#if NETFRAMEWORK
+                method.ReturnType.Assembly.GetName().Name != "mscorlib" &&
+#endif
                 IsSupportedType(method.ReturnType) &&
                 !JSMarshaller.IsConvertedType(method.ReturnType))
             {

--- a/src/NodeApi.DotNetHost/JSMarshaller.cs
+++ b/src/NodeApi.DotNetHost/JSMarshaller.cs
@@ -1197,7 +1197,11 @@ public class JSMarshaller
             s_argsParameter, s_callbackArg, Expression.Constant(index));
 
         Type? nullableType = null;
-        if (parameterType.IsGenericType &&
+        if (!parameterType.IsValueType)
+        {
+            nullableType = parameterType;
+        }
+        else if (parameterType.IsGenericType &&
             parameterType.GetGenericTypeDefinition() == typeof(Nullable<>))
         {
             nullableType = parameterType;
@@ -1213,7 +1217,7 @@ public class JSMarshaller
         {
             convertExpression = Expression.Condition(
                 Expression.Call(s_isNullOrUndefined, argExpression),
-                Expression.Convert(Expression.Constant(null), nullableType),
+                Expression.Constant(null, nullableType),
                 Expression.Convert(convertExpression, nullableType));
         }
 
@@ -1970,7 +1974,10 @@ public class JSMarshaller
         }
         else
         {
-            throw new NotImplementedException();
+            // Marshal the unknown collection type as undefined.
+            // Throwing an exception here might be helpful in some cases, but in other
+            // cases it may block use of the rest of the (supported) members of the type.
+            yield return Expression.Default(toType);
         }
     }
 
@@ -2106,7 +2113,10 @@ public class JSMarshaller
         }
         else
         {
-            throw new NotImplementedException();
+            // Marshal the unknown collection type as null.
+            // Throwing an exception here might be helpful in some cases, but in other
+            // cases it may block use of the rest of the (supported) members of the type.
+            yield return Expression.Default(typeof(JSValue));
         }
     }
 

--- a/src/NodeApi.DotNetHost/ManagedHost.cs
+++ b/src/NodeApi.DotNetHost/ManagedHost.cs
@@ -161,7 +161,7 @@ public sealed class ManagedHost : JSEventEmitter, IDisposable
         object sender,
         ResolveEventArgs args)
     {
-        AssemblyName assemblyInfo = new AssemblyName(args.Name);
+        AssemblyName assemblyInfo = new(args.Name);
 #else
         AssemblyLoadContext loadContext,
         AssemblyName assemblyInfo)

--- a/src/NodeApi.DotNetHost/ManagedHost.cs
+++ b/src/NodeApi.DotNetHost/ManagedHost.cs
@@ -350,9 +350,4 @@ public sealed class ManagedHost : JSEventEmitter, IDisposable
         Trace("< ManagedHost.LoadAssembly() => newly loaded");
         return assemblyValue;
     }
-
-    public override void Dispose()
-    {
-        base.Dispose();
-    }
 }

--- a/src/NodeApi.DotNetHost/ManagedHost.cs
+++ b/src/NodeApi.DotNetHost/ManagedHost.cs
@@ -44,6 +44,7 @@ public sealed class ManagedHost : JSEventEmitter, IDisposable
         AutoCamelCase = false,
     };
 
+    private readonly Dictionary<Type, JSReference> _exportedTypes = new();
     private readonly Dictionary<string, JSReference> _loadedModules = new();
     private readonly Dictionary<string, AssemblyExporter> _loadedAssemblies = new();
     private readonly AssemblyExporter _systemAssembly;
@@ -79,7 +80,8 @@ public sealed class ManagedHost : JSEventEmitter, IDisposable
             JSPropertyDescriptor.ForValue("removeListener", removeListener));
 
         // Export the .NET core library assembly by default, along with additional methods above.
-        _systemAssembly = new AssemblyExporter(typeof(object).Assembly, _marshaller, exports);
+        _systemAssembly = new AssemblyExporter(
+            typeof(object).Assembly, _marshaller, _exportedTypes, exports);
     }
 
     public static bool IsTracingEnabled { get; } =
@@ -341,7 +343,7 @@ public sealed class ManagedHost : JSEventEmitter, IDisposable
 #else
         Assembly assembly = _loadContext.LoadFromAssemblyPath(assemblyFilePath);
 #endif
-        assemblyExporter = new(assembly, _marshaller, target: new JSObject());
+        assemblyExporter = new(assembly, _marshaller, _exportedTypes, target: new JSObject());
         _loadedAssemblies.Add(assemblyFilePath, assemblyExporter);
         JSValue assemblyValue = assemblyExporter.AssemblyObject;
 

--- a/src/NodeApi.Generator/SourceGenerator.cs
+++ b/src/NodeApi.Generator/SourceGenerator.cs
@@ -179,6 +179,10 @@ public abstract class SourceGenerator
                 if (i == 0)
                 {
                     i = comment.IndexOf(' ');
+                    if (i < 0)
+                    {
+                        break;
+                    }
                 }
 
                 yield return comment.Substring(0, i).TrimEnd();

--- a/src/NodeApi/Interop/JSCallbackOverload.cs
+++ b/src/NodeApi/Interop/JSCallbackOverload.cs
@@ -230,15 +230,15 @@ public readonly struct JSCallbackOverload
     {
         if (defaultValue == null)
         {
-            if (parameterType.IsValueType)
+            if (!parameterType.IsValueType ||
+                (parameterType.IsGenericType &&
+                    parameterType.GetGenericTypeDefinition() == typeof(Nullable<>)))
             {
-                throw new InvalidOperationException(
-                    "Null default value is not valid for parameter type: " + parameterType);
+                return default;
             }
-            else
-            {
-                return JSValue.Null;
-            }
+
+            throw new InvalidOperationException(
+                "Null default value is not valid for parameter type: " + parameterType);
         }
         else if (parameterType == typeof(string))
         {

--- a/src/NodeApi/JSArray.cs
+++ b/src/NodeApi/JSArray.cs
@@ -34,6 +34,7 @@ public readonly partial struct JSArray : IList<JSValue>, IEquatable<JSValue>
     {
     }
 
+    /// <inheritdoc/>
     public int Length => _value.GetArrayLength();
 
     int ICollection<JSValue>.Count => _value.GetArrayLength();
@@ -46,8 +47,10 @@ public readonly partial struct JSArray : IList<JSValue>, IEquatable<JSValue>
         set => _value.SetElement(index, value);
     }
 
+    /// <inheritdoc/>
     public void Add(JSValue item) => _value["push"].Call(_value, item);
 
+    /// <inheritdoc/>
     public void CopyTo(JSValue[] array, int arrayIndex)
     {
         int i = arrayIndex;
@@ -89,23 +92,36 @@ public readonly partial struct JSArray : IList<JSValue>, IEquatable<JSValue>
         }
     }
 
+    /// <inheritdoc/>
     public Enumerator GetEnumerator() => new(_value);
 
     IEnumerator<JSValue> IEnumerable<JSValue>.GetEnumerator() => GetEnumerator();
 
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
-    int IList<JSValue>.IndexOf(JSValue item) => throw new System.NotImplementedException();
+    /// <inheritdoc/>
+    public int IndexOf(JSValue item) => (int)_value.CallMethod("indexOf", item);
 
-    void IList<JSValue>.Insert(int index, JSValue item) => throw new System.NotImplementedException();
+    /// <inheritdoc/>
+    public void Insert(int index, JSValue item) => _value.CallMethod("splice", index, 0, item);
 
-    void IList<JSValue>.RemoveAt(int index) => throw new System.NotImplementedException();
+    /// <inheritdoc/>
+    public void RemoveAt(int index) => _value.CallMethod("splice", index, 1);
 
-    void ICollection<JSValue>.Clear() => throw new System.NotImplementedException();
+    /// <inheritdoc/>
+    public void Clear() => _value.CallMethod("splice", 0, Length);
 
-    bool ICollection<JSValue>.Contains(JSValue item) => throw new System.NotImplementedException();
+    /// <inheritdoc/>
+    public bool Contains(JSValue item) => IndexOf(item) >= 0;
 
-    bool ICollection<JSValue>.Remove(JSValue item) => throw new System.NotImplementedException();
+    /// <inheritdoc/>
+    public bool Remove(JSValue item)
+    {
+        int index = IndexOf(item);
+        if (index < 0) return false;
+        RemoveAt(index);
+        return true;
+    }
 
     /// <summary>
     /// Compares two JS values using JS "strict" equality.
@@ -122,11 +138,13 @@ public readonly partial struct JSArray : IList<JSValue>, IEquatable<JSValue>
     /// </summary>
     public bool Equals(JSValue other) => _value.StrictEquals(other);
 
+    /// <inheritdoc/>
     public override bool Equals([NotNullWhen(true)] object? obj)
     {
         return obj is JSValue other && Equals(other);
     }
 
+    /// <inheritdoc/>
     public override int GetHashCode()
     {
         throw new NotSupportedException(

--- a/src/NodeApi/JSEventEmitter.cs
+++ b/src/NodeApi/JSEventEmitter.cs
@@ -192,7 +192,13 @@ public class JSEventEmitter : IDisposable
         }
     }
 
-    public virtual void Dispose()
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    protected virtual void Dispose(bool disposing)
     {
         if (_nodeEmitter != null)
         {

--- a/src/NodeApi/JSEventEmitter.cs
+++ b/src/NodeApi/JSEventEmitter.cs
@@ -1,0 +1,207 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.JavaScript.NodeApi;
+
+/// <summary>
+/// Event emitter that can be backed by either a Node.js `EventEmitter` object or
+/// a standalone (runtime-agnostic) listener tracker.
+/// </summary>
+public class JSEventEmitter : IDisposable
+{
+    private readonly JSReference? _nodeEmitter;
+    private readonly Dictionary<string, JSReference>? _listeners;
+
+    /// <summary>
+    /// Creates a new instance of a standalone (runtime-agnostic) event emitter.
+    /// </summary>
+    public JSEventEmitter()
+    {
+        _listeners = new Dictionary<string, JSReference>();
+    }
+
+    /// <summary>
+    /// Creates a new instance of an event emitter backed by a Node.js `EventEmitter` object.
+    /// </summary>
+    public JSEventEmitter(JSValue nodejsEventEmitter)
+    {
+        if (!nodejsEventEmitter.IsObject())
+        {
+            throw new ArgumentException("Event emitter must be an object.");
+        }
+
+        _nodeEmitter = new JSReference(nodejsEventEmitter);
+    }
+
+    public void AddListener(string eventName, JSValue listener)
+    {
+        if (_nodeEmitter != null)
+        {
+            _nodeEmitter.GetValue()!.Value.CallMethod("addListener", eventName, listener);
+            return;
+        }
+
+        if (!listener.IsFunction())
+        {
+            throw new ArgumentException("Listener must be a function.");
+        }
+
+        JSArray eventListeners;
+        if (_listeners!.TryGetValue(eventName, out JSReference? eventListenersReference))
+        {
+            eventListeners = (JSArray)eventListenersReference.GetValue()!.Value;
+        }
+        else
+        {
+            eventListeners = new JSArray();
+            _listeners.Add(eventName, new JSReference(eventListeners));
+        }
+
+        eventListeners.Add(listener);
+    }
+
+    public void RemoveListener(string eventName, JSValue listener)
+    {
+        if (_nodeEmitter != null)
+        {
+            _nodeEmitter.GetValue()!.Value.CallMethod("removeListener", eventName, listener);
+            return;
+        }
+
+        if (_listeners!.TryGetValue(eventName, out JSReference? eventListenersReference))
+        {
+            JSArray eventListeners = (JSArray)eventListenersReference.GetValue()!.Value;
+            eventListeners.Remove(listener);
+        }
+    }
+
+    public void Once(string eventName, JSCallback listener)
+    {
+        if (_nodeEmitter != null)
+        {
+            _nodeEmitter.GetValue()!.Value.CallMethod(
+                "once", eventName, JSValue.CreateFunction(eventName, listener));
+            return;
+        }
+
+        JSValue onceListener = default;
+        onceListener = JSValue.CreateFunction(eventName, (args) =>
+        {
+            listener(args);
+            RemoveListener(eventName, onceListener);
+            return default;
+        });
+
+        AddListener(eventName, onceListener);
+    }
+
+    public void Once(string eventName, JSValue listener)
+    {
+        if (_nodeEmitter != null)
+        {
+            _nodeEmitter.GetValue()!.Value.CallMethod("once", eventName, listener);
+            return;
+        }
+
+        JSValue onceListener = default;
+        onceListener = JSValue.CreateFunction(eventName, (args) =>
+        {
+            if (args.Length == 0)
+            {
+                listener.Call(args.ThisArg);
+            }
+            else if (args.Length == 1)
+            {
+                listener.Call(args.ThisArg, args[0]);
+            }
+            else
+            {
+                JSValue[] argsArray = new JSValue[args.Length];
+                for (int i = 0; i < argsArray.Length; i++)
+                {
+                    argsArray[i] = args[i];
+                }
+                listener.Call(args.ThisArg, argsArray);
+            }
+
+            RemoveListener(eventName, onceListener);
+            return default;
+        });
+
+        AddListener(eventName, onceListener);
+    }
+
+    public void Emit(string eventName)
+    {
+        if (_nodeEmitter != null)
+        {
+            _nodeEmitter.GetValue()!.Value.CallMethod("emit", eventName);
+            return;
+        }
+
+        if (_listeners!.TryGetValue(eventName, out JSReference? eventListenersReference))
+        {
+            JSArray eventListeners = (JSArray)eventListenersReference.GetValue()!.Value;
+            foreach (JSValue listener in eventListeners)
+            {
+                listener.Call(thisArg: default);
+            }
+        }
+    }
+
+    public void Emit(string eventName, JSValue arg)
+    {
+        if (_nodeEmitter != null)
+        {
+            _nodeEmitter.GetValue()!.Value.CallMethod("emit", eventName, arg);
+            return;
+        }
+
+        if (_listeners!.TryGetValue(eventName, out JSReference? eventListenersReference))
+        {
+            JSArray eventListeners = (JSArray)eventListenersReference.GetValue()!.Value;
+            foreach (JSValue listener in eventListeners)
+            {
+                listener.Call(thisArg: default, arg);
+            }
+        }
+    }
+
+    public void Emit(string eventName, params JSValue[] args)
+    {
+        if (_nodeEmitter != null)
+        {
+            JSValue[] argsArray = new JSValue[args.Length + 1];
+            argsArray[0] = eventName;
+            args.CopyTo(argsArray, 1);
+            _nodeEmitter.GetValue()!.Value.CallMethod("emit", argsArray);
+            return;
+        }
+
+        if (_listeners!.TryGetValue(eventName, out JSReference? eventListenersReference))
+        {
+            JSArray eventListeners = (JSArray)eventListenersReference.GetValue()!.Value;
+            foreach (JSValue listener in eventListeners)
+            {
+                listener.Call(thisArg: default, args);
+            }
+        }
+    }
+
+    public virtual void Dispose()
+    {
+        if (_nodeEmitter != null)
+        {
+            _nodeEmitter.Dispose();
+        }
+        else
+        {
+            _listeners!.Values.ToList().ForEach(l => l.Dispose());
+            _listeners.Clear();
+        }
+    }
+}

--- a/src/node-api-dotnet/index.d.ts
+++ b/src/node-api-dotnet/index.d.ts
@@ -28,12 +28,25 @@ export declare function require(dotnetAssemblyFilePath: string): any;
  * Loads an arbitrary .NET assembly that isn't necessarily designed as a JS module,
  * enabling dynamic invocation of any APIs in the assembly.
  * @param dotnetAssemblyFilePath Path to the .NET assembly DLL file to load.
- * @param resolveCallback Optional callback that returns the path to a dependent assembly DLL
- * when called with an assembly name and version.
  * @returns A JS object that represents the loaded assembly; each property of the object
  * is a public type in the assembly.
  */
-export declare function load(
-  dotnetAssemblyFilePath: string,
-  resolveCallback?: (assemblyName: string, assemblyVersion: string) => string,
-): Assembly | undefined;
+export declare function load(dotnetAssemblyFilePath: string): Assembly | undefined;
+
+/**
+ * Adds a listener for the `resolving` event, which is raised when a .NET assembly requires
+ * an additional dependent assembly to be resolved and loaded. The listener must call `load()`
+ * to load the requested assembly file.
+ */
+export declare function addListener(
+  event: 'resolving',
+  listener: (assemblyName: string, assemblyVersion: string) => void,
+): this;
+
+/**
+ * Removes a listener for the `resolving` event.
+ */
+export declare function removeListener(
+  event: 'resolving',
+  listener: (assemblyName: string, assemblyVersion: string) => void,
+): this;

--- a/src/node-api-dotnet/index.d.ts
+++ b/src/node-api-dotnet/index.d.ts
@@ -27,8 +27,13 @@ export declare function require(dotnetAssemblyFilePath: string): any;
 /**
  * Loads an arbitrary .NET assembly that isn't necessarily designed as a JS module,
  * enabling dynamic invocation of any APIs in the assembly.
- * @param dotnetAssemblyFilePath Path to the .NET assembly DLL file.
+ * @param dotnetAssemblyFilePath Path to the .NET assembly DLL file to load.
+ * @param resolveCallback Optional callback that returns the path to a dependent assembly DLL
+ * when called with an assembly name and version.
  * @returns A JS object that represents the loaded assembly; each property of the object
  * is a public type in the assembly.
  */
-export declare function load(dotnetAssemblyFilePath: string): Assembly | undefined;
+export declare function load(
+  dotnetAssemblyFilePath: string,
+  resolveCallback?: (assemblyName: string, assemblyVersion: string) => string,
+): Assembly | undefined;


### PR DESCRIPTION
The latest version of the Semantic Kernel library has a more complex dependency tree than before, as well as some API changes that uncovered more bugs and limitations in the JS marshaller. With this set of changes, the example project is working again with the current SK version `0.12.207.1`.

 - Add a `JSEventEmitter` class to the core NodeApi library. Later this will be used for general [events marshalling](#59) between .NET and JS, but now it is just used by `ManagedHost`.
 - Add a `resolving` JS event to `ManagedHost` that enables JS code to resolve paths to dependency assemblies on-demand, given assembly names and versions.
 - Fix `AssemblyExporter` to share a single dictionary of exported types when exporting multiple assemblies, supporting cross-referenced types among exported assemblies.
 - Fix `JSMarshaller` bug when marshalling a null value for a reference type.
 - Fix `JSCallbackOverload` bug when filling in defaults for optional reference-type parameters.
 - Fix TS generator comment wrapping bug dealing with long lines without any spaces.
 - In the example project `semantic-kernel.js`, load both `Microsoft.SemanticKernel.Core` and `Microsoft.SemanticKernel.Connectors.AI.OpenAI` assemblies (because the original `Microsoft.SemanticKernel` assembly is now empty), and use the `resolving` event to locate dependency paths.
 - Update `node-api-dotnet-generator` commands in Semantic Kernel example readme.

Due to the large set of dependencies, both the assembly resolve callback and generator commands are more complex and difficult than I would like. I plan to investigate using some MSBuild processes to simplify those, taking advantage of how MSBuild understands the dependencies between assemblies and the paths to the assemblies in nuget packages. But not in this PR.

Partially fixes: #88