### PR TITLE
Simplify native calls

### DIFF
--- a/src/NodeApi/Interop/EmptyAttributes.cs
+++ b/src/NodeApi/Interop/EmptyAttributes.cs
@@ -40,7 +40,7 @@ namespace Microsoft.JavaScript.NodeApi
     public sealed class UnmanagedCallersOnlyAttribute : Attribute
     {
         public UnmanagedCallersOnlyAttribute() { }
-        public Type[]? CallConvs { get; set; }
+        public Type[]? CallConvs;
     }
 }
 

--- a/src/NodeApi/Native/JSNativeApi.Interop.cs
+++ b/src/NodeApi/Native/JSNativeApi.Interop.cs
@@ -606,6 +606,10 @@ public static partial class JSNativeApi
                 // js_native_api.h APIs
                 //----------------------------------------------------------------------------------
 
+                // Use explicit delegate types to make sure that we use a delegate with CDecl
+                // calling conventions and to avoid runtime error when calling
+                // Marshal.GetFunctionPointerForDelegate because it cannot accept generic
+                // delegate types.
                 napi_add_finalizer = (delegate* unmanaged[Cdecl]<
                     napi_env, napi_value, nint, napi_finalize, nint, nint, napi_status>)
                     GetFunctionPointerForDelegateAndRootIt<DelegateTypes.napi_add_finalizer>(

--- a/src/NodeApi/Native/JSNativeApi.Interop.cs
+++ b/src/NodeApi/Native/JSNativeApi.Interop.cs
@@ -9,10 +9,6 @@ using System.Runtime.InteropServices;
 using System.Security;
 using System.Text;
 
-#if NET7_0_OR_GREATER
-[assembly: DisableRuntimeMarshalling]
-#endif
-
 namespace Microsoft.JavaScript.NodeApi;
 
 public static partial class JSNativeApi

--- a/src/NodeApi/Native/JSNativeApi.NodeApiInterop.cs
+++ b/src/NodeApi/Native/JSNativeApi.NodeApiInterop.cs
@@ -358,10 +358,10 @@ public static partial class JSNativeApi
             nint data,
             napi_threadsafe_function_call_mode is_blocking)
             => s_funcs.napi_call_threadsafe_function(func, data, is_blocking);
-        
+
         internal static napi_status napi_acquire_threadsafe_function(napi_threadsafe_function func)
             => s_funcs.napi_acquire_threadsafe_function(func);
-        
+
         internal static napi_status napi_release_threadsafe_function(
             napi_threadsafe_function func,
             napi_threadsafe_function_release_mode mode)
@@ -370,7 +370,7 @@ public static partial class JSNativeApi
         internal static napi_status napi_unref_threadsafe_function(
             napi_env env, napi_threadsafe_function func)
             => s_funcs.napi_unref_threadsafe_function(env, func);
-        
+
         internal static napi_status napi_ref_threadsafe_function(
             napi_env env, napi_threadsafe_function func)
             => s_funcs.napi_ref_threadsafe_function(env, func);
@@ -382,10 +382,10 @@ public static partial class JSNativeApi
             out napi_async_cleanup_hook_handle remove_handle)
         {
             remove_handle = default;
-            fixed(napi_async_cleanup_hook_handle* remove_handle_ptr = &remove_handle)
+            fixed (napi_async_cleanup_hook_handle* remove_handle_ptr = &remove_handle)
             {
                 return s_funcs.napi_add_async_cleanup_hook(
-                    env, hook, arg, (nint) remove_handle_ptr);
+                    env, hook, arg, (nint)remove_handle_ptr);
             }
         }
 


### PR DESCRIPTION
In the current code each native call checks if function is loaded and loads it on demand.
It makes each call to do extra check.
In this PR we simplify each call:
- During initialization we assign to each native pointer a special delay load stub.
- The delay load stub loads the function and assigns its pointer to the function pointer field.
- All other calls through the function pointer are going to call directly the native functions.