### PR TITLE
Use updated Hermes NuGet package in the examples

### DIFF
--- a/examples/hermes-engine/NuGet.config
+++ b/examples/hermes-engine/NuGet.config
@@ -3,9 +3,7 @@
   <packageSources>
     <clear />
     <add key="local" value="../../out/pkg" />
-<!-- Uncomment to compile example -->
-<!-- <add key="react-native" value="https://pkgs.dev.azure.com/ms/react-native/_packaging/react-native-public/nuget/v3/index.json" /> -->
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="react-native" value="https://pkgs.dev.azure.com/ms/react-native/_packaging/react-native-public/nuget/v3/index.json" />
   </packageSources>
   <disabledPackageSources>
     <clear />

--- a/examples/hermes-engine/hermes-engine.csproj
+++ b/examples/hermes-engine/hermes-engine.csproj
@@ -12,11 +12,11 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.JavaScript.NodeApi" Version="0.2.*-*" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.JavaScript.Hermes" Version="0.1.4" IncludeAssets="none" PrivateAssets="build;native;runtime" />
+    <PackageReference Include="Microsoft.JavaScript.Hermes" Version="0.1.6" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="$(PkgMicrosoft_JavaScript_Hermes)\lib\native\win32\x64\hermes.dll" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="$(PkgMicrosoft_JavaScript_Hermes)\build\native\win32\x64\hermes.dll" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
The new version of Hermes NuGet package follows the rules for the [native packages](https://learn.microsoft.com/en-us/nuget/guides/native-packages).
Accordig to these rules all native binaries must be in the `build\native` folder instead of `lib\native`.
Using such package in .Net code does not cause a build error because of unknown framework.
Thus, we can simplify the `PackageReference` for the Nuget.
