### PR TITLE
Fix TS generator issues after recent changes

### DIFF
--- a/src/NodeApi.DotNetHost/JSMarshaller.cs
+++ b/src/NodeApi.DotNetHost/JSMarshaller.cs
@@ -1586,13 +1586,13 @@ public class JSMarshaller
 
             PropertyInfo thisArgProperty = typeof(JSCallbackArgs).GetProperty(
                 nameof(JSCallbackArgs.ThisArg))!;
-            MethodInfo unwrapMethod = typeof(JSNativeApi).GetMethod(nameof(JSNativeApi.Unwrap))!;
             yield return Expression.Assign(
                 thisVariable,
                 Expression.TypeAs(
                     Expression.Call(
-                        unwrapMethod,
-                        Expression.Property(s_argsParameter, thisArgProperty)),
+                        s_unwrap,
+                        Expression.Property(s_argsParameter, thisArgProperty),
+                        Expression.Constant(type.Name)),
                     type));
             yield return Expression.IfThen(
                 Expression.Equal(thisVariable, Expression.Constant(null)),
@@ -1857,7 +1857,9 @@ public class JSMarshaller
             {
                 statements = new[]
                 {
-                    Expression.Convert(Expression.Call(s_unwrap, valueParameter), toType),
+                    Expression.Convert(
+                        Expression.Call(s_unwrap, valueParameter, Expression.Constant(toType.Name)),
+                        toType),
                 };
             }
         }
@@ -2001,7 +2003,7 @@ public class JSMarshaller
             else if (fromType == typeof(CancellationToken))
             {
                 MethodInfo toAbortSignal = typeof(JSAbortSignal).GetExplicitConversion(
-                    typeof(CancellationToken), typeof(JSAbortSignal));
+                    nullableType ?? fromType, typeof(JSAbortSignal));
                 MethodInfo asJSValue = typeof(JSAbortSignal).GetImplicitConversion(
                     typeof(JSAbortSignal), typeof(JSValue));
 

--- a/src/NodeApi/Interop/JSAbortSignal.cs
+++ b/src/NodeApi/Interop/JSAbortSignal.cs
@@ -35,6 +35,8 @@ public readonly struct JSAbortSignal : IEquatable<JSValue>
 
     public static explicit operator JSAbortSignal(CancellationToken cancellation)
         => FromCancellationToken(cancellation);
+    public static explicit operator JSAbortSignal(CancellationToken? cancellation)
+        => cancellation.HasValue ? FromCancellationToken(cancellation.Value) : default;
 
     private CancellationToken ToCancellationToken()
     {

--- a/src/NodeApi/Interop/JSClassBuilderOfT.cs
+++ b/src/NodeApi/Interop/JSClassBuilderOfT.cs
@@ -47,7 +47,7 @@ public class JSClassBuilder<T> : JSPropertyDescriptorList<JSClassBuilder<T>, T> 
 
     private static new T? Unwrap(JSCallbackArgs args)
     {
-        return (T?)args.ThisArg.Unwrap();
+        return (T?)args.ThisArg.Unwrap(typeof(T).Name);
     }
 
     /// <summary>

--- a/src/NodeApi/Interop/JSCollectionProxies.cs
+++ b/src/NodeApi/Interop/JSCollectionProxies.cs
@@ -299,7 +299,7 @@ internal static class JSCollectionProxies
             },
             Set = (JSObject target, JSValue property, JSValue value, JSObject receiver) =>
             {
-                var list = (IList<T>)((JSValue)target).Unwrap();
+                var list = (IList<T>)((JSValue)target).Unwrap(typeof(IList<T>).Name);
 
                 if (property.IsNumber())
                 {

--- a/src/NodeApi/Interop/NodeStream.Proxy.cs
+++ b/src/NodeApi/Interop/NodeStream.Proxy.cs
@@ -155,7 +155,7 @@ public partial class NodeStream
     {
         // The count (argument 0) is intentionally ignored.
         JSValue nodeStream = args.ThisArg;
-        var stream = (Stream)nodeStream.Unwrap();
+        var stream = (Stream)nodeStream.Unwrap(typeof(Stream).Name);
 
         ReadAsync(stream, nodeStream);
 
@@ -216,7 +216,7 @@ public partial class NodeStream
     {
         // The encoding (argument 1) is currently ignored.
         JSValue nodeStream = args.ThisArg;
-        var stream = (Stream)nodeStream.Unwrap();
+        var stream = (Stream)nodeStream.Unwrap(typeof(Stream).Name);
         JSValue chunk = args[0];
         JSValue callback = args[2];
 
@@ -273,7 +273,7 @@ public partial class NodeStream
     private static JSValue Final(JSCallbackArgs args)
     {
         JSValue nodeStream = args.ThisArg;
-        var stream = (Stream)nodeStream.Unwrap();
+        var stream = (Stream)nodeStream.Unwrap(typeof(Stream).Name);
         JSValue callback = args[0];
 
         FinalAsync(stream, callback);
@@ -312,7 +312,7 @@ public partial class NodeStream
     {
         // The error (argument 0) is currently ignored.
         JSValue nodeStream = args.ThisArg;
-        var stream = (Stream)nodeStream.Unwrap();
+        var stream = (Stream)nodeStream.Unwrap(typeof(Stream).Name);
         JSValue callback = args[1];
 
         stream.Close();

--- a/src/NodeApi/JSObject.cs
+++ b/src/NodeApi/JSObject.cs
@@ -59,7 +59,7 @@ public readonly partial struct JSObject : IDictionary<JSValue, JSValue>, IEquata
 
     public T Unwrap<T>() where T : class
     {
-        return (T)JSNativeApi.Unwrap(_value);
+        return (T)JSNativeApi.Unwrap(_value, typeof(T).Name);
     }
 
     public JSValue this[JSValue name]

--- a/src/NodeApi/Native/JSNativeApi.cs
+++ b/src/NodeApi/Native/JSNativeApi.cs
@@ -616,9 +616,16 @@ public static partial class JSNativeApi
     /// Gets the object that was previously attached to a JS wrapper.
     /// (Throws an exception if unwrapping failed.)
     /// </summary>
-    public static object Unwrap(this JSValue thisValue)
+    public static object Unwrap(this JSValue thisValue, string? unwrapType = null)
     {
-        napi_unwrap(Env, (napi_value)thisValue, out nint result).ThrowIfFailed();
+        napi_status status = napi_unwrap(Env, (napi_value)thisValue, out nint result);
+
+        if (status == napi_status.napi_invalid_arg && unwrapType != null)
+        {
+            throw new JSException(new JSError($"Failed to unwrap object of type '{unwrapType}'"));
+        }
+
+        status.ThrowIfFailed();
         return GCHandle.FromIntPtr(result).Target!;
     }
 


### PR DESCRIPTION
Fixing a few issues with building and running the SemanticKernel demo after recent changes:
 - Fix TS generator crash when a `ref` or `out` parameter is both generic and nullable.
 - Fix TS generator output for parameters of `Action<>` and `Func<>` delegates. Parameter names were omitted, but they are required in TypeScript.
 - Fix marshalling of nullable `CancellationToken` parameters.

Also this change will help with diagnosing another error that was reported with using SK APIs:
 - Add a type name parameter to the `Unwrap()` API to improve the error message when unwrapping fails.
