### PR TITLE
Pass args via file

### DIFF
--- a/src/NodeApi.Generator/NodeApi.Generator.csproj
+++ b/src/NodeApi.Generator/NodeApi.Generator.csproj
@@ -32,6 +32,10 @@
     <PackageReference Include="System.Reflection.MetadataLoadContext" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="Microsoft.JavaScript.NodeApi.Test" />
+  </ItemGroup>
+
   <!--
     Source generator dependencies require special handling.
     https://github.com/dotnet/roslyn-sdk/blob/main/samples/CSharp/SourceGenerators/SourceGeneratorSamples/CSharpSourceGeneratorSamples.csproj

--- a/src/NodeApi.Generator/NodeApi.Generator.targets
+++ b/src/NodeApi.Generator/NodeApi.Generator.targets
@@ -7,6 +7,8 @@
     <NodeApiGeneratorAssemblyPath>$(MSBuildThisFileDirectory)../analyzers/dotnet/cs/$(NodeApiGeneratorAssemblyName).dll</NodeApiGeneratorAssemblyPath>
     <NodeApiAssemblyJSModuleType Condition=" '$(NodeApiAssemblyJSModuleType)' == '' ">commonjs</NodeApiAssemblyJSModuleType>
     <NodeApiTypeDefinitionsGeneratorOptions>--module $(NodeApiAssemblyJSModuleType) $(NodeApiTypedefsGeneratorOptions) --framework $(TargetFramework)</NodeApiTypeDefinitionsGeneratorOptions>
+
+    <NodeApiGeneratedFilesDir Condition="'$(NodeApiGeneratedFilesDir)' == ''">$([MSBuild]::NormalizeDirectory('$(MSBuildProjectDirectory)', '$(IntermediateOutputPath)', 'Generated Files'))</NodeApiGeneratedFilesDir>
   </PropertyGroup>
 
   <Target Name="ConfigureNodeApiTypeDefinitions"
@@ -15,10 +17,10 @@
   >
     <!-- When the project does not have any source files, copy all reference assemblies to output and generate typedefs for them. -->
     <PropertyGroup Condition=" '@(Compile)' == '' ">
-        <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-        <CopyBuildOutputToOutputDirectory>false</CopyBuildOutputToOutputDirectory>
-        <CopyOutputSymbolsToOutputDirectory>false</CopyOutputSymbolsToOutputDirectory>
-        <GenerateNodeApiTypeDefinitionsForReferences Condition=" '$(GenerateNodeApiTypeDefinitionsForReferences)' == '' ">true</GenerateNodeApiTypeDefinitionsForReferences>
+      <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+      <CopyBuildOutputToOutputDirectory>false</CopyBuildOutputToOutputDirectory>
+      <CopyOutputSymbolsToOutputDirectory>false</CopyOutputSymbolsToOutputDirectory>
+      <GenerateNodeApiTypeDefinitionsForReferences Condition=" '$(GenerateNodeApiTypeDefinitionsForReferences)' == '' ">true</GenerateNodeApiTypeDefinitionsForReferences>
     </PropertyGroup>
   </Target>
 
@@ -31,7 +33,13 @@
     Outputs="$(TargetDir)$(NodeApiTypeDefinitionsFileName)"
     Condition=" '$(GenerateNodeApiTypeDefinitions)' == 'true' AND Exists('$(TargetPath)') "
   >
-    <Exec Command="dotnet &quot;$(NodeApiGeneratorAssemblyPath)&quot; --assembly &quot;$(TargetPath)&quot; --reference &quot;@(ReferencePathWithRefAssemblies)&quot; --typedefs &quot;$(TargetDir)$(NodeApiTypeDefinitionsFileName)&quot; $(NodeApiTypeDefinitionsGeneratorOptions)"
+    <PropertyGroup>
+      <NodeApiArgumentsFile>$(NodeApiGeneratedFilesDir)NodeApi.arg</NodeApiArgumentsFile>
+      <NodeApiArgumentsContent>--assembly &quot;$(TargetPath)&quot; @(ReferencePathWithRefAssemblies->'--reference "%(Identity)"') --typedefs &quot;$(TargetDir)$(NodeApiTypeDefinitionsFileName)&quot; $(NodeApiTypeDefinitionsGeneratorOptions)</NodeApiArgumentsContent>
+    </PropertyGroup>
+    <MakeDir Directories="$(NodeApiGeneratedFilesDir)" />
+    <WriteLinesToFile File="$(NodeApiArgumentsFile)" Lines="$(NodeApiArgumentsContent)" Overwrite="true" />
+    <Exec Command="dotnet &quot;$(NodeApiGeneratorAssemblyPath)&quot; &quot;$(NodeApiArgumentsFile)&quot;"
       ConsoleToMSBuild="true" />
   </Target>
 
@@ -101,7 +109,13 @@
       <_NodeApiAllTypeDefs Include="@(NodeApiSystemReferenceAssemblies->'$(TargetDir)%(Identity).d.ts')" />
     </ItemGroup>
 
-    <Exec Command="dotnet &quot;$(NodeApiGeneratorAssemblyPath)&quot; $(_SuppressTSGenerationWarnings) --assemblies &quot;@(_NodeApiAllReferenceAssemblies)&quot; --typedefs &quot;@(_NodeApiAllTypeDefs)&quot; $(NodeApiTypeDefinitionsGeneratorOptions)"
+    <PropertyGroup>
+      <NodeApiArgumentsFile>$(NodeApiGeneratedFilesDir)NodeApiReferences.arg</NodeApiArgumentsFile>
+      <NodeApiArgumentsContent>$(_SuppressTSGenerationWarnings) @(_NodeApiAllReferenceAssemblies->'--assemblies "%(Identity)"') --typedefs &quot;@(_NodeApiAllTypeDefs)&quot; $(NodeApiTypeDefinitionsGeneratorOptions)"</NodeApiArgumentsContent>
+    </PropertyGroup>
+    <MakeDir Directories="$(NodeApiGeneratedFilesDir)" />
+    <WriteLinesToFile File="$(NodeApiArgumentsFile)" Lines="$(NodeApiArgumentsContent)" Overwrite="true" />
+    <Exec Command="dotnet &quot;$(NodeApiGeneratorAssemblyPath)&quot; &quot;$(NodeApiArgumentsFile)&quot;"
       ConsoleToMSBuild="true" />
   </Target>
 

--- a/src/NodeApi.Generator/Program.cs
+++ b/src/NodeApi.Generator/Program.cs
@@ -88,8 +88,52 @@ public static class Program
         return 0;
     }
 
+    // Split cmd-line into args[]
+    // ToDo: Currently only supports double quotes and no escapes
+    internal static string[] SplitCmdLine(string cmd)
+    {
+        List<string> args = new();
+
+        bool inQuotes = false;
+        int i = 0, start = 0;
+        for (; i < cmd.Length; i++)
+        {
+            char c = cmd[i];
+            if (c == '"')
+            {
+                inQuotes = !inQuotes;
+                continue;
+            }
+
+            if (inQuotes || !char.IsWhiteSpace(c))
+                continue;
+
+            AddCurrent();
+            start = i + 1;
+        }
+        AddCurrent();
+
+        void AddCurrent()
+        {
+            int length = i - start;
+            if (length > 0)
+                args.Add(cmd.Substring(start, length).Replace("\"", null));
+        }
+
+        return args.ToArray();
+    }
+
     private static bool ParseArgs(string[] args)
     {
+        // If we only get a single argument pointing to a *.arg file
+        // treat content as arguments
+        if (args.Length == 1 && args[0].EndsWith(".arg"))
+        {
+            string fileName = args[0];
+            // args = System.CommandLine.ParsingCommandLineStringSplitter.Instance.Split(File.ReadAllText(fileName)).ToArray();
+            args = SplitCmdLine(File.ReadAllText(fileName));
+        }
+
         string? targetFramework = null;
 
         for (int i = 0; i < args.Length; i++)

--- a/test/TypeDefsGeneratorTests.cs
+++ b/test/TypeDefsGeneratorTests.cs
@@ -253,6 +253,19 @@ export interface GenericDelegate$1<T> { (arg: T): T; }",
             ["T:GenericDelegate`1"] = "generic-delegate",
         }));
     }
+
+    [Theory]
+    [InlineData("abc test 456 z", new[] { "abc", "test", "456", "z" })]
+    [InlineData("abc  test 456   z", new[] { "abc", "test", "456", "z" })]
+    [InlineData("abc test    456 z", new[] { "abc", "test", "456", "z" })]
+    [InlineData(" abc test 456   z  ", new[] { "abc", "test", "456", "z" })]
+    [InlineData(" abc \"a b c\" \"456\"   z  ", new[] { "abc", "a b c", "456", "z" })]
+    public void SplitCmdLine(string cmd, string[] expectedArgs)
+    {
+        var result = Program.SplitCmdLine(cmd);
+
+        Assert.Equal(expectedArgs, result);
+    }
 }
 
 #endif // !NETFRAMEWORK


### PR DESCRIPTION
### Why
Big projects often have a lot of dependencies resulting in a lot of referenced assemblies.
As all of these have to be passed to the generator, the command may quickly exceed the maximum length (on windows).

### What
Similar to `CsWinRT`: Generate a file and use that as args:
https://github.com/microsoft/CsWinRT/blob/ab4eb3d08778aa49f1d4fde0c1bbf635733571a1/nuget/Microsoft.Windows.CsWinRT.targets#L187-L191

### Potential issues
 - The generator has to understand the file-format generated by msbuild
   - Every line as argument
   Easy to parse but needs bigger changes in msbuild files and arg parsing
   - Parse using library (e.g. System.CommandLine)
   SourceGenerators with dependencies are a bit of a pain...
   - Custom parsing (_current implementation_)

---

Fixes #148 