### PR TITLE
feat: add support for collection classes

### DIFF
--- a/src/NodeApi/Interop/JSRuntimeContext.cs
+++ b/src/NodeApi/Interop/JSRuntimeContext.cs
@@ -393,6 +393,21 @@ public sealed class JSRuntimeContext : IDisposable
             });
     }
 
+    public JSValue GetOrCreateCollectionWrapper<T>(
+        List<T> collection,
+        JSValue.From<T> toJS,
+        JSValue.To<T> fromJS)
+    {
+        return collection is JSArrayListClass<T> adapter ? adapter.Value :
+            GetOrCreateCollectionProxy(collection, () =>
+            {
+                JSProxy.Handler proxyHandler = _collectionProxyHandlerMap.GetOrAdd(
+                    typeof(IList<T>),
+                    (_) => CreateArrayProxyHandlerForList(toJS, fromJS));
+                return new JSProxy(new JSArray(), proxyHandler, collection);
+            });
+    }
+
 #if !NETFRAMEWORK
     public JSValue GetOrCreateCollectionWrapper<T>(
         IReadOnlySet<T> collection,


### PR DESCRIPTION
* allow getting and setting List
* allow getting ReadOnlyCollection

changes:
- Extracted checks for collection as methods (`IsSettableCollectionType` and `IsGettableCollectionType`) to allow adding more conditions when collections should be wrapped
- Created new extension of ListClass i.e. List<>
- added capability to wrap List<> in builders from and to JS

This PR is in relation to https://github.com/microsoft/node-api-dotnet/issues/124
I am still looking at adding support for, and will open more PRs if things go well.
- Getting and Setting Array
- Getting and Setting ArrayList