### PR TITLE
Delegates and cancellation

### DIFF
--- a/bench/NodeApi.Bench.csproj
+++ b/bench/NodeApi.Bench.csproj
@@ -5,6 +5,7 @@
     <TargetFrameworks Condition=" '$(TargetFrameworks)' == '' and $([MSBuild]::IsOsPlatform('Windows')) ">net7.0;net472</TargetFrameworks>
     <OutputType>exe</OutputType>
     <RootNamespace>Microsoft.JavaScript.NodeApi.Bench</RootNamespace>
+    <IsPackable>false</IsPackable>
     <IsPublishable>false</IsPublishable>
     <NoWarn>MSB3270</NoWarn><!-- Processor architecture mismatch bewteen "MSIL" and ... -->
   </PropertyGroup>

--- a/src/NodeApi.DotNetHost/AssemblyExporter.cs
+++ b/src/NodeApi.DotNetHost/AssemblyExporter.cs
@@ -155,7 +155,16 @@ internal class AssemblyExporter
             }
             if (type.IsClass || type.IsInterface || type.IsValueType)
             {
-                return ExportClass(type);
+                if (type.IsClass && type.BaseType?.FullName == typeof(MulticastDelegate).FullName)
+                {
+                    // Delegate types are not exported as type objects, but the JS marshaller can
+                    // still dynamically convert delegate instances to/from JS functions.
+                    return JSValue.Undefined;
+                }
+                else
+                {
+                    return ExportClass(type);
+                }
             }
             else
             {

--- a/src/NodeApi.DotNetHost/TypeExtensions.cs
+++ b/src/NodeApi.DotNetHost/TypeExtensions.cs
@@ -94,7 +94,7 @@ internal static class TypeExtensions
             .Where((m) => m.Name == "op_Implicit" && m.ReturnType == toType &&
                 m.GetParameters()[0].ParameterType == fromType).SingleOrDefault() ??
             throw new MissingMemberException(
-                $"Explicit conversion method for {fromType.Name}->{toType.Name} " +
+                $"Implicit conversion method for {fromType.Name}->{toType.Name} " +
                 $"not found on type {declaringType.Name}.");
 
 #if NETFRAMEWORK

--- a/src/NodeApi.Generator/ExpressionExtensions.cs
+++ b/src/NodeApi.Generator/ExpressionExtensions.cs
@@ -65,7 +65,9 @@ internal static class ExpressionExtensions
             BlockExpression block => FormatBlock(block, path, variables),
 
             ConstantExpression constant => constant.Type == typeof(Type) ?
-                $"typeof({FormatType((Type)constant.Value!)})" : constant.ToString(),
+                $"typeof({FormatType((Type)constant.Value!)})" :
+                constant.Type == typeof(bool) ? constant.ToString().ToLowerInvariant() :
+                constant.ToString(),
 
             DefaultExpression defaultExpression => "default",
 
@@ -73,7 +75,7 @@ internal static class ExpressionExtensions
                 ToCS(cast.Operand, path, variables) + " as " + FormatType(cast.Type),
 
             UnaryExpression { NodeType: ExpressionType.Convert } cast =>
-                "(" + FormatType(cast.Type) + ")" + ToCS(cast.Operand, path, variables),
+                "(" + FormatType(cast.Type) + ")" + WithParentheses(cast.Operand, path, variables),
 
             BinaryExpression binary =>
                 ToCS(binary.Left, path, variables) +
@@ -201,7 +203,8 @@ internal static class ExpressionExtensions
             (expression.NodeType == ExpressionType.TypeAs ||
             expression.NodeType == ExpressionType.Convert ||
             expression.NodeType == ExpressionType.Call ||
-            expression.NodeType == ExpressionType.MemberAccess))
+            expression.NodeType == ExpressionType.MemberAccess ||
+            expression.NodeType == ExpressionType.Lambda))
         {
             // Wrap extra parentheses around casts when needed.
             cs = $"({cs})";

--- a/src/NodeApi.Generator/SourceBuilder.cs
+++ b/src/NodeApi.Generator/SourceBuilder.cs
@@ -91,7 +91,7 @@ internal class SourceBuilder : SourceText
         {
             IncreaseIndent();
         }
-        else if (line.EndsWith("(") || line.EndsWith("?"))
+        else if (line.EndsWith("(") || line.EndsWith("?") || line.EndsWith("=>"))
         {
             // The "extra" indent persists until the end of the set of lines appended together
             // (before the split) or until a line ending with a semicolon."

--- a/src/NodeApi/Interop/JSAbortSignal.cs
+++ b/src/NodeApi/Interop/JSAbortSignal.cs
@@ -85,13 +85,12 @@ public readonly struct JSAbortSignal : IEquatable<JSValue>
             {
                 JSValue controller = abortControllerClass.CallAsConstructor();
                 JSReference controllerReference = new(controller);
-                cancellation.Register(
-                    () =>
-                    {
-                        controllerReference.GetValue()!.Value.CallMethod("abort");
-                        controllerReference.Dispose();
-                    },
-                    useSynchronizationContext: true);
+                JSSynchronizationContext syncContext = JSSynchronizationContext.Current!;
+                cancellation.Register(() => syncContext.Post(() =>
+                {
+                    controllerReference.GetValue()!.Value.CallMethod("abort");
+                    controllerReference.Dispose();
+                }));
                 return new JSAbortSignal(controller["signal"]);
             }
             else

--- a/src/NodeApi/Interop/JSAbortSignal.cs
+++ b/src/NodeApi/Interop/JSAbortSignal.cs
@@ -1,0 +1,130 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+
+namespace Microsoft.JavaScript.NodeApi.Interop;
+
+/// <summary>
+/// Represents a JavaScript AbortSignal object and supports conversion to and from
+/// <see cref="CancellationToken" />.
+/// </summary>
+/// <remarks>
+/// https://nodejs.org/api/globals.html#class-abortsignal
+/// https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
+/// </remarks>
+public readonly struct JSAbortSignal : IEquatable<JSValue>
+{
+    private readonly JSValue _value;
+
+    public static explicit operator JSAbortSignal(JSValue value) => new(value);
+    public static implicit operator JSValue(JSAbortSignal promise) => promise._value;
+
+    public static explicit operator JSAbortSignal(JSObject obj) => (JSAbortSignal)(JSValue)obj;
+    public static implicit operator JSObject(JSAbortSignal promise) => (JSObject)promise._value;
+
+    private JSAbortSignal(JSValue value)
+    {
+        _value = value;
+    }
+
+    public static explicit operator CancellationToken(JSAbortSignal signal)
+        => signal.ToCancellationToken();
+
+    public static explicit operator JSAbortSignal(CancellationToken cancellation)
+        => FromCancellationToken(cancellation);
+
+    private CancellationToken ToCancellationToken()
+    {
+        if (!_value.IsObject())
+        {
+            return default;
+        }
+        else if ((bool)_value.GetProperty("aborted"))
+        {
+            return new CancellationToken(canceled: true);
+        }
+        else
+        {
+            CancellationTokenSource cancellationSource = new();
+            _value.CallMethod("addEventListener", "abort", JSValue.CreateFunction("abort", (args) =>
+            {
+                cancellationSource.Cancel();
+                return default;
+            }));
+            return cancellationSource.Token;
+        }
+    }
+
+    private static JSAbortSignal FromCancellationToken(CancellationToken cancellation)
+    {
+        if (cancellation == default)
+        {
+            return default;
+        }
+        else if (cancellation.IsCancellationRequested)
+        {
+            JSValue abortSignalClass = JSValue.Global["AbortSignal"];
+            if (abortSignalClass.IsFunction())
+            {
+                JSValue value = abortSignalClass.CallMethod("abort");
+                return new JSAbortSignal(value);
+            }
+            else
+            {
+                // AbortSignal is not supported in this environment.
+                return default;
+            }
+        }
+        else
+        {
+            JSValue abortControllerClass = JSValue.Global["AbortController"];
+            if (abortControllerClass.IsFunction())
+            {
+                JSValue controller = abortControllerClass.CallAsConstructor();
+                JSReference controllerReference = new(controller);
+                cancellation.Register(
+                    () =>
+                    {
+                        controllerReference.GetValue()!.Value.CallMethod("abort");
+                        controllerReference.Dispose();
+                    },
+                    useSynchronizationContext: true);
+                return new JSAbortSignal(controller["signal"]);
+            }
+            else
+            {
+                // AbortController is not supported in this environment.
+                return default;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Compares two JS values using JS "strict" equality.
+    /// </summary>
+    public static bool operator ==(JSAbortSignal a, JSAbortSignal b) => a._value.StrictEquals(b);
+
+    /// <summary>
+    /// Compares two JS values using JS "strict" equality.
+    /// </summary>
+    public static bool operator !=(JSAbortSignal a, JSAbortSignal b) => !a._value.StrictEquals(b);
+
+    /// <summary>
+    /// Compares two JS values using JS "strict" equality.
+    /// </summary>
+    public bool Equals(JSValue other) => _value.StrictEquals(other);
+
+    public override bool Equals([NotNullWhen(true)] object? obj)
+    {
+        return obj is JSValue other && Equals(other);
+    }
+
+    public override int GetHashCode()
+    {
+        throw new NotSupportedException(
+            "Hashing JS values is not supported. Use JSSet or JSMap instead.");
+    }
+}

--- a/test/TestCases/napi-dotnet/Delegates.cs
+++ b/test/TestCases/napi-dotnet/Delegates.cs
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.JavaScript.NodeApi.TestCases;
+
+[JSExport]
+public delegate string TestDelegate(string value);
+
+
+[JSExport]
+public static class Delegates
+{
+    public static void CallAction(Action<int> actionDelegate, int value) => actionDelegate(value);
+
+    public static int CallFunc(Func<int, int> funcDelegate, int value) => funcDelegate(value);
+
+    public static string CallDelegate(TestDelegate testDelegate, string value) => testDelegate(value);
+
+    public static string CallDotnetDelegate(Func<TestDelegate, string> callDelegate)
+        => callDelegate((string value) => "#" + value);
+
+    public static async Task WaitUntilCancelled(CancellationToken cancellation)
+    {
+        TaskCompletionSource<bool> completion = new();
+        cancellation.Register(() =>
+        {
+            completion.SetResult(true);
+        });
+        await completion.Task;
+    }
+
+    public static async Task CallDelegateAndCancel(
+        Func<CancellationToken, Task> cancellableDelegate)
+    {
+        CancellationTokenSource cancellationSource = new();
+        Task delegateTask = cancellableDelegate(cancellationSource.Token);
+        await Task.Delay(100);
+        cancellationSource.Cancel();
+        await delegateTask;
+    }
+}

--- a/test/TestCases/napi-dotnet/Delegates.cs
+++ b/test/TestCases/napi-dotnet/Delegates.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.JavaScript.NodeApi.Interop;
 
 namespace Microsoft.JavaScript.NodeApi.TestCases;
 
@@ -25,11 +26,9 @@ public static class Delegates
 
     public static async Task WaitUntilCancelled(CancellationToken cancellation)
     {
+        JSSynchronizationContext syncContext = JSSynchronizationContext.Current!;
         TaskCompletionSource<bool> completion = new();
-        cancellation.Register(() =>
-        {
-            completion.SetResult(true);
-        });
+        cancellation.Register(() => syncContext.Post(() => completion.SetResult(true)));
         await completion.Task;
     }
 

--- a/test/TestCases/napi-dotnet/delegates.js
+++ b/test/TestCases/napi-dotnet/delegates.js
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+const assert = require('assert');
+
+/** @type {import('./napi-dotnet')} */
+const binding = require('../common').binding;
+
+const Delegates = binding.Delegates;
+assert.strictEqual(typeof Delegates, 'object');
+
+let actionValue = 0;
+Delegates.callAction((value) => actionValue = value, 1);
+assert.strictEqual(actionValue, 1);
+
+const funcValue = Delegates.callFunc((value) => value + 1, 1);
+assert.strictEqual(funcValue, 2);
+
+const delegateValue = Delegates.callDelegate((value) => value + '!', 'test');
+assert.strictEqual(delegateValue, 'test!');
+
+// Marshalling .NET delegates to JS is not yet implemented.
+////const delegateValue2 = Delegates.callDotnetDelegate((dotnetAction) => dotnetAction('test'));
+////assert.strictEqual(delegateValue2, '#test');
+
+async function testCancellation() {
+  let timeoutHandle;
+  let timeout = new Promise((_, reject) => {
+    timeoutHandle = setTimeout(() => reject('waitUntilCancelled() timed out.'), 5000);
+  });
+
+  let abortController = new AbortController();
+  const waitPromise = Delegates.waitUntilCancelled(abortController.signal);
+  setTimeout(() => abortController.abort(), 100);
+  await Promise.race([waitPromise, timeout]);
+  clearTimeout(timeoutHandle);
+
+  timeout = new Promise((_, reject) => {
+    timeoutHandle = setTimeout(() => reject('callDelegateAndCancel() timed out.'), 5000);
+  });
+
+  const callPromise = Delegates.callDelegateAndCancel((abortSignal) => {
+    assert.strictEqual(typeof abortSignal, 'object');
+    return new Promise((resolve) => {
+      abortSignal.addEventListener('abort', resolve);
+    });
+  });
+  await Promise.race([callPromise, timeout]);
+  clearTimeout(timeoutHandle);
+}
+testCancellation().catch(assert.fail);

--- a/test/TestCases/napi-dotnet/dynamic_invoke.js
+++ b/test/TestCases/napi-dotnet/dynamic_invoke.js
@@ -44,7 +44,13 @@ const TestEnum = assembly.TestEnum;
 assert.strictEqual(TestEnum.Two, 2);
 assert.strictEqual(TestEnum[2], 'Two');
 
-test();
+const Delegates = assembly.Delegates;
+assert.strictEqual(typeof Delegates, 'object');
+const funcValue = Delegates.CallFunc((value) => value + 1, 1);
+assert.strictEqual(funcValue, 2);
+const delegateValue = Delegates.CallDelegate((value) => value + '!', 'test');
+assert.strictEqual(delegateValue, 'test!');
+
 async function test() {
   const interfaceObj = assembly.AsyncMethods.InterfaceTest;
   assert.strictEqual(typeof interfaceObj, 'object');
@@ -60,3 +66,4 @@ async function test() {
     await assembly.AsyncMethods.ReverseInterfaceTest(asyncInterfaceImpl, 'buddy');
   assert.strictEqual(reverseInterfaceResult, 'Hello, buddy!');
 }
+test().catch(assert.fail);


### PR DESCRIPTION
 - Marshal JS functions to .NET delegates, so .NET code can invoke the JS callback.
   - `Action<>` and `Func<>` as well as custom delegate types are supported.
 - Marshal .NET `CancellationToken` to/from JS `AbortSignal`
 - Add `JSAbortSignal` struct to main library; it facilitates marshalling of `CancellationTokens`.
 - Update TS generator accordingly.

So far, delegate marshalling is only _one-way_: JS can pass a function to .NET, so .NET can then invoke the callback. The opposite (marshalling .NET delegates to JS functions) will come soon in another PR; I just didn't want to block on it.

Fixes: #61 
Partially fixes: #65 