### PR TITLE
Fix regression when passing value as `object` type

### DIFF
--- a/src/NodeApi.DotNetHost/JSMarshaller.cs
+++ b/src/NodeApi.DotNetHost/JSMarshaller.cs
@@ -1803,7 +1803,7 @@ public class JSMarshaller
         {
             statements = new[] { valueParameter };
         }
-        else if (toType == typeof(object) || !toType.IsPublic)
+        else if (toType == typeof(object) || !(toType.IsPublic || toType.IsNestedPublic))
         {
             // Marshal unknown or nonpublic type as external, so at least it can be round-tripped.
             // Also accept a wrapped value - this handles the case when an instance of a specific


### PR DESCRIPTION
This fixes a regression when working with APIs such as `IKernel.ImportSkill(object)`.

If a .NET property or method takes an `object` type, it should accept _either_ a .NET object wrapped as a JS value or a JS external value. (The latter is used for .NET objects of unknown or non-public types.)

Also check for `IsNestedPublic` when deciding whether to marshal as external. Oddly, nested types have `IsPublic=false` and `IsNestedPublic=true`. There is more work still to fully [support nested types](#133), but this may unblock some scenarios.