### PR TITLE
Marshal .NET delegates to JS functions

### DIFF
--- a/src/NodeApi.Generator/ExpressionExtensions.cs
+++ b/src/NodeApi.Generator/ExpressionExtensions.cs
@@ -29,7 +29,7 @@ internal static class ExpressionExtensions
         => ToCS(
             expression,
             path: expression.Name ?? string.Empty,
-            variables: new HashSet<string>());
+            variables: null);
 
     /// <summary>
     /// Recursively traverses an expression tree and builds C# code from the expressions.
@@ -43,7 +43,7 @@ internal static class ExpressionExtensions
     private static string ToCS(
         Expression expression,
         string path,
-        HashSet<string> variables)
+        HashSet<string>? variables)
     {
         path += "/" + expression?.NodeType.ToString() ?? string.Empty;
 
@@ -55,7 +55,7 @@ internal static class ExpressionExtensions
             LambdaExpression lambda =>
                 // Format as either a method or a lambda depending on whether this node
                 // is inside a block (where variables have been defined).
-                (variables.Count == 0 ? FormatType(lambda.ReturnType) + " " + lambda.Name + "(" +
+                (variables is null ? FormatType(lambda.ReturnType) + " " + lambda.Name + "(" +
                   string.Join(", ", lambda.Parameters.Select((p) => p.ToCS())) + ")\n" :
                 "(" + string.Join(", ", lambda.Parameters.Select((p) => p.ToCS())) + ") =>\n") +
                 ToCS(lambda.Body, path, variables),
@@ -195,7 +195,7 @@ internal static class ExpressionExtensions
     private static string WithParentheses(
         Expression expression,
         string path,
-        HashSet<string> variables)
+        HashSet<string>? variables)
     {
         string cs = ToCS(expression, path, variables);
 
@@ -216,10 +216,12 @@ internal static class ExpressionExtensions
     private static string FormatBlock(
         BlockExpression block,
         string path,
-        HashSet<string> variables)
+        HashSet<string>? variables)
     {
         StringBuilder s = new();
         s.Append("{\n");
+
+        variables ??= new HashSet<string>();
 
         for (int i = 0; i < block.Expressions.Count; i++)
         {
@@ -332,7 +334,7 @@ internal static class ExpressionExtensions
         MethodInfo method,
         IReadOnlyCollection<Expression> arguments,
         string path,
-        HashSet<string> variables)
+        HashSet<string>? variables)
         => (method.IsGenericMethod
             ? "<" + string.Join(", ", method.GetGenericArguments().Select(FormatType)) + ">"
             : string.Empty) + FormatArgs(arguments, path, variables);
@@ -340,6 +342,6 @@ internal static class ExpressionExtensions
     private static string FormatArgs(
         IEnumerable<Expression> arguments,
         string path,
-        HashSet<string> variables)
+        HashSet<string>? variables)
         => "(" + string.Join(", ", arguments.Select((a) => ToCS(a, path, variables))) + ")";
 }

--- a/src/NodeApi.Generator/ModuleGenerator.cs
+++ b/src/NodeApi.Generator/ModuleGenerator.cs
@@ -656,10 +656,10 @@ public class ModuleGenerator : SourceGenerator, ISourceGenerator
     private void ExportDelegate(ITypeSymbol delegateType)
     {
         MethodInfo delegateInvokeMethod = delegateType.AsType().GetMethod("Invoke")!;
-        Expression<JSCallback> fromAdapter = _marshaller.BuildFromJSMethodExpression(
+        LambdaExpression fromAdapter = _marshaller.BuildFromJSDelegateMethodExpression(
             delegateInvokeMethod);
         _callbackAdapters.Add(fromAdapter.Name!, fromAdapter);
-        LambdaExpression toAapter = _marshaller.BuildToJSMethodExpression(
+        LambdaExpression toAapter = _marshaller.BuildToJSDelegateMethodExpression(
             delegateInvokeMethod);
         _callbackAdapters.Add(toAapter.Name!, toAapter);
     }

--- a/test/TestCases/napi-dotnet/delegates.js
+++ b/test/TestCases/napi-dotnet/delegates.js
@@ -19,9 +19,13 @@ assert.strictEqual(funcValue, 2);
 const delegateValue = Delegates.callDelegate((value) => value + '!', 'test');
 assert.strictEqual(delegateValue, 'test!');
 
-// Marshalling .NET delegates to JS is not yet implemented.
-////const delegateValue2 = Delegates.callDotnetDelegate((dotnetAction) => dotnetAction('test'));
-////assert.strictEqual(delegateValue2, '#test');
+// Pass a function to a .NET method. The function is marshalled to .NET as a delegate.
+// The .NET method calls that delegate, passing another delegate as an argument.
+// The call with delegate argument is marshalled to JS, with delegate marshalled as a function.
+// That function is then called with "test" argument. .NET prepends "#", and the
+// return value is marshalled all the way back.
+const delegateValue2 = Delegates.callDotnetDelegate((dotnetAction) => dotnetAction('test'));
+assert.strictEqual(delegateValue2, '#test');
 
 async function testCancellation() {
   let timeoutHandle;

--- a/test/TestCases/napi-dotnet/dynamic_invoke.js
+++ b/test/TestCases/napi-dotnet/dynamic_invoke.js
@@ -50,6 +50,8 @@ const funcValue = Delegates.CallFunc((value) => value + 1, 1);
 assert.strictEqual(funcValue, 2);
 const delegateValue = Delegates.CallDelegate((value) => value + '!', 'test');
 assert.strictEqual(delegateValue, 'test!');
+const delegateValue2 = Delegates.CallDotnetDelegate((dotnetAction) => dotnetAction('test'));
+assert.strictEqual(delegateValue2, '#test');
 
 async function test() {
   const interfaceObj = assembly.AsyncMethods.InterfaceTest;


### PR DESCRIPTION
Fixes #65 

This completes the delegates marshalling work that was started in #119.

 - Marshal .NET delegates to JS functions.
 - When marshalling JS functions to .NET delegates, use `JSSynchronizationContext` to invoke the callback on the JS thread.