### PR TITLE
Marshal Tuple, ValueTuple, KeyValuePair

### DIFF
--- a/Docs/typescript.md
+++ b/Docs/typescript.md
@@ -26,17 +26,25 @@ generated automatically. Or, the generator tool is available separately via the
 | `string` | `string`              |
 
 ### Object types
-
-| C# Type                       | TypeScript Projection            |
-|-------------------------------|----------------------------------|
-| `class Example`               | `class Example`                  |
-| `struct Example`              | `class Example`                  |
-| `interface IExample`          | `interface IExample`             |
-| `delegate A Example(B value)` | `declare function Example(value: B): A` |
+| C# Type                       | TypeScript Projection |
+|-------------------------------|-----------------------|
+| `class Example`               | `class Example`       |
+| `struct Example`              | `class Example`       |
+| `interface IExample`          | `interface IExample`  |
 
 .NET property names and method names are automatically camel-cased when projected to JavaScript /
 TypeScript by a [C# node module](./node-module.md). Names are projected as-is (without any
 camel-casing) when [dynamically invoking .NET APIs from JavaScript](./dynamic-invoke).
+
+### Delegate types
+| C# Type                       | TypeScript Projection                   |
+|-------------------------------|-----------------------------------------|
+| `Action<T1, T2, ...>`         | `(arg1: T1, arg2: T2, ...) => void`     |
+| `Func<T1, T2, ... TResult>`   | `(arg1: T1, arg2: T2, ...) => TResult`  |
+| `Predicate<T>`                | `(value: T) => boolean`                 |
+| `delegate A Example(B value)` | `declare function Example(value: B): A` |
+
+Named delegate types are declared as TypeScript functions. Generic delegate types are inlined.
 
 ### Enums
 | C# Type                          | TypeScript Projection                |
@@ -71,21 +79,28 @@ for element access. Otherwise prefer collection interfaces (below) which are pas
 
 ### Collection types
 
-| C# Type                  | TypeScript Projection |
-|--------------------------|-----------------------|
-| `IEnumerable<T>`         | `Iterable<T>`         |
-| `IReadOnlyCollection<T>` | `ReadonlySet<T>`      |
-| `ICollection<T>`         | `Set<T>`              |
-| `IReadOnlySet<T>`        | `ReadonlySet<T>`      |
-| `ISet<T>`                | `Set<T>`              |
-| `IReadOnlyList<T>`       | `readonly T[]` (`ReadonlyArray<T>`) |
-| `IList<T>`               | `T[]` aka `Array<T>`  |
-| `IReadOnlyDictionary<T>` | `ReadonlyMap<T>`      |
-| `IDictionary<T>`         | `Map<T>`              |
+| C# Type                     | TypeScript Projection |
+|-----------------------------|-----------------------|
+| `IEnumerable<T>`            | `Iterable<T>`         |
+| `IReadOnlyCollection<T>`    | `ReadonlySet<T>`      |
+| `ICollection<T>`            | `Set<T>`              |
+| `IReadOnlySet<T>`           | `ReadonlySet<T>`      |
+| `ISet<T>`                   | `Set<T>`              |
+| `IReadOnlyList<T>`          | `readonly T[]` (`ReadonlyArray<T>`) |
+| `IList<T>`                  | `T[]` aka `Array<T>`  |
+| `IReadOnlyDictionary<T>`    | `ReadonlyMap<T>`      |
+| `IDictionary<T>`            | `Map<T>`              |
+| `KeyValuePair<TKey, TValue>`| `[TKey, TValue]`      |
+| `Tuple<T1, T2, ...>`        | `[T1, T2, ...]`       |
+| `ValueTuple<T1, T2, ...>`   | `[T1, T2, ...]`       |
 
 Collections exported from .NET use JavaScript proxies with .NET handlers to avoid copying items
 across the .NET/JS boundary. But this implementation detail does not affect the types visible to
 JavaScript code, e.g. a dictionary from .NET still satisfies `instanceof Map` in JS.
+
+`ValueTuple`s with named properties are still projected as JS arrays, not JS objects with named
+properties. So C# `(string A, int B)` becomes TypeScript `[string, number]`, not
+`{ A: string, B: number }`.
 
 ### Special types
 

--- a/src/NodeApi.DotNetHost/JSMarshaller.cs
+++ b/src/NodeApi.DotNetHost/JSMarshaller.cs
@@ -2083,7 +2083,6 @@ public class JSMarshaller
                                     nameof(BuildConvertToJSValueExpression)))),
                         typeof(JSValue)),
                 };
-                
             }
             else if (fromType == typeof(ValueTuple))
             {

--- a/test/TestCases/napi-dotnet/ComplexTypes.cs
+++ b/test/TestCases/napi-dotnet/ComplexTypes.cs
@@ -51,11 +51,20 @@ public static class ComplexTypes
     public static IDictionary<string, IList<ClassObject>> ObjectListDictionary { get; set; }
         = new Dictionary<string, IList<ClassObject>>();
 
-    public static Memory<uint> Slice(Memory<uint> array, int start, int length) => array.Slice(start, length);
+    public static Memory<uint> Slice(Memory<uint> array, int start, int length)
+        => array.Slice(start, length);
 
     public static TestEnum TestEnum { get; set; }
 
     public static DateTime Date { get; set; } = new DateTime(2023, 2, 1, 0, 0, 0, DateTimeKind.Utc);
+
+    public static KeyValuePair<string, int> Pair { get; set; }
+        = new KeyValuePair<string, int>("pair", 1);
+
+    public static Tuple<string, int> Tuple { get; set; }
+        = new Tuple<string, int>("tuple", 2);
+
+    public static (string Key, int Value) ValueTuple { get; set; } = (Key: "valueTuple", Value: 3);
 }
 
 /// <summary>

--- a/test/TestCases/napi-dotnet/complex_types.js
+++ b/test/TestCases/napi-dotnet/complex_types.js
@@ -173,6 +173,23 @@ assert.deepStrictEqual(dateValue, new Date("2023-02-01"));
 ComplexTypes.date = new Date("2024-03-02T11:00");
 assert.deepStrictEqual(ComplexTypes.date, new Date("2024-03-02T11:00"));
 
+// Tuples
+const pairValue = ComplexTypes.pair;
+assert(Array.isArray(pairValue));
+assert.deepStrictEqual(pairValue, ['pair', 1]);
+ComplexTypes.pair = ['pair', -1];
+assert.deepStrictEqual(ComplexTypes.pair, ['pair', -1]);
+const tupleValue = ComplexTypes.tuple;
+assert(Array.isArray(tupleValue));
+assert.deepStrictEqual(tupleValue, ['tuple', 2]);
+ComplexTypes.tuple = ['tuple', -2];
+assert.deepStrictEqual(ComplexTypes.tuple, ['tuple', -2]);
+const valueTupleValue = ComplexTypes.valueTuple;
+assert(Array.isArray(valueTupleValue));
+assert.deepStrictEqual(valueTupleValue, ['valueTuple', 3]);
+ComplexTypes.valueTuple = ['valueTuple', -3];
+assert.deepStrictEqual(ComplexTypes.valueTuple, ['valueTuple', -3]);
+
 // Ref / out parameters
 const results = classInstance.appendAndGetPreviousValue('!');
 assert.strictEqual('object', typeof results);


### PR DESCRIPTION
Fixes: #60 

I chose to project .NET tuples as JS arrays rather than JS objects for two reasons:
 - [TypeScript uses the term "tuple"](https://www.typescriptlang.org/docs/handbook/2/objects.html#tuple-types) to refer to "an array type that knows exactly how many elements it contains and exactly which types it contains at specific positions".
 - JavaScript core APIs such as [`Object.entries()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/entries) use array tuples, not objects, for key-value pairs.

For consistency, `ValueTuple`s with named properties are still projected as JS arrays, not JS objects with named properties. So C# `(string A, int B)` becomes TypeScript `[string, number]`, not `{ A: string, B: number }`.

This change also adds support for the `Predicate<T>` generic delegate, which is commonly used in public APIs. I forgot to include along with `Action<>` and `Func<>` delegate support added recently.