### PR TITLE
Generic interface method callbacks

### DIFF
--- a/examples/semantic-kernel/example.js
+++ b/examples/semantic-kernel/example.js
@@ -1,17 +1,33 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { SK, SKOpenAI } from './semantic-kernel.js';
+// @ts-check
 
-const kernel = SK.Kernel.Builder.Build();
+import { SK, SKOpenAI, Logging } from './semantic-kernel.js';
+const LogLevel = Logging.LogLevel;
+
+/** @type {import('./bin/Microsoft.Extensions.Logging.Abstractions').ILogger} */
+const logger = {
+  Log(logLevel, eventId, state, exception, formatter) {
+    console.log(`LOG (${LogLevel[logLevel]}): ${formatter(state, exception)}`);
+  },
+
+  IsEnabled(logLevel) { return true; },
+
+  BeginScope(state) { return { dispose() { } }; },
+};
+
+const kernel = SK.Kernel.Builder
+  .WithLogger(logger)
+  .Build();
 
 // The JS marshaller does not yet support extension methods.
 SKOpenAI.KernelConfigOpenAIExtensions.AddAzureTextCompletionService(
   kernel.Config,
   'davinci-azure',
-  process.env['OPENAI_DEPLOYMENT'],
-  process.env['OPENAI_ENDPOINT'],
-  process.env['OPENAI_KEY'],
+  process.env['OPENAI_DEPLOYMENT'] || '',
+  process.env['OPENAI_ENDPOINT'] || '',
+  process.env['OPENAI_KEY'] || '',
 );
 
 const skPrompt = `

--- a/examples/semantic-kernel/semantic-kernel.js
+++ b/examples/semantic-kernel/semantic-kernel.js
@@ -9,6 +9,7 @@ import dotnet from 'node-api-dotnet';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
+const loggingAssemblyName = 'Microsoft.Extensions.Logging.Abstractions';
 const skAssemblyName = 'Microsoft.SemanticKernel.Core';
 const skOpenAIAssemblyName = 'Microsoft.SemanticKernel.Connectors.AI.OpenAI';
 
@@ -26,5 +27,7 @@ dotnet.addListener('resolving', (name, version) => {
 const SK = dotnet.load(resolveAssembly(skAssemblyName));
 /** @type import('./bin/Microsoft.SemanticKernel.Connectors.AI.OpenAI') */
 const SKOpenAI = dotnet.load(resolveAssembly(skOpenAIAssemblyName));
+/** @type import('./bin/Microsoft.Extensions.Logging.Abstractions') */
+const Logging = dotnet.load(resolveAssembly(loggingAssemblyName));
 
-export { SK, SKOpenAI };
+export { SK, SKOpenAI, Logging };

--- a/src/NodeApi.DotNetHost/JSMarshaller.cs
+++ b/src/NodeApi.DotNetHost/JSMarshaller.cs
@@ -2924,7 +2924,11 @@ public class JSMarshaller
 
         if (parameter.GetCustomAttribute<OutAttribute>() is not null)
         {
-            parameterType = parameterType.MakeByRefType();
+            if (!parameterType.IsByRef)
+            {
+                parameterType = parameterType.MakeByRefType();
+            }
+
             if (parameter.GetCustomAttribute<InAttribute>() is null)
             {
                 // ParameterExpression doesn't distinguish between ref and out parameters,

--- a/src/NodeApi.DotNetHost/JSMarshaller.cs
+++ b/src/NodeApi.DotNetHost/JSMarshaller.cs
@@ -42,12 +42,23 @@ public class JSMarshaller
     /// </summary>
     public const string ResultPropertyName = "result";
 
+    [ThreadStatic]
+    private static JSMarshaller? s_current;
+
+    public static JSMarshaller Current
+    {
+        get => s_current ??
+            throw new InvalidOperationException("No current JSMarshaller instance.");
+        internal set => s_current = value;
+    }
+
     private readonly Lazy<JSInterfaceMarshaller> _interfaceMarshaller = new();
 
     private readonly ConcurrentDictionary<Type, Delegate> _fromJSDelegates = new();
     private readonly ConcurrentDictionary<Type, Delegate> _toJSDelegates = new();
     private readonly ConcurrentDictionary<Type, LambdaExpression> _fromJSExpressions = new();
     private readonly ConcurrentDictionary<Type, LambdaExpression> _toJSExpressions = new();
+    private readonly ConcurrentDictionary<MethodInfo, Delegate> _jsMethodDelegates = new();
 
     private static readonly ParameterExpression s_argsParameter =
         Expression.Parameter(typeof(JSCallbackArgs), "__args");
@@ -210,6 +221,24 @@ public class JSMarshaller
     }
 
     /// <summary>
+    /// Gets a delegate for a .NET adapter to a JS method. When invoked, the adapter will
+    /// marshal the arguments to JS, invoke the JS method, then marshal the return value
+    /// (or exception) back to .NET.
+    /// </summary>
+    /// <remarks>
+    /// The delegate has an extra initial argument of type <see cref="JSValue"/> that is
+    /// the JS object on which the method will be invoked.
+    /// </remarks>
+    public Delegate GetToJSMethodDelegate(MethodInfo method)
+    {
+        return _jsMethodDelegates.GetOrAdd(method, (method) =>
+        {
+            LambdaExpression jsMethodExpression = BuildToJSMethodExpression(method);
+            return jsMethodExpression.Compile();
+        });
+    }
+
+    /// <summary>
     /// Gets a lambda expression that converts from a JS value to a specified type.
     /// </summary>
     /// <param name="toType">The type the value will be converted to.</param>
@@ -346,6 +375,8 @@ public class JSMarshaller
     public Expression<JSCallback> BuildFromJSMethodExpression(MethodInfo method)
     {
         if (method is null) throw new ArgumentNullException(nameof(method));
+        else if (method.IsGenericMethodDefinition) throw new ArgumentException(
+            "Construct a generic method definition from the method first.", nameof(method));
 
         try
         {
@@ -436,6 +467,8 @@ public class JSMarshaller
     public LambdaExpression BuildToJSMethodExpression(MethodInfo method)
     {
         if (method is null) throw new ArgumentNullException(nameof(method));
+        else if (method.IsGenericMethodDefinition) throw new ArgumentException(
+            "Construct a generic method definition from the method first.", nameof(method));
 
         try
         {
@@ -467,8 +500,12 @@ public class JSMarshaller
              * }
              */
 
+            // If the method is an explicit interface implementation, parse off the simple name.
+            // Then convert to JSValue for use as a JS property name.
+            int dotIndex = method.Name.LastIndexOf('.');
             Expression methodName = Expression.Convert(
-                Expression.Constant(ToCamelCase(method.Name)),
+                Expression.Constant(ToCamelCase(
+                    dotIndex >= 0 ? method.Name.Substring(dotIndex + 1) : method.Name)),
                 typeof(JSValue),
                 typeof(JSValue).GetImplicitConversion(typeof(string), typeof(JSValue)));
 
@@ -604,8 +641,12 @@ public class JSMarshaller
     /// the JS function that will be invoked. The lambda expression may be converted to a
     /// delegate with <see cref="LambdaExpression.Compile()"/>.
     /// </remarks>
-    public LambdaExpression BuildToJSDelegateMethodExpression(MethodInfo method)
+    public LambdaExpression BuildToJSFunctionExpression(MethodInfo method)
     {
+        if (method is null) throw new ArgumentNullException(nameof(method));
+        else if (method.IsGenericMethodDefinition) throw new ArgumentException(
+            "Construct a generic method definition from the method first.", nameof(method));
+
         try
         {
             ParameterInfo[] methodParameters = method.GetParameters();
@@ -729,7 +770,7 @@ public class JSMarshaller
     /// the delegate that will be invoked. The lambda expression may be converted to a
     /// delegate with <see cref="LambdaExpression.Compile()"/>.
     /// </remarks>
-    public LambdaExpression BuildFromJSDelegateMethodExpression(MethodInfo method)
+    public LambdaExpression BuildFromJSFunctionExpression(MethodInfo method)
     {
         try
         {
@@ -787,10 +828,10 @@ public class JSMarshaller
         }
     }
 
-    private LambdaExpression BuildToJSDelegateExpression(Type delegateType)
+    private LambdaExpression BuildToJSFunctionExpression(Type delegateType)
     {
         MethodInfo invokeMethod = delegateType.GetMethod(nameof(Action.Invoke))!;
-        LambdaExpression methodExpression = BuildToJSDelegateMethodExpression(invokeMethod);
+        LambdaExpression methodExpression = BuildToJSFunctionExpression(invokeMethod);
 
         // When invoking a JS function via a .NET delegate, use the synchronization context
         // to ensure the call is made on the JS thread. Ordinary method calls from .NET to
@@ -862,10 +903,10 @@ public class JSMarshaller
             new[] { valueParameter });
     }
 
-    private LambdaExpression BuildFromJSDelegateExpression(Type delegateType)
+    private LambdaExpression BuildFromJSFunctionExpression(Type delegateType)
     {
         MethodInfo invokeMethod = delegateType.GetMethod(nameof(Action.Invoke))!;
-        LambdaExpression methodExpression = BuildFromJSDelegateMethodExpression(invokeMethod);
+        LambdaExpression methodExpression = BuildFromJSFunctionExpression(invokeMethod);
 
         /*
          * JSValue.CreateFunction(name, (__args) => __value.Invoke(...args));
@@ -1762,6 +1803,19 @@ public class JSMarshaller
         {
             statements = new[] { valueParameter };
         }
+        else if (toType == typeof(object) || !toType.IsPublic)
+        {
+            // Marshal unknown or nonpublic type as external, so at least it can be round-tripped.
+            MethodInfo getExternalMethod =
+                typeof(JSNativeApi).GetStaticMethod(nameof(JSNativeApi.GetValueExternal));
+            statements = new[]
+            {
+                Expression.Condition(
+                    Expression.Call(s_isNullOrUndefined, valueParameter),
+                    Expression.Default(toType),
+                    Expression.Convert(Expression.Call(getExternalMethod, valueParameter), toType)),
+            };
+        }
         else if (toType.IsEnum)
         {
             // Cast the JSValue to the enum underlying type, then to the enum type.
@@ -1898,7 +1952,7 @@ public class JSMarshaller
                 statements = new[]
                 {
                     Expression.Invoke(
-                        BuildToJSDelegateExpression(toType),
+                        BuildToJSFunctionExpression(toType),
                         valueParameter),
                 };
             }
@@ -2017,6 +2071,18 @@ public class JSMarshaller
         else if (fromType == typeof(JSValue))
         {
             statements = new[] { valueParameter };
+        }
+        else if (fromType == typeof(object) || !fromType.IsPublic)
+        {
+            // Marshal unknown or nonpublic type as external, so at least it can be round-tripped.
+            Expression objectExpression = fromType.IsValueType ?
+                Expression.Convert(valueExpression, typeof(object)) : valueExpression;
+            MethodInfo createExternalMethod =
+                typeof(JSValue).GetStaticMethod(nameof(JSValue.CreateExternal));
+            statements = new[]
+            {
+                Expression.Call(createExternalMethod, objectExpression),
+            };
         }
         else if (fromType.IsEnum)
         {
@@ -2148,7 +2214,7 @@ public class JSMarshaller
                 statements = new[]
                 {
                     Expression.Invoke(
-                        BuildFromJSDelegateExpression(fromType),
+                        BuildFromJSFunctionExpression(fromType),
                         valueParameter),
                 };
             }
@@ -2867,6 +2933,11 @@ public class JSMarshaller
             }
         }
 
+        if (parameterType.IsGenericTypeDefinition || parameterType.IsGenericParameter)
+        {
+            parameterType = typeof(object);
+        }
+
         return Expression.Parameter(parameterType, parameterName);
     }
 
@@ -2887,7 +2958,7 @@ public class JSMarshaller
     }
 
     /// <summary>
-    /// If the lambda expresion consists of a single statement, the statement expression is returned
+    /// If the lambda expression consists of a single statement, the statement expression is returned
     /// directly, with the "value" parameter replaced with the target expression. Otherwise,
     /// an invocation expression for the lambda is returned.
     /// </summary>

--- a/src/NodeApi.DotNetHost/JSRuntimeContextExtensions.cs
+++ b/src/NodeApi.DotNetHost/JSRuntimeContextExtensions.cs
@@ -13,12 +13,6 @@ namespace Microsoft.JavaScript.NodeApi.DotNetHost;
 public static class JSRuntimeContextExtensions
 {
     /// <summary>
-    /// The marshaller instance can be static because it does not hold any JS values,
-    /// only expressions and delegates generated from reflection.
-    /// </summary>
-    private static readonly JSMarshaller s_marshaller = new();
-
-    /// <summary>
     /// Imports a module or module property from JavaScript and converts it to an interface.
     /// </summary>
     /// <typeparam name="T">Type of the value being imported.</typeparam>
@@ -36,7 +30,7 @@ public static class JSRuntimeContextExtensions
         string? property)
     {
         JSValue jsValue = runtimeContext.Import(module, property);
-        return s_marshaller.To<T>(jsValue);
+        return JSMarshaller.Current.To<T>(jsValue);
     }
 
     /// <summary>

--- a/src/NodeApi.Generator/ExpressionExtensions.cs
+++ b/src/NodeApi.Generator/ExpressionExtensions.cs
@@ -295,6 +295,10 @@ internal static class ExpressionExtensions
         {
             return "(anonymous)";
         }
+        else if (type.IsGenericParameter)
+        {
+            return type.Name;
+        }
         else if (type.IsGenericType)
         {
             if (type.GetGenericTypeDefinition() == typeof(Nullable<>))

--- a/src/NodeApi/JSError.cs
+++ b/src/NodeApi/JSError.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
@@ -235,12 +236,15 @@ public struct JSError
     {
         // Do not construct a JSError object here, because that would require a runtime context.
 
-        // If the exception is a JSException for an error value, throw that error value;
-        // otherwise consturct a new error value from the exception message.
-        JSValue error = (exception as JSException)?.Error?.Value ??
-            JSValue.CreateError(code: null, (JSValue)exception.Message);
+        string message = (exception as TargetInvocationException)?.InnerException?.Message
+            ?? exception.Message;
 
-        // When running on V8, the `Error.catpureStackTrace()` function and `Error.stack` property
+        // If the exception is a JSException for an error value, throw that error value;
+        // otherwise construct a new error value from the exception message.
+        JSValue error = (exception as JSException)?.Error?.Value ??
+            JSValue.CreateError(code: null, (JSValue)message);
+
+        // When running on V8, the `Error.captureStackTrace()` function and `Error.stack` property
         // can be used to add the .NET stack info to the JS error stack.
         JSValue captureStackTrace = JSValue.Global["Error"]["captureStackTrace"];
         if (captureStackTrace.IsFunction())

--- a/src/NodeApi/JSError.cs
+++ b/src/NodeApi/JSError.cs
@@ -131,12 +131,6 @@ public struct JSError
 
     public JSError(Exception exception)
     {
-#if DEBUG
-        // .NET exception stack traces are not yet propagated to JS.
-        // For now, write the stack trace to stdout in debug builds.
-        Console.WriteLine(exception);
-#endif
-
         if (exception is JSException jsException)
         {
             JSError? error = jsException.Error;
@@ -251,7 +245,7 @@ public struct JSError
         {
             // Capture the stack trace of the .NET exception, which will be combined with
             // the JS stack trace when requested.
-            JSValue dotnetStack = exception.StackTrace ?? string.Empty;
+            JSValue dotnetStack = exception.StackTrace?.Replace("\r", string.Empty) ?? string.Empty;
 
             // Capture the current JS stack trace as an object.
             // Defer formatting the stack as a string until requested.

--- a/test/HostedClrTests.cs
+++ b/test/HostedClrTests.cs
@@ -37,7 +37,7 @@ public class HostedClrTests
 
         string hostFilePath = s_builtHostModule.Value;
 
-        string buildLogFilePath = GetBuildLogFilePath(moduleName);
+        string buildLogFilePath = GetBuildLogFilePath("hosted", moduleName);
         if (!s_builtTestModules.TryGetValue(moduleName, out string? moduleFilePath))
         {
             moduleFilePath = BuildTestModuleCSharp(moduleName, buildLogFilePath);

--- a/test/HostedClrTests.cs
+++ b/test/HostedClrTests.cs
@@ -40,14 +40,21 @@ public class HostedClrTests
         string buildLogFilePath = GetBuildLogFilePath("hosted", moduleName);
         if (!s_builtTestModules.TryGetValue(moduleName, out string? moduleFilePath))
         {
-            moduleFilePath = BuildTestModuleCSharp(moduleName, buildLogFilePath);
+            try
+            {
+                moduleFilePath = BuildTestModuleCSharp(moduleName, buildLogFilePath);
+            }
+            finally
+            {
+                // Save the built module path for the other tests that use the same module.
+                // Or if the build failed, save null so the next test won't try to build again.
+                s_builtTestModules.Add(moduleName, moduleFilePath);
+            }
 
             if (moduleFilePath != null)
             {
                 BuildTestModuleTypeScript(moduleName);
             }
-
-            s_builtTestModules.Add(moduleName, moduleFilePath);
         }
 
         if (moduleFilePath == null)

--- a/test/NativeAotTests.cs
+++ b/test/NativeAotTests.cs
@@ -68,6 +68,7 @@ public class NativeAotTests
             ["TargetFramework"] = GetCurrentFrameworkTarget(),
             ["RuntimeIdentifier"] = GetCurrentPlatformRuntimeIdentifier(),
             ["Configuration"] = Configuration,
+            ["DefineConstants"] = "AOT",
         };
 
         BuildProject(

--- a/test/NativeAotTests.cs
+++ b/test/NativeAotTests.cs
@@ -29,7 +29,7 @@ public class NativeAotTests
         string testCaseName = id.Substring(id.IndexOf('/') + 1);
         string testCasePath = testCaseName.Replace('/', Path.DirectorySeparatorChar);
 
-        string buildLogFilePath = GetBuildLogFilePath(moduleName);
+        string buildLogFilePath = GetBuildLogFilePath("aot", moduleName);
         if (!s_builtTestModules.TryGetValue(moduleName, out string? moduleFilePath))
         {
             moduleFilePath = BuildTestModuleCSharp(moduleName, buildLogFilePath);

--- a/test/NativeAotTests.cs
+++ b/test/NativeAotTests.cs
@@ -32,14 +32,21 @@ public class NativeAotTests
         string buildLogFilePath = GetBuildLogFilePath("aot", moduleName);
         if (!s_builtTestModules.TryGetValue(moduleName, out string? moduleFilePath))
         {
-            moduleFilePath = BuildTestModuleCSharp(moduleName, buildLogFilePath);
+            try
+            {
+                moduleFilePath = BuildTestModuleCSharp(moduleName, buildLogFilePath);
+            }
+            finally
+            {
+                // Save the built module path for the other tests that use the same module.
+                // Or if the build failed, save null so the next test won't try to build again.
+                s_builtTestModules.Add(moduleName, moduleFilePath);
+            }
 
             if (moduleFilePath != null)
             {
                 BuildTestModuleTypeScript(moduleName);
             }
-
-            s_builtTestModules.Add(moduleName, moduleFilePath);
         }
 
         if (moduleFilePath == null)

--- a/test/TestBuilder.cs
+++ b/test/TestBuilder.cs
@@ -104,10 +104,10 @@ internal static class TestBuilder
         return directoryPath;
     }
 
-    public static string GetBuildLogFilePath(string moduleName)
+    public static string GetBuildLogFilePath(string prefix, string moduleName)
     {
         string logDir = GetModuleIntermediateOutputPath(moduleName);
-        return Path.Combine(logDir, "build.log");
+        return Path.Combine(logDir, prefix + "-build.log");
     }
 
     public static string GetRunLogFilePath(string prefix, string moduleName, string testCasePath)

--- a/test/TestCases/napi-dotnet/ComplexTypes.cs
+++ b/test/TestCases/napi-dotnet/ComplexTypes.cs
@@ -88,9 +88,13 @@ public interface ITestInterface
 {
     string? Value { get; set; }
 
-    string? AppendValue(string append);
+    string AppendValue(string append);
 
     void AppendAndGetPreviousValue(ref string value, out string? previousValue);
+
+#if !AOT
+    string AppendGenericValue<T>(T value);
+#endif
 }
 
 /// <summary>
@@ -101,10 +105,10 @@ public class ClassObject : ITestInterface
 {
     public string? Value { get; set; }
 
-    public string? AppendValue(string append)
+    public string AppendValue(string append)
     {
         Value = (Value ?? "") + append;
-        return Value;
+        return Value!;
     }
 
     public void AppendAndGetPreviousValue(ref string value, out string? previousValue)
@@ -123,6 +127,19 @@ public class ClassObject : ITestInterface
     public static string? StaticValue { get; set; }
 
     public ClassObject ThisObject() => this;
+
+#if !AOT
+    public string AppendGenericValue<T>(T value)
+    {
+        Value = (Value ?? "") + value?.ToString();
+        return Value!;
+    }
+
+    public static void CallGenericMethod(ITestInterface obj, int value)
+    {
+        obj.AppendGenericValue<int>(value);
+    }
+#endif
 }
 
 [JSExport]

--- a/test/TestCases/napi-dotnet/complex_types.js
+++ b/test/TestCases/napi-dotnet/complex_types.js
@@ -195,3 +195,15 @@ const results = classInstance.appendAndGetPreviousValue('!');
 assert.strictEqual('object', typeof results);
 assert.strictEqual('test2!', results.value);
 assert.strictEqual('test2', results.previousValue);
+
+if (ClassObject.callGenericMethod) {
+  console.log('Calling generic method on interface implemented by JS.')
+  let appendedValue = undefined;
+  ClassObject.callGenericMethod({
+    // TODO: This method should be camel-case... probably?
+    AppendGenericValue(value) { appendedValue = value; }
+  }, 10);
+  assert.strictEqual(appendedValue, 10);
+} else {
+  console.log('Skipping generic method on interface implemented by JS.')
+}


### PR DESCRIPTION
This change enables JS to implement .NET interfaces that include _generic methods_, which can then be called by .NET with arbitrary generic type arguments. A primary motivation is to support the [`Microsoft.Extensions.Logging.ILogger` interface](https://learn.microsoft.com/en-us/dotnet/api/microsoft.extensions.logging.ilogger.log) that is used by the `SemanticKernel` example.

 - Add a `JSMarshaller.Current` property. It can be used by code that needs to do dynamic marshalling to get the current marshaller instance (with appropriate settings and caches).
    - Unfortunately the current marshaller instance cannot be a property on `JSRuntimeContext` because of assembly separation. (Maybe it should be an extension method on that class?)
    - `ManagedHost`, `JSInterfaceMarshaller`, and `JSRuntimeContextExtensions` are updated to reference this property.
 - Rename a few `JSMarshaller` methods for greater clarity.
 - Add support for generic methods and parameters in `SymbolExtensions` when converting from method symbols and type symbols to methods and types.
 - Make small updates in a few other areas of the marshalling code to support generic type parameters.
 - Add support for generic interface methods in `JSInterfaceMarshaller`
 - Marshal unknown (`object`) or nonpublic types as JS "external" values. They cannot be used from JS, but at least they can be round-tripped back to .NET. (We can consider doing something a little better later.)
 - Get actual exception message from `TargetInvocationException` which may be thrown from dynamic delegate invocations.
 - Add a test case for a generic interface method implemented by JS. It is skipped for AOT testing because AOT cannot support that kind of dynamic marshalling.
 - Update `examples/SemanticKernel` to implement `ILogger`.

There is still a lot more to do to enable [full generics marshalling](#67), but this is a small piece of it.