### PR TITLE
Fix publish.yml for .NET 8

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -43,7 +43,7 @@ parameters:
       TargetRuntime: osx-arm64
       DotNetVersion: 8.0.x
       DotNetMoniker: net8.0
-      UseGlobalJson: false
+      UseGlobalJson: true
     - Name: linux_x64
       VMImage: ubuntu-latest
       TargetRuntime: linux-x64
@@ -153,7 +153,7 @@ jobs:
         inputs:
           packageType: sdk
           version: $(DotNetVersion)
-          useGlobalJson: true
+          useGlobalJson: $(UseGlobalJson)
 
       - script: env
         displayName: Print environment

--- a/global.json
+++ b/global.json
@@ -1,6 +1,7 @@
 {
   "sdk": {
     "version": "8.0.100-rc.1",
+    "allowPrerelease": true,
     "rollForward": "latestPatch"
   }
 }


### PR DESCRIPTION
The publish pipeline [failed](https://office.visualstudio.com/ISS/_build/results?buildId=22906754&view=results) because .NET 8 RC1 was not installed because preview versions weren't considered. The [doc for the `UseDotNet@2` task](https://learn.microsoft.com/en-us/azure/devops/pipelines/tasks/reference/use-dotnet-v2?view=azure-pipelines) says `includePreviewVersions` only applies when `useGlobalJson=false`. I assume that means it will respect the `allowPrerelease` property in `global.json` otherwise, so I added that.