### PR TITLE
Generics marshalling

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -38,6 +38,12 @@
 
   <ItemGroup>
     <PackageReference Include="Nerdbank.GitVersioning" PrivateAssets="all" />
+    <!-- All projects need to be rebuilt if the version changes. -->
+    <Content Include="$(MSBuildThisFileDirectory)version.json" Link="version.json">
+      <CopyToOutputDirectory>DoNotCopy</CopyToOutputDirectory>
+      <Visible>false</Visible><!-- Hide from VS solution explorer -->
+      <Pack>false</Pack> <!--Exclude from NuGet packages -->
+    </Content>
   </ItemGroup>
 
   <Import Project="./rid.props" />

--- a/Docs/dynamic-invoke.md
+++ b/Docs/dynamic-invoke.md
@@ -12,9 +12,10 @@ For examples of this scenario, see
        <TargetFramework>net6.0</TargetFramework>
        <OutDir>bin</OutDir>
        <NodeApiAssemblyJSModuleType>commonjs</NodeApiAssemblyJSModuleType>
+       <GenerateNodeApiTypeDefinitionsForReferences>true</GenerateNodeApiTypeDefinitionsForReferences>
      </PropertyGroup>
      <ItemGroup>
-       <PackageReference Include="Microsoft.JavaScript.NodeApi.Generator" Version="0.2.*" />
+       <PackageReference Include="Microsoft.JavaScript.NodeApi.Generator" Version="0.4.*" />
        <PackageReference Include="Example.Package" Version="1.2.3" />
        <PackageReference Include="Example.Package.Two" Version="2.3.4" />
      </ItemGroup>

--- a/Docs/generics.md
+++ b/Docs/generics.md
@@ -1,0 +1,60 @@
+# Using .NET Generics in JavaScript
+The JavaScript runtime type system lacks generics, so .NET generic types and methods are projected
+into JavaScript using a special convention. The projections are suffixed with the dollar (`$`)
+character, chosen because it is a valid identifier charater in JavaScript but not in C#, and
+because it looks like an operator.
+
+Note while TypeScript does have generics, they are merely a compile-time facade and do not have
+any effect on runtime binding or execution. So it is unfortunately not possible in most cases
+to directly map .NET generics to TypeScript generics. (The exception is when [mapping .NET generic
+collection interfaces to TypeScript generic collections](./typescript.md#collection-types) like
+`Array<T>` and `Map<TKey, TValue>`, which does work.)
+
+```JavaScript
+// JavaScript
+import dotnet from 'node-api-dotnet';
+const System = dotnet.System;
+System.Enum.Parse$(System.DayOfWeek)('Tuesday'); // Call generic method
+System.Comparer$(System.DateTime).Create()       // Call static method on generic class
+const TaskCompletionSourceOfDate = System.TaskCompletionSource$(System.DateTime);
+new TaskCompletionSourceOfDate();                // Create instance of generic class
+new System.TaskCompletionSource();               // Create instance of non-generic class
+```
+
+A .NET _generic method definition_ is projected as a function with a `$` suffix. That function
+takes generic type parameter(s) and returns the _specialized_ generic function. So, .NET
+`Enum.Parse<T>()` is projected as `Enum.Parse$(Type)`.
+
+A .NET _generic type definition_ is also projected as a function with a `$` suffix. That function
+takes generic type parameter(s) and returns the _specialized_ generic type. So, .NET `Comparer<T>`
+is projected as `Comparer$(Type)`.
+
+If a type has both generic and non-generic variants, the non-generic type is still available
+normally, without any `$` suffix. If a type has multiple generic variants then the one `$` function
+returns the requested type specialization according to the number of type arguments supplied.
+
+## Getting a type full name
+Calling the `toString()` method on the JS projection of any generic type definition, specialized
+type, or non-generic type returns the full .NET type name. This may be helpful for diagnostics.
+
+```JavaScript
+// JavaScript
+System.Comparer$.toString();                  // 'System.Comparer<T>'
+System.Comparer$(System.DateTime).toString(); // 'System.Comparer<System.DateTime>
+System.String.toString();                     // 'System.String'
+```
+
+## Static binding / AOT
+The above applies to [dynamic binding](./dynamic-invoke.md), when the `node-api-dotnet` library
+can use reflection to locate generic type and method definitions, specialize them, and invoke them.
+But some of that is impossible to do in an ahead-of-time compiled environment. Dynamically
+specifying generic type arguments from JavaScript would require reflection and code-generation,
+whch are not supported in an AOT executable. (In a pure C# application, the AOT compiler would be
+able to know exactly what type arguments are used with any generic type or method, so it can
+generate specialized code accordingly.)
+
+This means that C# Node API modules compiled as AOT cannot export generic types or methods.
+They can still use generic types in properties or methods, when the type argument is specified
+ahead of time. For example it is OK to use AOT to export a method that has a parameter of type
+`KeyValuePair<string, int>`. But exporting a generic method with type parameter T and method
+parameter `KeyValuePair<string, T>` will not work with AOT.

--- a/Docs/typescript.md
+++ b/Docs/typescript.md
@@ -162,3 +162,8 @@ function GetAllResults(value: string):
 ```
 </td></tr>
 </table>
+
+### Generics
+.NET generic types other than those listed above, and generic methods, are projected to JavaScript
+in a way that the generic specializations can be accessed at runtime (unlike TypeScript generics
+which have no runtime representation). See [.NET Generics in JavaScript](./generics.md) for details.

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ For more examples, see the [examples](./examples/) directory.
  - [Stream across .NET and JS](#stream-across-net-and-js)
  - [Optional .NET native AOT compilation](#optional-net-native-aot-compilation)
  - [High performance](#high-performance)
+ - [Work with .NET generic APIs in JS](#generics)
 
 ### Load and call .NET assemblies from JS
 The `node-api-dotnet` package manages hosting the .NET runtime in the JS process
@@ -256,6 +257,17 @@ Techniques benefitting performance include:
 Thanks to these design choices, JS to .NET calls are [more than twice as fast](
     https://github.com/jasongin/napi-dotnet/pull/23) when compared to `edge-js` using
     [that project's benchmark](https://github.com/tjanczuk/edge/wiki/Performance).
+
+### Generics
+Even though the JavaScript runtime type system lacks generics, it is possible to work with .NET
+generic types and methods from JavaScript:
+
+```JavaScript
+// JavaScript
+System.Enum.Parse$(System.DayOfWeek)('Tuesday');
+```
+
+For details, see [Using .NET Generics in JavaScript](./docs/generics.md).
 
 ## Getting Started
 #### Requirements

--- a/examples/semantic-kernel/semantic-kernel.csproj
+++ b/examples/semantic-kernel/semantic-kernel.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SemanticKernel" Version="0.14.547.1-preview" />
-    <PackageReference Include="Microsoft.JavaScript.NodeApi.Generator" Version="0.2.*-*" />
+    <PackageReference Include="Microsoft.JavaScript.NodeApi.Generator" Version="0.4.*-*" />
   </ItemGroup>
 
 </Project>

--- a/src/NodeApi.DotNetHost/TypeExporter.cs
+++ b/src/NodeApi.DotNetHost/TypeExporter.cs
@@ -516,7 +516,7 @@ internal class TypeExporter
         return method.CallingConvention != CallingConventions.VarArgs &&
             method.Name != nameof(System.Collections.IEnumerable.GetEnumerator) &&
             method.GetParameters().All(IsSupportedParameter) &&
-            IsSupportedParameter(method.ReturnParameter);
+            (method.ReturnType == typeof(void) || IsSupportedParameter(method.ReturnParameter));
     }
 
     private static bool IsSupportedParameter(ParameterInfo parameter)

--- a/src/NodeApi.DotNetHost/TypeExporter.cs
+++ b/src/NodeApi.DotNetHost/TypeExporter.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Threading.Tasks;
+using System.Xml.Linq;
 using Microsoft.JavaScript.NodeApi.Interop;
 
 using static Microsoft.JavaScript.NodeApi.DotNetHost.ManagedHost;
@@ -42,61 +43,69 @@ internal class TypeExporter
     /// if the type could not be exported.</returns>
     public JSReference? TryExportType(Type type)
     {
-        // TODO: Handle generic types.
-
-        JSReference? valueReference;
         try
         {
-            if (!IsSupportedType(type))
-            {
-                Trace($"      Unsupported type: {type}");
-                return null;
-            }
-            else if (type.IsEnum)
-            {
-                valueReference = ExportEnum(type);
-            }
-            else if (type.IsClass || type.IsInterface || type.IsValueType)
-            {
-                if (type.IsClass && type.BaseType?.FullName == typeof(MulticastDelegate).FullName)
-                {
-                    // Delegate types are not exported as type objects, but the JS marshaller can
-                    // still dynamically convert delegate instances to/from JS functions.
-                    Trace($"      Delegate types are not exported.");
-                    return null;
-                }
-                else
-                {
-                    valueReference = ExportClass(type);
-                }
-            }
-            else
-            {
-                Trace($"      Unknown type kind: {type}");
-                return null;
-            }
+            return ExportType(type);
+        }
+        catch (NotSupportedException ex)
+        {
+            Trace($"Cannot export type {type}: {ex}");
+            return null;
         }
         catch (Exception ex)
         {
             Trace($"Failed to export type {type}: {ex}");
             return null;
         }
-
-        return valueReference;
     }
 
-    private JSReference? ExportClass(Type type)
+    private JSReference ExportType(Type type)
+    {
+        if (!IsSupportedType(type))
+        {
+            throw new NotSupportedException("The type is not supported for JS export.");
+        }
+        else if (type.IsEnum)
+        {
+            return ExportEnum(type);
+        }
+        else if (type.IsGenericTypeDefinition)
+        {
+            return ExportGenericTypeDefinition(type);
+        }
+        else if (type.IsClass || type.IsInterface || type.IsValueType)
+        {
+            if (type.IsClass && type.BaseType?.FullName == typeof(MulticastDelegate).FullName)
+            {
+                // Delegate types are not exported as type objects, but the JS marshaller can
+                // still dynamically convert delegate instances to/from JS functions.
+                throw new NotSupportedException("Delegate types are not exported.");
+            }
+            else
+            {
+                return ExportClass(type);
+            }
+        }
+        else
+        {
+            throw new NotSupportedException("Unknown type kind.");
+        }
+    }
+
+    private JSReference ExportClass(Type type)
     {
         if (_exportedTypes.TryGetValue(type, out JSReference? classObjectReference))
         {
             return classObjectReference;
         }
 
+        /*
         if (type == typeof(object) || type == typeof(string) ||
             type == typeof(void) || type.IsPrimitive)
         {
-            return default;
+            throw new NotSupportedException($"Cannot export primitive type.");
         }
+        */
 
         Trace($"> {nameof(TypeExporter)}.ExportClass({type.FullName})");
 
@@ -337,30 +346,20 @@ internal class TypeExporter
                 continue;
             }
 
-            JSCallbackDescriptor methodDescriptor;
-            if (methods.Length == 1 &&
-                !methods[0].GetParameters().Any((p) => p.IsOptional))
+            if (methods.Any((m) => m.IsGenericMethodDefinition))
             {
-                MethodInfo method = methods[0];
-                Trace($"    {(methodIsStatic ? "static " : string.Empty)}{methodName}(" +
-                    string.Join(", ", method.GetParameters().Select((p) => p.ParameterType)) + ")");
+                MethodInfo[] genericMethods = methods.Where(
+                    (m) => m.IsGenericMethodDefinition).ToArray();
+                ExportGenericMethodDefinition(classBuilder, genericMethods);
 
-                methodDescriptor = _marshaller.BuildFromJSMethodExpression(method).Compile();
-            }
-            else
-            {
-                // Set up overload resolution for multiple methods or optional parmaeters.
-                Trace($"    {(methodIsStatic ? "static " : string.Empty)}{methodName}[" +
-                    methods.Length + "]");
-                foreach (MethodInfo method in methods)
+                methods = methods.Where((m) => !m.IsGenericMethodDefinition).ToArray();
+                if (methods.Length == 0)
                 {
-                    Trace($"        {methodName}(" + string.Join(
-                        ", ", method.GetParameters().Select((p) => p.ParameterType)) + ")");
-
+                    continue;
                 }
-
-                methodDescriptor = _marshaller.BuildMethodOverloadDescriptor(methods);
             }
+
+            JSCallbackDescriptor methodDescriptor = CreateMethodDescriptor(methods);
 
             addMethodMethod.Invoke(
                 classBuilder,
@@ -384,6 +383,35 @@ internal class TypeExporter
                         methodDescriptor.Data,
                     });
             }
+        }
+    }
+
+    private JSCallbackDescriptor CreateMethodDescriptor(MethodInfo[] methods)
+    {
+        string methodName = methods[0].Name;
+        bool methodIsStatic = methods[0].IsStatic;
+        if (methods.Length == 1 &&
+            !methods[0].GetParameters().Any((p) => p.IsOptional))
+        {
+            MethodInfo method = methods[0];
+            Trace($"    {(methodIsStatic ? "static " : string.Empty)}{methodName}(" +
+                string.Join(", ", method.GetParameters().Select((p) => p.ParameterType)) + ")");
+
+            return _marshaller.BuildFromJSMethodExpression(method).Compile();
+        }
+        else
+        {
+            // Set up overload resolution for multiple methods or optional parmaeters.
+            Trace($"    {(methodIsStatic ? "static " : string.Empty)}{methodName}[" +
+                methods.Length + "]");
+            foreach (MethodInfo method in methods)
+            {
+                Trace($"        {methodName}(" + string.Join(
+                    ", ", method.GetParameters().Select((p) => p.ParameterType)) + ")");
+
+            }
+
+            return _marshaller.BuildMethodOverloadDescriptor(methods);
         }
     }
 
@@ -447,7 +475,13 @@ internal class TypeExporter
 
     private static bool IsSupportedType(Type type)
     {
+        if (type.IsByRef)
+        {
+            type = type.GetElementType()!;
+        }
+
         if (type.IsPointer ||
+            type == typeof(void) ||
             type == typeof(Type) ||
             type.Namespace == "System.Reflection" ||
             (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Memory<>)) ||
@@ -488,8 +522,7 @@ internal class TypeExporter
 
     private static bool IsSupportedMethod(MethodInfo method)
     {
-        return !method.IsGenericMethodDefinition &&
-            method.CallingConvention != CallingConventions.VarArgs &&
+        return method.CallingConvention != CallingConventions.VarArgs &&
             method.Name != nameof(System.Collections.IEnumerable.GetEnumerator) &&
             method.GetParameters().All(IsSupportedParameter) &&
             IsSupportedParameter(method.ReturnParameter);
@@ -498,6 +531,143 @@ internal class TypeExporter
     private static bool IsSupportedParameter(ParameterInfo parameter)
     {
         Type parameterType = parameter.ParameterType;
+
+        if (parameter.Position < 0 && parameterType.IsByRef)
+        {
+            // Ref return values are not supported.
+            return false;
+        }
+
         return IsSupportedType(parameterType);
+    }
+
+    private JSReference ExportGenericTypeDefinition(Type type)
+    {
+        // TODO: Support multiple generic types with same name and differing type arg counts.
+
+        if (_exportedTypes.TryGetValue(type, out JSReference? genericTypeFunctionReference))
+        {
+            return genericTypeFunctionReference;
+        }
+
+        // A generic type definition is exported as a function that constructs the
+        // specialized generic type.
+        JSFunction function = new JSFunction(MakeGenericType, callbackData: type);
+
+        // Override the type's toString() to return the formatted generic type name.
+        ((JSValue)function).SetProperty("toString", new JSFunction(() => type.FormatName()));
+
+        genericTypeFunctionReference = new JSReference(function);
+        _exportedTypes.Add(type, genericTypeFunctionReference);
+        return genericTypeFunctionReference;
+    }
+
+    /// <summary>
+    /// Makes a specialized generic type from a generic type definition and type arguments.
+    /// </summary>
+    /// <param name="args">Type arguments passed as JS values.</param>
+    /// <returns>A strong reference to a JS value that represents the specialized generic
+    /// type.</returns>
+    private JSValue MakeGenericType(JSCallbackArgs args)
+    {
+        Type genericTypeDefinition = args.Data as Type ??
+            throw new ArgumentException("Missing generic type definition.");
+
+        Type[] typeArgs = new Type[args.Length];
+        for (int i = 0; i < typeArgs.Length; i++)
+        {
+            typeArgs[i] = args[i].TryUnwrap() as Type ??
+                throw new ArgumentException($"Invalid generic type argument at position {i}.");
+        }
+
+        Type genericType;
+        try
+        {
+            genericType = genericTypeDefinition.MakeGenericType(typeArgs);
+        }
+        catch (Exception ex)
+        {
+            throw new JSException(
+                $"Failed to make generic type {genericTypeDefinition.FormatName()} with supplied " +
+                $"type arguments: [{string.Join(", ", typeArgs.Select((t) => t.FormatName()))}]. " +
+                ex.Message,
+                ex);
+        }
+
+        JSReference exportedTypeReference = ExportType(genericType);
+        return exportedTypeReference.GetValue()!.Value;
+    }
+
+    private void ExportGenericMethodDefinition(object classBuilder, MethodInfo[] methods)
+    {
+        // Add method that is a function that makes the generic method.
+        MethodInfo addMethodMethod = classBuilder.GetType().GetInstanceMethod(
+            "AddMethod",
+            new[]
+            {
+                typeof(string),
+                typeof(JSCallback),
+                typeof(JSPropertyAttributes),
+                typeof(object),
+            });
+        addMethodMethod.Invoke(
+            classBuilder,
+            new object[]
+            {
+                methods[0].Name + '$',
+                (JSCallback)MakeGenericMethod,
+                JSPropertyAttributes.Enumerable | JSPropertyAttributes.Configurable |
+                    (methods[0].IsStatic ? JSPropertyAttributes.Static : default),
+                methods,
+            });
+    }
+
+    private JSValue MakeGenericMethod(JSCallbackArgs args)
+    {
+        MethodInfo[] genericMethodDefinitions = args.Data as MethodInfo[] ??
+            throw new ArgumentException("Missing generic type definition.");
+
+        Type[] typeArgs = new Type[args.Length];
+        for (int i = 0; i < typeArgs.Length; i++)
+        {
+            typeArgs[i] = args[i].TryUnwrap() as Type ??
+                throw new ArgumentException($"Invalid generic type argument at position {i}.");
+        }
+
+        MethodInfo[] matchingMethodDefinitions = genericMethodDefinitions
+            .Where((m) => m.GetGenericArguments().Length == typeArgs.Length)
+            .ToArray();
+
+        if (matchingMethodDefinitions.Length == 0)
+        {
+            throw new JSException(
+                "Incorrect number of type arguments for method: +" +
+                genericMethodDefinitions[0].Name);
+        }
+
+        MethodInfo[] matchingMethods;
+        try
+        {
+            matchingMethods = genericMethodDefinitions.Select((m) => m.MakeGenericMethod(typeArgs))
+                .ToArray();
+        }
+        catch (Exception ex)
+        {
+            throw new JSException(
+                $"Failed to make generic method {genericMethodDefinitions[0].Name} with supplied " +
+                $"type arguments: [{string.Join(", ", typeArgs.Select((t) => t.FormatName()))}]. " +
+                ex.Message,
+                ex);
+        }
+
+        JSCallbackDescriptor descriptor = CreateMethodDescriptor(matchingMethods);
+        JSFunction function = new JSFunction(descriptor.Callback, descriptor.Data);
+
+        if (!args.ThisArg.IsUndefined())
+        {
+            function = function.Bind(args.ThisArg);
+        }
+
+        return function;
     }
 }

--- a/src/NodeApi.Generator/NodeApi.Generator.csproj
+++ b/src/NodeApi.Generator/NodeApi.Generator.csproj
@@ -28,7 +28,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" />
-    <PackageReference Include="Nullability.Source" Condition="$(NetFramework)" />
+    <PackageReference Include="Nullability.Source" Condition=" '$(NetFramework)' == 'true' " />
     <PackageReference Include="System.Reflection.MetadataLoadContext" />
   </ItemGroup>
 

--- a/src/NodeApi.Generator/TypeDefinitionsGenerator.cs
+++ b/src/NodeApi.Generator/TypeDefinitionsGenerator.cs
@@ -821,9 +821,6 @@ import { Duplex } from 'stream';
     private string GetTSType(PropertyInfo property)
     {
         Type propertyType = property.PropertyType;
-        bool isStatic = property.GetMethod?.IsStatic ??
-            property.SetMethod?.IsStatic ?? false;
-
         if (propertyType.IsByRef)
         {
             propertyType = propertyType.GetElementType()!;

--- a/src/NodeApi/Interop/JSClassBuilderOfT.cs
+++ b/src/NodeApi/Interop/JSClassBuilderOfT.cs
@@ -9,8 +9,6 @@ namespace Microsoft.JavaScript.NodeApi.Interop;
 
 public class JSClassBuilder<T> : JSPropertyDescriptorList<JSClassBuilder<T>, T> where T : class
 {
-    private const char GenericTypeNameSuffix = '$';
-
     private readonly JSCallbackDescriptor? _constructorDescriptor;
 
     public string ClassName { get; }
@@ -257,38 +255,9 @@ public class JSClassBuilder<T> : JSPropertyDescriptorList<JSClassBuilder<T>, T> 
             }
         }
 
-        static string TypeName(Type type)
-        {
-            string typeName = type.Name;
-            if (type.IsGenericType)
-            {
-                int nameEnd = typeName.IndexOf('`');
-                if (nameEnd >= 0)
-                {
-                    typeName = typeName.Substring(0, nameEnd);
-                    typeName += GenericTypeNameSuffix;
-                }
-            }
-            return typeName;
-        }
-
-        // Include the declaring type(s) of nested types.
-        string typeName = TypeName(typeof(T));
-        Type? declaringType = typeof(T).DeclaringType;
-        while (declaringType != null)
-        {
-            typeName = TypeName(declaringType) + '.' + typeName;
-            declaringType = declaringType.DeclaringType;
-        }
-
-        if (typeof(T).Namespace != null)
-        {
-            typeName = typeof(T).Namespace + '.' + typeName;
-        }
-
         AddMethod(
             "toString",
-            (_) => typeName,
+            (_) => typeof(T).FormatName(),
             JSPropertyAttributes.Static | JSPropertyAttributes.DefaultMethod);
     }
 }

--- a/src/NodeApi/Interop/JSRuntimeContext.cs
+++ b/src/NodeApi/Interop/JSRuntimeContext.cs
@@ -259,7 +259,8 @@ public sealed class JSRuntimeContext : IDisposable
     {
         if (obj == null)
         {
-            return JSValue.Null;
+            // Marshal null object reference to JS undefined. 
+            return JSValue.Undefined;
         }
 
         JSValue? wrapper = null;

--- a/src/NodeApi/Interop/TypeExtensions.cs
+++ b/src/NodeApi/Interop/TypeExtensions.cs
@@ -1,0 +1,53 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Linq;
+
+namespace Microsoft.JavaScript.NodeApi.Interop;
+
+public static class TypeExtensions
+{
+    public static string FormatName(this Type type)
+    {
+        static string FormatNameWithoutNamespace(Type type)
+        {
+            string typeName = type.Name;
+            if (type.IsGenericType)
+            {
+                int nameEnd = typeName.IndexOf('`');
+                if (nameEnd >= 0)
+                {
+                    typeName = typeName.Substring(0, nameEnd);
+                }
+
+                Type[] typeArgs = type.GetGenericArguments();
+                if (type.IsGenericTypeDefinition)
+                {
+                    typeName += '<' + string.Join(",", typeArgs.Select((t) => t.Name)) + '>';
+                }
+                else
+                {
+                    typeName += '<' + string.Join(",", typeArgs.Select(FormatName)) + '>';
+                }
+            }
+            return typeName;
+        }
+
+        // Include the declaring type(s) of nested types.
+        string typeName = FormatNameWithoutNamespace(type);
+        Type? declaringType = type.DeclaringType;
+        while (declaringType != null)
+        {
+            typeName = FormatNameWithoutNamespace(declaringType) + '.' + typeName;
+            declaringType = declaringType.DeclaringType;
+        }
+
+        if (type.Namespace != null)
+        {
+            typeName = type.Namespace + '.' + typeName;
+        }
+
+        return typeName;
+    }
+}

--- a/src/NodeApi/NodeApi.csproj
+++ b/src/NodeApi/NodeApi.csproj
@@ -21,7 +21,7 @@
     <UseSystemResourceKeys>true</UseSystemResourceKeys><!-- Trim detailed system exception messages. -->
   </PropertyGroup>
 
-  <ItemGroup Condition="$(NetFramework)">
+  <ItemGroup Condition=" '$(NetFramework)' == 'true' ">
     <PackageReference Include="System.Memory" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
   </ItemGroup>

--- a/test/TestBuilder.cs
+++ b/test/TestBuilder.cs
@@ -255,6 +255,7 @@ internal static class TestBuilder
                 (errorOutput != null ? "\n" + errorOutput + "\n" : string.Empty) +
                 "Full output: " + logFilePath;
 
+            logWriter.Close();
             string jsFileName = Path.GetFileName(jsFilePath);
             string[] logLines = File.ReadAllLines(logFilePath);
             for (int i = 0; i < logLines.Length; i++)

--- a/test/TestCases/Directory.Build.props
+++ b/test/TestCases/Directory.Build.props
@@ -24,7 +24,7 @@
     <ItemGroup>
         <ProjectReference Include="$(NodeApiSrcDir)NodeApi\NodeApi.csproj" />
         <ProjectReference Include="$(NodeApiSrcDir)NodeApi.DotNetHost\NodeApi.DotNetHost.csproj" />
-        <PackageReference Include="Microsoft.JavaScript.NodeApi.Generator" VersionOverride="0.3.*-*" />
+        <PackageReference Include="Microsoft.JavaScript.NodeApi.Generator" VersionOverride="0.4.*-*" />
     </ItemGroup>
 
     <PropertyGroup>

--- a/test/TestCases/napi-dotnet/Generics.cs
+++ b/test/TestCases/napi-dotnet/Generics.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.JavaScript.NodeApi.TestCases;
+
+// Note these types do not have [JSExport] attributes: static binding does not support generics.
+
+public class GenericClass<T>
+{
+    public GenericClass(T value) { Value = value; }
+    public T Value { get; set; }
+    public T GetValue(T value) => value;
+}
+
+public class GenericClassWithConstraint<T> where T : struct
+{
+    public GenericClassWithConstraint(T value) { Value = value; }
+    public T Value { get; set;}
+    public T GetValue(T value) => value;
+}
+
+public struct GenericStruct<T>
+{
+    public GenericStruct(T value) { Value = value; }
+    public T Value { get; set;}
+    public T GetValue(T value) => value;
+}
+
+public static class StaticClassWithGenericMethods
+{
+    public static T GetValue<T>(T value) => value;
+}
+
+public class NonstaticClassWithGenericMethods
+{
+    public T GetValue<T>(T value) => value;
+}

--- a/test/TestCases/napi-dotnet/Generics.cs
+++ b/test/TestCases/napi-dotnet/Generics.cs
@@ -3,6 +3,8 @@
 
 namespace Microsoft.JavaScript.NodeApi.TestCases;
 
+#pragma warning disable CA1822 // Mark members as static
+
 // Note these types do not have [JSExport] attributes: static binding does not support generics.
 
 public class GenericClass<T>
@@ -15,14 +17,14 @@ public class GenericClass<T>
 public class GenericClassWithConstraint<T> where T : struct
 {
     public GenericClassWithConstraint(T value) { Value = value; }
-    public T Value { get; set;}
+    public T Value { get; set; }
     public T GetValue(T value) => value;
 }
 
 public struct GenericStruct<T>
 {
     public GenericStruct(T value) { Value = value; }
-    public T Value { get; set;}
+    public T Value { get; set; }
     public T GetValue(T value) => value;
 }
 

--- a/test/TestCases/napi-dotnet/dynamic_generics.js
+++ b/test/TestCases/napi-dotnet/dynamic_generics.js
@@ -1,0 +1,89 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+const assert = require('assert');
+
+const dotnetHost = process.env.TEST_DOTNET_HOST_PATH;
+const dotnetVersion = process.env.TEST_DOTNET_VERSION;
+const dotnet = require(dotnetHost)
+  .initialize(dotnetVersion, dotnetHost.replace(/\.node$/, '.DotNetHost.dll'));
+const System = dotnet.System;
+const ns = 'Microsoft.JavaScript.NodeApi.TestCases';
+
+// Load the test module using dynamic binding `load()` instead of static binding `require()`.
+const assemblyPath = process.env.TEST_DOTNET_MODULE_PATH;
+dotnet.load(assemblyPath);
+const TestCases = dotnet.Microsoft.JavaScript.NodeApi.TestCases;
+
+const GenericClass$ = TestCases.GenericClass$;
+assert.strictEqual(typeof GenericClass$, 'function');
+assert.strictEqual( GenericClass$.toString(), `${ns}.GenericClass<T>`);
+
+const GenericClassOfInt = GenericClass$(System.Int32);
+assert.strictEqual(typeof GenericClassOfInt, 'function');
+assert.strictEqual(GenericClassOfInt.toString(), `${ns}.GenericClass<System.Int32>`);
+const genericInstanceOfInt = new GenericClassOfInt(1);
+assert.strictEqual(genericInstanceOfInt.Value, 1);
+assert.strictEqual(genericInstanceOfInt.GetValue(-1), -1);
+
+const GenericClassOfString = GenericClass$(System.String);
+assert.strictEqual(typeof GenericClassOfString, 'function');
+assert.strictEqual(GenericClassOfString.toString(), `${ns}.GenericClass<System.String>`);
+const genericInstanceOfString = new GenericClassOfString('two');
+assert.strictEqual(genericInstanceOfString.Value, 'two');
+assert.strictEqual(genericInstanceOfString.GetValue('TWO'), 'TWO');
+
+const GenericClassOfClassObject = GenericClass$(TestCases.ClassObject);
+assert.strictEqual(typeof GenericClassOfClassObject, 'function');
+assert.strictEqual(GenericClassOfClassObject.toString(), `${ns}.GenericClass<${ns}.ClassObject>`);
+const obj = new TestCases.ClassObject();
+const genericInstanceOfClassObject = new GenericClassOfClassObject(obj);
+assert.strictEqual(genericInstanceOfClassObject.Value, obj);
+genericInstanceOfClassObject.Value = undefined;
+assert.strictEqual(genericInstanceOfClassObject.Value, undefined);
+assert.strictEqual(genericInstanceOfClassObject.GetValue(obj), obj);
+
+const GenericClassWithConstraint$ = TestCases.GenericClassWithConstraint$;
+assert.strictEqual(typeof GenericClassWithConstraint$, 'function');
+
+let error = undefined;
+try { GenericClassWithConstraint$(); } catch (e) { error = e; }
+assert(error.message.startsWith(
+  `Failed to make generic type ${ns}.GenericClassWithConstraint<T> with supplied type arguments: []`));
+try { GenericClassWithConstraint$(System.Int32, System.Int32); } catch (e) { error = e; }
+assert(error.message.startsWith(
+  `Failed to make generic type ${ns}.GenericClassWithConstraint<T> with supplied type arguments: [System.Int32, System.Int32]`));
+try { GenericClassWithConstraint$(System.String); } catch (e) { error = e; }
+assert(error.message.startsWith(
+  `Failed to make generic type ${ns}.GenericClassWithConstraint<T> with supplied type arguments: [System.String]`));
+
+const GenericClassOfStruct = new GenericClassWithConstraint$(TestCases.StructObject);
+assert.strictEqual(typeof GenericClassOfStruct, 'function');
+assert.strictEqual(GenericClassOfStruct.toString(), `${ns}.GenericClassWithConstraint<${ns}.StructObject>`);
+const obj2 = new TestCases.StructObject();
+obj2.Value = 'test';
+const genericInstanceOfStruct = new GenericClassOfStruct(obj2);
+assert.strictEqual(genericInstanceOfStruct.Value.Value, 'test');
+assert.strictEqual(genericInstanceOfStruct.GetValue(obj2).Value, 'test');
+
+const GenericStruct$ = TestCases.GenericStruct$;
+assert.strictEqual(typeof GenericStruct$, 'function');
+const GenericStructOfInt = GenericStruct$(System.Int32);
+assert.strictEqual(typeof GenericStructOfInt, 'function');
+assert.strictEqual(GenericStructOfInt.toString(), `${ns}.GenericStruct<System.Int32>`);
+const genericStructInstanceOfInt = new GenericStructOfInt();
+genericStructInstanceOfInt.Value = 3;
+assert.strictEqual(genericStructInstanceOfInt.Value, 3);
+assert.strictEqual(genericStructInstanceOfInt.GetValue(-3), -3);
+
+const GenericStructOfInterface = GenericStruct$(TestCases.ITestInterface);
+assert.strictEqual(
+  GenericStructOfInterface.toString(), `${ns}.GenericStruct<${ns}.ITestInterface>`);
+
+assert.strictEqual(
+  typeof TestCases.StaticClassWithGenericMethods.GetValue$(System.Int32), 'function');
+assert.strictEqual(TestCases.StaticClassWithGenericMethods.GetValue$(System.Int32)(11), 11);
+
+const nonstaticInstance = new TestCases.NonstaticClassWithGenericMethods();
+assert.strictEqual(typeof nonstaticInstance.GetValue$(System.String), 'function');
+assert.strictEqual(nonstaticInstance.GetValue$(System.String)('twelve'), 'twelve');

--- a/test/TestCases/projects/ts-esm/out/test.js
+++ b/test/TestCases/projects/ts-esm/out/test.js
@@ -1,6 +1,0 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
-import dotnet from 'node-api-dotnet';
-import './bin/System.Runtime.js';
-import './bin/System.Console.js';
-dotnet.System.Console.WriteLine('Test!');

--- a/test/TypeDefsGeneratorTests.cs
+++ b/test/TypeDefsGeneratorTests.cs
@@ -3,7 +3,9 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
+using System.Xml.Linq;
 using Microsoft.JavaScript.NodeApi.Generator;
 using Xunit;
 
@@ -14,19 +16,55 @@ namespace Microsoft.JavaScript.NodeApi.Test;
 
 public class TypeDefsGeneratorTests
 {
-    private readonly TypeDefinitionsGenerator _generator = new(
-        typeof(TypeDefsGeneratorTests).Assembly,
-        assemblyDoc: null,
-        referenceAssemblies: new Dictionary<string, Assembly>(),
-        suppressWarnings: true);
+    private static TypeDefinitionsGenerator CreateTypeDefinitionsGenerator(
+        Dictionary<string, string> docs)
+    {
+        string ns = typeof(TypeDefsGeneratorTests).FullName + "+";
+        XDocument docsXml = new XDocument(new XElement("root", new XElement("members",
+            docs.Select((pair) => new XElement("member",
+                new XAttribute("name", pair.Key.Insert(2, ns)),
+                new XElement("summary", pair.Value))))));
+        return new TypeDefinitionsGenerator(
+            typeof(TypeDefsGeneratorTests).Assembly,
+            assemblyDoc: docsXml,
+            referenceAssemblies: new Dictionary<string, Assembly>(),
+            suppressWarnings: true);
+    }
 
-    private string GenerateTypeDefinition(Type type)
-        => _generator.GenerateTypeDefinition(type).TrimEnd();
+    private string GenerateTypeDefinition(Type type, Dictionary<string, string> docs)
+        => CreateTypeDefinitionsGenerator(docs).GenerateTypeDefinition(type).TrimEnd();
 
-    private string GenerateMemberDefinition(MemberInfo member)
-        => _generator.GenerateMemberDefinition(member).TrimEnd();
+    private string GenerateMemberDefinition(MemberInfo member, Dictionary<string, string> docs)
+        => CreateTypeDefinitionsGenerator(docs).GenerateMemberDefinition(member).TrimEnd();
 
-    private class SimpleClass
+    private interface SimpleInterface
+    {
+        string TestProperty { get; set; }
+        string TestMethod();
+    }
+
+    [Fact]
+    public void GenerateSimpleInterface()
+    {
+        // NOTE: String literals in these tests use TABS for indendation!
+        Assert.Equal(@"
+/** interface */
+export interface SimpleInterface {
+	/** property */
+	TestProperty: string;
+
+	/** method */
+	TestMethod(): string;
+}",
+        GenerateTypeDefinition(typeof(SimpleInterface), new Dictionary<string, string>
+        {
+            ["T:SimpleInterface"] = "interface",
+            ["P:SimpleInterface.TestProperty"] = "property",
+            ["M:SimpleInterface.TestMethod"] = "method",
+        }));
+    }
+
+    private class SimpleClass : SimpleInterface
     {
         public string TestProperty { get; set; } = null!;
         public string TestMethod() { return string.Empty; }
@@ -36,13 +74,24 @@ public class TypeDefsGeneratorTests
     public void GenerateSimpleClass()
     {
         Assert.Equal(@"
+/** class */
 export class SimpleClass {
+	/** constructor */
 	constructor();
 
+	/** property */
 	TestProperty: string;
 
+	/** method */
 	TestMethod(): string;
-}", GenerateTypeDefinition(typeof(SimpleClass)));
+}",
+        GenerateTypeDefinition(typeof(SimpleClass), new Dictionary<string, string>
+        {
+            ["T:SimpleClass"] = "class",
+            ["M:SimpleClass.#ctor"] = "constructor",
+            ["P:SimpleClass.TestProperty"] = "property",
+            ["M:SimpleClass.TestMethod"] = "method",
+        }));
     }
 
     [Fact]
@@ -50,7 +99,8 @@ export class SimpleClass {
     {
         Assert.Equal(@"TestProperty: string;",
             GenerateMemberDefinition(
-                typeof(SimpleClass).GetProperty(nameof(SimpleClass.TestProperty))!));
+                typeof(SimpleClass).GetProperty(nameof(SimpleClass.TestProperty))!,
+                new Dictionary<string, string>()));
     }
 
     [Fact]
@@ -58,7 +108,8 @@ export class SimpleClass {
     {
         Assert.Equal(@"TestMethod(): string;",
             GenerateMemberDefinition(
-                typeof(SimpleClass).GetMethod(nameof(SimpleClass.TestMethod))!));
+                typeof(SimpleClass).GetMethod(nameof(SimpleClass.TestMethod))!,
+                new Dictionary<string, string>()));
     }
 
     private delegate void SimpleDelegate(string arg);
@@ -67,8 +118,140 @@ export class SimpleClass {
     public void GenerateSimpleDelegate()
     {
         Assert.Equal(@"
+/** delegate */
 export interface SimpleDelegate { (arg: string): void; }",
-            GenerateTypeDefinition(typeof(SimpleDelegate)));
+        GenerateTypeDefinition(typeof(SimpleDelegate), new Dictionary<string, string>
+        {
+            ["T:SimpleDelegate"] = "delegate",
+        }));
+    }
+
+    private enum TestEnum
+    {
+        Zero = 0,
+        One = 1,
+    }
+
+    [Fact]
+    public void GenerateEnum()
+    {
+        Assert.Equal(@"
+/** enum */
+export enum TestEnum {
+	/** zero */
+	Zero = 0,
+
+	/** one */
+	One = 1,
+}",
+        GenerateTypeDefinition(typeof(TestEnum), new Dictionary<string, string>
+        {
+            ["T:TestEnum"] = "enum",
+            ["F:TestEnum.Zero"] = "zero",
+            ["F:TestEnum.One"] = "one",
+        }));
+    }
+
+    private interface GenericInterface<T>
+    {
+        T TestProperty { get; set; }
+        T TestMethod(T value);
+    }
+
+    [Fact]
+    public void GenerateGenericInterface()
+    {
+        Assert.Equal(@"
+/** [Generic type factory] generic-interface */
+export function GenericInterface$(T: IType<any>): GenericInterface$$1<any>;
+
+/** generic-interface */
+export interface GenericInterface$$1<T> {
+}
+
+/** generic-interface */
+export interface GenericInterface$1<T> {
+	/** instance-property */
+	TestProperty: T;
+
+	/** instance-method */
+	TestMethod(value: T): T;
+}",
+        GenerateTypeDefinition(typeof(GenericInterface<>), new Dictionary<string, string>
+        {
+            ["T:GenericInterface`1"] = "generic-interface",
+            ["P:GenericInterface`1.TestProperty"] = "instance-property",
+            ["M:GenericInterface`1.TestMethod(T)"] = "instance-method",
+        }));
+    }
+
+    private class GenericClass<T> : GenericInterface<T>
+    {
+        public GenericClass(T value) { TestProperty = value; }
+        public T TestProperty { get; set; } = default!;
+        public T TestMethod(T value) { return value; }
+        public static T TestStaticProperty { get; set; } = default!;
+        public static T TestStaticMethod(T value) { return value; }
+    }
+
+    [Fact]
+    public void GenerateGenericClass()
+    {
+        Assert.Equal(@"
+/** [Generic type factory] generic-class */
+export function GenericClass$(T: IType<any>): GenericClass$$1<any>;
+
+/** generic-class */
+export interface GenericClass$$1<T> {
+	/** constructor */
+	new(value: T): GenericClass$1<T>;
+
+	/** static-property */
+	TestStaticProperty: T;
+
+	/** static-method */
+	TestStaticMethod(value: T): T;
+}
+
+/** generic-class */
+export interface GenericClass$1<T> {
+	/** instance-property */
+	TestProperty: T;
+
+	/** instance-method */
+	TestMethod(value: T): T;
+}",
+        GenerateTypeDefinition(typeof(GenericClass<>), new Dictionary<string, string>
+        {
+            ["T:GenericClass`1"] = "generic-class",
+            ["M:GenericClass`1.#ctor(T)"] = "constructor",
+            ["P:GenericClass`1.TestStaticProperty"] = "static-property",
+            ["M:GenericClass`1.TestStaticMethod(T)"] = "static-method",
+            ["P:GenericClass`1.TestProperty"] = "instance-property",
+            ["M:GenericClass`1.TestMethod(T)"] = "instance-method",
+        }));
+    }
+
+    private delegate T GenericDelegate<T>(T arg);
+
+    [Fact]
+    public void GenerateGenericDelegate()
+    {
+        Assert.Equal(@"
+/** [Generic type factory] generic-delegate */
+export function GenericDelegate$(T: IType<any>): GenericDelegate$$1<any>;
+
+/** generic-delegate */
+export interface GenericDelegate$$1<T> {
+	new(func: (arg: T) => T): GenericDelegate$1<T>;
+}
+
+/** generic-delegate */
+export interface GenericDelegate$1<T> { (arg: T): T; }",
+        GenerateTypeDefinition(typeof(GenericDelegate<>), new Dictionary<string, string>
+        {
+            ["T:GenericDelegate`1"] = "generic-delegate",
+        }));
     }
 }
 

--- a/test/TypeDefsGeneratorTests.cs
+++ b/test/TypeDefsGeneratorTests.cs
@@ -20,7 +20,7 @@ public class TypeDefsGeneratorTests
         Dictionary<string, string> docs)
     {
         string ns = typeof(TypeDefsGeneratorTests).FullName + "+";
-        XDocument docsXml = new XDocument(new XElement("root", new XElement("members",
+        XDocument docsXml = new(new XElement("root", new XElement("members",
             docs.Select((pair) => new XElement("member",
                 new XAttribute("name", pair.Key.Insert(2, ns)),
                 new XElement("summary", pair.Value))))));

--- a/version.json
+++ b/version.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
 
-	"version": "0.3",
+	"version": "0.4",
 
 	"publicReleaseRefSpec": [
 		"^refs/heads/main$",


### PR DESCRIPTION
Fixes: #67

 - Dynamically export generic types and methods using the `$` suffix convention as described in `generics.md`.
 - Generate type definitions for generic types.
   - Aside from the generic factory function, generic classes are projected as two TS interfaces: `ClassName$$N` and `ClassName$N` (where N is the number of generic type parameters). The `$$` interface includes static members and constructors; the other includes only instance members. (These names will rarely if ever need to be typed out in user code.)
 - Add test cases for generic invocation and typedefs generation.