### PR TITLE
Switch to main thread for interface callback

### DIFF
--- a/src/NodeApi.Generator/ExpressionExtensions.cs
+++ b/src/NodeApi.Generator/ExpressionExtensions.cs
@@ -106,6 +106,8 @@ internal static class ExpressionExtensions
                       ToCS(conditional.IfFalse, path, variables),
 
             MemberExpression { NodeType: ExpressionType.MemberAccess } member =>
+                member.Expression is ParameterExpression parameterExpression &&
+                parameterExpression.Name == "this" ? member.Member.Name :
                 (member.Expression != null ? WithParentheses(member.Expression, path, variables) :
                     member.Member.DeclaringType!.FullName) + "." + member.Member.Name,
 

--- a/src/NodeApi/JSReference.cs
+++ b/src/NodeApi/JSReference.cs
@@ -108,7 +108,7 @@ public class JSReference : IDisposable
     /// </summary>
     public void Run(Action<JSValue> action)
     {
-        Action getValueAndRunAction = () =>
+        void GetValueAndRunAction()
         {
             JSValue? value = GetValue();
             if (!value.HasValue)
@@ -117,16 +117,16 @@ public class JSReference : IDisposable
             }
 
             action(value.Value);
-        };
+        }
 
         JSSynchronizationContext? synchronizationContext = SynchronizationContext;
         if (synchronizationContext != null)
         {
-            synchronizationContext.Run(getValueAndRunAction);
+            synchronizationContext.Run(GetValueAndRunAction);
         }
         else
         {
-            getValueAndRunAction();
+            GetValueAndRunAction();
         }
     }
 
@@ -137,7 +137,7 @@ public class JSReference : IDisposable
     /// </summary>
     public T Run<T>(Func<JSValue, T> action)
     {
-        Func<T> getValueAndRunAction = () =>
+        T GetValueAndRunAction()
         {
             JSValue? value = GetValue();
             if (!value.HasValue)
@@ -146,16 +146,16 @@ public class JSReference : IDisposable
             }
 
             return action(value.Value);
-        };
+        }
 
         JSSynchronizationContext? synchronizationContext = SynchronizationContext;
         if (synchronizationContext != null)
         {
-            return synchronizationContext.Run(getValueAndRunAction);
+            return synchronizationContext.Run(GetValueAndRunAction);
         }
         else
         {
-            return getValueAndRunAction();
+            return GetValueAndRunAction();
         }
     }
 

--- a/src/NodeApi/JSReference.cs
+++ b/src/NodeApi/JSReference.cs
@@ -101,6 +101,11 @@ public class JSReference : IDisposable
         return result;
     }
 
+    /// <summary>
+    /// Runs an action with the referenced value, using the <see cref="JSSynchronizationContext" />
+    /// associated with the reference to switch to the JS thread (if necessary) while operating
+    /// on the value.
+    /// </summary>
     public void Run(Action<JSValue> action)
     {
         Action getValueAndRunAction = () =>
@@ -125,6 +130,11 @@ public class JSReference : IDisposable
         }
     }
 
+    /// <summary>
+    /// Runs an action with the referenced value, using the <see cref="JSSynchronizationContext" />
+    /// associated with the reference to switch to the JS thread (if necessary) while operating
+    /// on the value.
+    /// </summary>
     public T Run<T>(Func<JSValue, T> action)
     {
         Func<T> getValueAndRunAction = () =>

--- a/test/TestCases/napi-dotnet/AsyncMethods.cs
+++ b/test/TestCases/napi-dotnet/AsyncMethods.cs
@@ -35,6 +35,10 @@ public static class AsyncMethods
     public static async Task<string> ReverseInterfaceTest(
         IAsyncInterface jsInterface, string greeter)
     {
+        // ConfigureAwait(false) does not return to the JS thread, but the interface callback
+        // should still use the JS thread.
+        await Task.Delay(50).ConfigureAwait(false);
+
         // Invoke a method on a JS object that implements the interface.
         return await jsInterface.TestAsync(greeter);
     }

--- a/test/TestCases/napi-dotnet/errors.js
+++ b/test/TestCases/napi-dotnet/errors.js
@@ -67,15 +67,16 @@ function catchJSError() {
   assert(stack[0].startsWith(`at Object.${throwJSError.name} `));
 
   // Skip over initial non-.NET lines in the stack trace.
-  while (!stack[0].startsWith(`at ${dotnetNamespacePrefix}`)) stack.shift();
+  while (stack.length > 0 && !stack[0].startsWith(`at ${dotnetNamespacePrefix}`)) stack.shift();
 
   // The .NET stack trace should include the .NET method that called the JS thrower.
-  while (!stack[0].includes('Errors.ThrowJSError(')) stack.shift();
+  while (stack.length > 0 && !stack[0].includes('ThrowJSError(')) stack.shift();
   assert(stack.length > 0);
 
   // Skip over .NET lines in the stack trace. (Native delegates may include !<BaseAddress>)
-  while (stack[0].startsWith(`at ${dotnetNamespacePrefix}`) ||
-    stack[0].includes('!<')) stack.shift();
+  while (stack.length > 0 && (stack[0].startsWith(`at ${dotnetNamespacePrefix}`) ||
+    stack[0].includes('!<'))) stack.shift();
+  assert(stack.length > 0);
 
   // The following JS line of the stack trace should refer to this JS method.
   assert(stack[0].startsWith(`at ${catchJSError.name} `));


### PR DESCRIPTION
Fixes #141 

When calling a .NET interface adapter for a JS object, the generated marshalling code uses the `JSSynchronizationContext` on the `JSReference` to switch back to the JS thread if necessary, before getting the referenced JS object and calling the method. 

The same problem exists for collection adapters, but this PR does not address collections.