### PR TITLE
Set up benchmarks project

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -36,6 +36,25 @@
                 "reveal": "always"
             },
             "problemMatcher": "$msCompile"
+          },
+          {
+            "label": "bench",
+            "command": "dotnet",
+            "type": "shell",
+            "args": [
+                "run",
+                "-c",
+                "Release",
+                "-f",
+                "net7.0"
+            ],
+            "options": {
+                "cwd": "${workspaceFolder}/bench"
+            },
+            "presentation": {
+                "reveal": "always"
+            },
+            "problemMatcher": "$msCompile"
         }
     ]
 }

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,6 +3,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
+    <PackageVersion Include="BenchmarkDotNet" Version="0.13.5" />
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.5.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" />

--- a/NodeApi.sln
+++ b/NodeApi.sln
@@ -29,6 +29,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "GitHub Workflows", "GitHub 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NodeApi.DotNetHost", "src\NodeApi.DotNetHost\NodeApi.DotNetHost.csproj", "{50F53625-D418-4A39-8B3D-842D38229D40}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NodeApi.Bench", "bench\NodeApi.Bench.csproj", "{9EC2AB75-6B03-4E83-8A5D-8660B40B0A9C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -51,6 +53,10 @@ Global
 		{50F53625-D418-4A39-8B3D-842D38229D40}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{50F53625-D418-4A39-8B3D-842D38229D40}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{50F53625-D418-4A39-8B3D-842D38229D40}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9EC2AB75-6B03-4E83-8A5D-8660B40B0A9C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9EC2AB75-6B03-4E83-8A5D-8660B40B0A9C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9EC2AB75-6B03-4E83-8A5D-8660B40B0A9C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9EC2AB75-6B03-4E83-8A5D-8660B40B0A9C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/bench/.gitignore
+++ b/bench/.gitignore
@@ -1,0 +1,1 @@
+BenchmarkDotNet.Artifacts

--- a/bench/Benchmarks.cs
+++ b/bench/Benchmarks.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 using System;

--- a/bench/Benchmarks.cs
+++ b/bench/Benchmarks.cs
@@ -1,0 +1,69 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.IO;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Running;
+using Microsoft.JavaScript.NodeApi.Runtimes;
+using static Microsoft.JavaScript.NodeApi.JSNativeApi.Interop;
+using static Microsoft.JavaScript.NodeApi.Test.TestUtils;
+
+namespace Microsoft.JavaScript.NodeApi.Bench;
+
+public abstract class Benchmarks
+{
+    public static void Main(string[] args)
+    {
+        // Example: dotnet run -c Release --filter aot
+        // If no filter is specified, the switcher will prompt.
+        BenchmarkSwitcher.FromAssembly(typeof(Benchmarks).Assembly).Run(args);
+    }
+
+    public class NonAot : Benchmarks
+    {
+        // Non-AOT-only benchmarks may go here
+    }
+
+    [SimpleJob(RuntimeMoniker.NativeAot70)]
+    public class Aot : Benchmarks
+    {
+        // AOT-only benchmarks may go here
+    }
+
+    private static string LibnodePath { get; } = Path.Combine(
+        GetRepoRootDirectory(),
+        "bin",
+        "win-x64", // TODO
+        "libnode" + GetSharedLibraryExtension());
+
+    private napi_env _env;
+    private JSValue _function;
+    private JSValue _callback;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        NodejsPlatform platform = new(LibnodePath);
+
+        // This setup avoids using NodejsEnvironment so benchmarks can run on the same thread.
+        // NodejsEnvironment creates a separate thread that would slow down the micro-benchmarks.
+        _env = JSNativeApi.CreateEnvironment(
+            (napi_platform)platform, (error) => Console.WriteLine(error), null);
+
+        // The new scope instance saves itself as the thread-local JSValueScope.Current.
+        JSValueScope scope = new(JSValueScopeType.Root, _env);
+
+        // Create some JS values that will be used by the benchmarks.
+        _function = JSNativeApi.RunScript("function callMeBack(cb) { cb(); }; callMeBack");
+        _callback = JSValue.CreateFunction("callback", (args) => JSValue.Undefined);
+    }
+
+    [Benchmark]
+    public void CallJS()
+    {
+        _function.Call(thisArg: default, _callback);
+    }
+}
+

--- a/bench/Directory.Build.props
+++ b/bench/Directory.Build.props
@@ -1,0 +1,7 @@
+<Project>
+  <PropertyGroup>
+    <LangVersion>10</LangVersion>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/bench/NodeApi.Bench.csproj
+++ b/bench/NodeApi.Bench.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net472;net7.0</TargetFrameworks>
+    <OutputType>exe</OutputType>
+    <RootNamespace>Microsoft.JavaScript.NodeApi.Bench</RootNamespace>
+    <IsPublishable>false</IsPublishable>
+    <NoWarn>MSB3270</NoWarn><!-- Processor architecture mismatch bewteen "MSIL" and ... -->
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="../test/TestUtils.cs" Link="TestUtils.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\src\NodeApi\NodeApi.csproj" />
+    <ProjectReference Include="..\src\NodeApi.DotNetHost\NodeApi.DotNetHost.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/bench/NodeApi.Bench.csproj
+++ b/bench/NodeApi.Bench.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;net7.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(TargetFrameworks)' == '' and ! $([MSBuild]::IsOsPlatform('Windows')) ">net7.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(TargetFrameworks)' == '' and $([MSBuild]::IsOsPlatform('Windows')) ">net7.0;net472</TargetFrameworks>
     <OutputType>exe</OutputType>
     <RootNamespace>Microsoft.JavaScript.NodeApi.Bench</RootNamespace>
     <IsPublishable>false</IsPublishable>

--- a/test/HostedClrTests.cs
+++ b/test/HostedClrTests.cs
@@ -13,6 +13,8 @@ using static Microsoft.JavaScript.NodeApi.Test.TestBuilder;
 
 namespace Microsoft.JavaScript.NodeApi.Test;
 
+using static TestUtils;
+
 public class HostedClrTests
 {
     private static readonly Dictionary<string, string?> s_builtTestModules = new();

--- a/test/HostedClrTests.cs
+++ b/test/HostedClrTests.cs
@@ -7,13 +7,12 @@ using System.IO;
 using Xunit;
 
 using static Microsoft.JavaScript.NodeApi.Test.TestBuilder;
+using static Microsoft.JavaScript.NodeApi.Test.TestUtils;
 
 // Avoid running MSBuild on the same project concurrently.
 [assembly: CollectionBehavior(DisableTestParallelization = true)]
 
 namespace Microsoft.JavaScript.NodeApi.Test;
-
-using static TestUtils;
 
 public class HostedClrTests
 {

--- a/test/NativeAotTests.cs
+++ b/test/NativeAotTests.cs
@@ -10,10 +10,9 @@ using System.IO;
 using Xunit;
 
 using static Microsoft.JavaScript.NodeApi.Test.TestBuilder;
+using static Microsoft.JavaScript.NodeApi.Test.TestUtils;
 
 namespace Microsoft.JavaScript.NodeApi.Test;
-
-using static TestUtils;
 
 public class NativeAotTests
 {

--- a/test/NativeAotTests.cs
+++ b/test/NativeAotTests.cs
@@ -13,6 +13,8 @@ using static Microsoft.JavaScript.NodeApi.Test.TestBuilder;
 
 namespace Microsoft.JavaScript.NodeApi.Test;
 
+using static TestUtils;
+
 public class NativeAotTests
 {
     private static readonly Dictionary<string, string?> s_builtTestModules = new();

--- a/test/NodejsEmbeddingTests.cs
+++ b/test/NodejsEmbeddingTests.cs
@@ -11,20 +11,11 @@ using Xunit;
 
 namespace Microsoft.JavaScript.NodeApi.Test;
 
+using static TestUtils;
+
 public class NodejsEmbeddingTests
 {
-    private static string LibnodePath { get; } = Path.Combine(
-        TestBuilder.RepoRootDirectory,
-        "bin",
-        TestBuilder.GetCurrentPlatformRuntimeIdentifier(),
-        "libnode" + GetSharedLibraryExtension());
-
-    private static string GetSharedLibraryExtension()
-    {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) return ".dll";
-        else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) return ".dylib";
-        else return ".so";
-    }
+    private static string LibnodePath { get; } = GetLibnodePath();
 
     // The Node.js platform may only be initialized once per process.
     private static NodejsPlatform? NodejsPlatform { get; } =

--- a/test/NodejsEmbeddingTests.cs
+++ b/test/NodejsEmbeddingTests.cs
@@ -8,10 +8,9 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using Microsoft.JavaScript.NodeApi.Runtimes;
 using Xunit;
+using static Microsoft.JavaScript.NodeApi.Test.TestUtils;
 
 namespace Microsoft.JavaScript.NodeApi.Test;
-
-using static TestUtils;
 
 public class NodejsEmbeddingTests
 {

--- a/test/TestBuilder.cs
+++ b/test/TestBuilder.cs
@@ -9,10 +9,9 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using Xunit;
+using static Microsoft.JavaScript.NodeApi.Test.TestUtils;
 
 namespace Microsoft.JavaScript.NodeApi.Test;
-
-using static TestUtils;
 
 /// <summary>
 /// Utility methods that assist with building and running test cases.

--- a/test/TestBuilder.cs
+++ b/test/TestBuilder.cs
@@ -6,12 +6,13 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
 using Xunit;
 
 namespace Microsoft.JavaScript.NodeApi.Test;
+
+using static TestUtils;
 
 /// <summary>
 /// Utility methods that assist with building and running test cases.
@@ -30,39 +31,14 @@ internal static class TestBuilder
     "Release";
 #endif
 
-    public static string RepoRootDirectory { get; } = GetRootDirectory();
+    public static string RepoRootDirectory { get; } = GetRepoRootDirectory();
 
     public static string TestCasesDirectory { get; } = GetTestCasesDirectory();
-
-    private static string GetRootDirectory()
-    {
-        string? solutionDir = Path.GetDirectoryName(
-#if NETFRAMEWORK
-            new Uri(typeof(TestBuilder).Assembly.CodeBase).LocalPath)!;
-#else
-#pragma warning disable IL3000 // Assembly.Location returns an empty string for assemblies embedded in a single-file app
-            typeof(TestBuilder).Assembly.Location)!;
-#pragma warning restore IL3000
-#endif
-
-        // This assumes there is only a .SLN file at the root of the repo.
-        while (Directory.GetFiles(solutionDir, "*.sln").Length == 0)
-        {
-            solutionDir = Path.GetDirectoryName(solutionDir);
-
-            if (string.IsNullOrEmpty(solutionDir))
-            {
-                throw new DirectoryNotFoundException("Solution directory not found.");
-            }
-        }
-
-        return solutionDir;
-    }
 
     private static string GetTestCasesDirectory()
     {
         // This assumes tests are organized in this test/TestCases directory structure.
-        string testCasesDir = Path.Combine(GetRootDirectory(), "test", "TestCases");
+        string testCasesDir = Path.Combine(GetRepoRootDirectory(), "test", "TestCases");
 
         if (!Directory.Exists(testCasesDir))
         {
@@ -139,33 +115,6 @@ internal static class TestBuilder
     {
         string logDir = GetModuleIntermediateOutputPath(moduleName);
         return Path.Combine(logDir, $"{prefix}-{Path.GetFileName(testCasePath)}.log");
-    }
-
-    public static string GetCurrentPlatformRuntimeIdentifier()
-    {
-        string os = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "win" :
-          RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? "osx" :
-          RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ? "linux" :
-          throw new PlatformNotSupportedException(
-            "Platform not supported: " + Environment.OSVersion.Platform);
-
-        string arch = RuntimeInformation.ProcessArchitecture switch
-        {
-            Architecture.X86 => "x86",
-            Architecture.X64 => "x64",
-            Architecture.Arm64 => "arm64",
-            _ => throw new PlatformNotSupportedException(
-              "CPU architecture not supported: " + RuntimeInformation.ProcessArchitecture),
-        };
-
-        return $"{os}-{arch}";
-    }
-
-    public static string GetCurrentFrameworkTarget()
-    {
-        Version frameworkVersion = Environment.Version;
-        return frameworkVersion.Major == 4 ? "net472" :
-            $"net{frameworkVersion.Major}.{frameworkVersion.Minor}";
     }
 
     public static string CreateProjectFile(string moduleName)

--- a/test/TestUtils.cs
+++ b/test/TestUtils.cs
@@ -1,0 +1,78 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+
+namespace Microsoft.JavaScript.NodeApi.Test;
+
+public static class TestUtils
+{
+    public static string GetRepoRootDirectory()
+    {
+#if NETFRAMEWORK
+        string assemblyLocation = new Uri(typeof(TestUtils).Assembly.CodeBase).LocalPath;
+#else
+#pragma warning disable IL3000 // Assembly.Location returns an empty string for assemblies embedded in a single-file app
+        string assemblyLocation = typeof(TestUtils).Assembly.Location!;
+#pragma warning restore IL3000
+#endif
+
+        string? solutionDir = string.IsNullOrEmpty(assemblyLocation) ?
+            Environment.CurrentDirectory : Path.GetDirectoryName(assemblyLocation);
+
+        // This assumes there is only a .SLN file at the root of the repo.
+        while (Directory.GetFiles(solutionDir!, "*.sln").Length == 0)
+        {
+            solutionDir = Path.GetDirectoryName(solutionDir);
+
+            if (string.IsNullOrEmpty(solutionDir))
+            {
+                throw new DirectoryNotFoundException("Solution directory not found.");
+            }
+        }
+
+        return solutionDir!;
+    }
+
+    public static string GetCurrentPlatformRuntimeIdentifier()
+    {
+        string os = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "win" :
+          RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? "osx" :
+          RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ? "linux" :
+          throw new PlatformNotSupportedException(
+            "Platform not supported: " + Environment.OSVersion.Platform);
+
+        string arch = RuntimeInformation.ProcessArchitecture switch
+        {
+            Architecture.X86 => "x86",
+            Architecture.X64 => "x64",
+            Architecture.Arm64 => "arm64",
+            _ => throw new PlatformNotSupportedException(
+              "CPU architecture not supported: " + RuntimeInformation.ProcessArchitecture),
+        };
+
+        return $"{os}-{arch}";
+    }
+
+    public static string GetCurrentFrameworkTarget()
+    {
+        Version frameworkVersion = Environment.Version;
+        return frameworkVersion.Major == 4 ? "net472" :
+            $"net{frameworkVersion.Major}.{frameworkVersion.Minor}";
+    }
+
+    public static string GetSharedLibraryExtension()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) return ".dll";
+        else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) return ".dylib";
+        else return ".so";
+    }
+
+    public static string GetLibnodePath() => Path.Combine(
+        GetRepoRootDirectory(),
+        "bin",
+        GetCurrentPlatformRuntimeIdentifier(),
+        "libnode" + GetSharedLibraryExtension());
+}


### PR DESCRIPTION
So far there is just one micro-benchmark: a JS callback. It runs on both AOT and non-AOT (net7.0) runtime.

BenchmarkDotNet does not like its MSBuild output directories modified, so I had to prevent it from using the project-wide `Directory.Build.props`. Fine. It can play in its own directory.

`TestUtils.cs` has some utility functions that are shared by both tests and benchmarks. The source file is included in both projects (there is no project reference).

I think it will be easiest to drive most (or all?) benchmarks from .NET, calling into an embedded Node.js (or other) runtime. And then we will need `libnode` packages published so others (or build machines) can run the benchmarks.

There is a lot more that can be done, but this is a start.

Related to #108