### PR TITLE
Fix CI build break

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "7.0.300",
+    "version": "7.0.302",
     "rollForward": "latestPatch"
   }
 }


### PR DESCRIPTION
The CI cannot install .Net version 7.0.300.
Changing version to 7.0.302 fixed the issue.
See: https://dev.azure.com/office/ISS/_build/results?buildId=20719334&view=results