### PR TITLE
Update to latest SK and fix issues

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -23,39 +23,28 @@ parameters:
     - Name: win_x64
       VMImage: windows-latest
       TargetRuntime: win-x64
-      DotNetVersion: 8.0.x
-      DotNetMoniker: net8.0
-      UseGlobalJson: true
     - Name: win_arm64
       VMImage: windows-latest
       TargetRuntime: win-arm64
-      DotNetVersion: 8.0.x
-      DotNetMoniker: net8.0
-      UseGlobalJson: true
     - Name: osx_x64
       VMImage: macos-latest
       TargetRuntime: osx-x64
-      DotNetVersion: 8.0.x
-      DotNetMoniker: net8.0
-      UseGlobalJson: true
     - Name: osx_arm64
       VMImage: macos-latest
       TargetRuntime: osx-arm64
-      DotNetVersion: 8.0.x
-      DotNetMoniker: net8.0
       UseGlobalJson: true
     - Name: linux_x64
       VMImage: ubuntu-latest
       TargetRuntime: linux-x64
-      DotNetVersion: 8.0.x
-      DotNetMoniker: net8.0
-      UseGlobalJson: true
 
 jobs:
   # Build Native AOT .Net hosts for Node-API modules.
   - ${{ each matrixEntry in parameters.buildMatrix }}:
     - job: buildAOTBinary${{ matrixEntry.Name }}
       displayName: Build ${{ matrixEntry.TargetRuntime }} AOT binary
+
+      variables:
+        DotNetMoniker: net8.0
 
       pool:
         vmImage: ${{ matrixEntry.VMImage }}
@@ -69,12 +58,10 @@ jobs:
           lfs: false
 
         - task: UseDotNet@2
-          displayName: Install .Net ${{ matrixEntry.DotNetVersion }}
+          displayName: Install .NET SDK using global.json
           inputs:
             packageType: sdk
-            version: ${{ matrixEntry.DotNetVersion }}
-            includePreviewVersions: ${{ eq(matrixEntry.UseGlobalJson, false) }}
-            useGlobalJson: ${{ matrixEntry.UseGlobalJson }}
+            useGlobalJson: true
 
         - script: env
           displayName: Print environment
@@ -82,27 +69,21 @@ jobs:
         - script: dotnet --info
           displayName: Print .Net info
 
-        - task: DeleteFiles@1 # To enable net8.0 use for osx-arm64
-          displayName: Delete global.json
-          inputs:
-            Contents: global.json
-          condition: eq(${{ matrixEntry.UseGlobalJson }}, false)
-
         - script: >
             dotnet publish
             --configuration Release
             --runtime ${{ matrixEntry.TargetRuntime }}
             --no-self-contained
-            --framework ${{ matrixEntry.DotNetMoniker }}
+            --framework $(DotNetMoniker)
           displayName: Build Native AOT binaries
           env:
-            TargetFrameworks: ${{ matrixEntry.DotNetMoniker }}
+            TargetFrameworks: $(DotNetMoniker)
 
         - task: CopyFiles@2
           displayName: Copy Native AOT binaries to staging
           inputs:
             sourceFolder: "$(Build.SourcesDirectory)/out/bin/Release/NodeApi/\
-              ${{ matrixEntry.DotNetMoniker }}/${{ matrixEntry.TargetRuntime }}/publish"
+              $(DotNetMoniker)/${{ matrixEntry.TargetRuntime }}/publish"
             targetFolder: $(Build.StagingDirectory)/AOT/${{ matrixEntry.TargetRuntime }}
             contents: Microsoft.JavaScript.NodeApi.node
 
@@ -126,9 +107,7 @@ jobs:
     variables:
       VMImage: windows-latest
       TargetRuntime: win-x64
-      DotNetVersion: 8.0.x
       DotNetMoniker: net8.0
-      UseGlobalJson: true
       TargetRuntimeList:
 
     pool:
@@ -149,11 +128,10 @@ jobs:
           version: 6.0.x
 
       - task: UseDotNet@2
-        displayName: Install .Net $(DotNetVersion)
+        displayName: Install .NET SDK using global.json
         inputs:
           packageType: sdk
-          version: $(DotNetVersion)
-          useGlobalJson: $(UseGlobalJson)
+          useGlobalJson: true
 
       - script: env
         displayName: Print environment

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -51,15 +51,5 @@
     <NetFramework>false</NetFramework>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Nerdbank.GitVersioning" PrivateAssets="all" />
-    <!-- All projects need to be rebuilt if the version changes. -->
-    <Content Include="$(MSBuildThisFileDirectory)version.json" Link="version.json">
-      <CopyToOutputDirectory>DoNotCopy</CopyToOutputDirectory>
-      <Visible>false</Visible><!-- Hide from VS solution explorer -->
-      <Pack>false</Pack> <!--Exclude from NuGet packages -->
-    </Content>
-  </ItemGroup>
-
   <Import Project="./rid.props" />
 </Project>

--- a/examples/semantic-kernel/semantic-kernel.csproj
+++ b/examples/semantic-kernel/semantic-kernel.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SemanticKernel" Version="0.14.547.1-preview" />
+    <PackageReference Include="Microsoft.SemanticKernel" Version="0.24.230918.1-preview" />
     <PackageReference Include="Microsoft.JavaScript.NodeApi.Generator" Version="0.4.*-*" />
   </ItemGroup>
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,0 +1,14 @@
+<Project>
+    <Import Project="../Directory.Build.props" />
+
+  <ItemGroup>
+    <PackageReference Include="Nerdbank.GitVersioning" PrivateAssets="all" />
+    <!-- All projects need to be rebuilt if the version changes. -->
+    <Content Include="$(MSBuildThisFileDirectory)version.json" Link="version.json">
+      <CopyToOutputDirectory>DoNotCopy</CopyToOutputDirectory>
+      <Visible>false</Visible><!-- Hide from VS solution explorer -->
+      <Pack>false</Pack> <!--Exclude from NuGet packages -->
+    </Content>
+  </ItemGroup>
+
+  </Project>

--- a/src/NodeApi.DotNetHost/JSInterfaceMarshaller.cs
+++ b/src/NodeApi.DotNetHost/JSInterfaceMarshaller.cs
@@ -114,8 +114,7 @@ internal class JSInterfaceMarshaller
                 typeBuilder,
                 property,
                 getFieldBuilder,
-                setFieldBuilder,
-                marshaller);
+                setFieldBuilder);
         }
 
         foreach (MethodInfo method in interfaceMethods)
@@ -127,7 +126,7 @@ internal class JSInterfaceMarshaller
 
         foreach (EventInfo eventInfo in interfaceEvents)
         {
-            BuildEventImplementation(typeBuilder, eventInfo, marshaller);
+            BuildEventImplementation(typeBuilder, eventInfo);
         }
 
         implementationType = typeBuilder.CreateType()!;
@@ -212,8 +211,7 @@ internal class JSInterfaceMarshaller
         TypeBuilder typeBuilder,
         PropertyInfo property,
         FieldInfo? getDelegateField,
-        FieldInfo? setDelegateField,
-        JSMarshaller marshaller)
+        FieldInfo? setDelegateField)
     {
         PropertyBuilder propertyBuilder = typeBuilder.DefineProperty(
             property.Name,
@@ -472,8 +470,7 @@ internal class JSInterfaceMarshaller
 
     private static void BuildEventImplementation(
         TypeBuilder typeBuilder,
-        EventInfo eventInfo,
-        JSMarshaller marshaller)
+        EventInfo eventInfo)
     {
         EventBuilder eventBuilder = typeBuilder.DefineEvent(
             eventInfo.DeclaringType!.Name + ".add_" + eventInfo.Name, // Explicit interface impl

--- a/src/NodeApi.DotNetHost/JSMarshaller.cs
+++ b/src/NodeApi.DotNetHost/JSMarshaller.cs
@@ -249,6 +249,13 @@ public class JSMarshaller
     }
 
     /// <summary>
+    /// Gets a delegate for a .NET adapter to a JS method, using the current thread
+    /// JS marshaller instance.
+    /// </summary>
+    public static Delegate StaticGetToJSMethodDelegate(MethodInfo method)
+        => Current.GetToJSMethodDelegate(method);
+
+    /// <summary>
     /// Gets a lambda expression that converts from a JS value to a specified type.
     /// </summary>
     /// <param name="toType">The type the value will be converted to.</param>

--- a/src/NodeApi.DotNetHost/TypeExporter.cs
+++ b/src/NodeApi.DotNetHost/TypeExporter.cs
@@ -208,7 +208,7 @@ internal class TypeExporter
             {
                 ExportTypeIfSupported(method.ReturnType);
             }
-            
+
             if (member is MethodInfo interfaceMethod && type.IsInterface)
             {
                 // Interface method parameter types must be exported in case the interface

--- a/src/NodeApi.DotNetHost/TypeExporter.cs
+++ b/src/NodeApi.DotNetHost/TypeExporter.cs
@@ -201,13 +201,15 @@ internal class TypeExporter
             {
                 ExportTypeIfSupported(property.PropertyType);
             }
-            else if (member is MethodInfo method &&
+
+            if (member is MethodInfo method &&
                 IsSupportedMethod(method) &&
                 !JSMarshaller.IsConvertedType(method.ReturnType))
             {
                 ExportTypeIfSupported(method.ReturnType);
             }
-            else if (member is MethodInfo interfaceMethod && type.IsInterface)
+            
+            if (member is MethodInfo interfaceMethod && type.IsInterface)
             {
                 // Interface method parameter types must be exported in case the interface
                 // will be implemented by JS.
@@ -339,6 +341,8 @@ internal class TypeExporter
 
             if (methods.Any((m) => m.IsGenericMethodDefinition))
             {
+                Trace($"    {(methodIsStatic ? "static " : string.Empty)}{methodName}<>()");
+
                 MethodInfo[] genericMethods = methods.Where(
                     (m) => m.IsGenericMethodDefinition).ToArray();
                 ExportGenericMethodDefinition(classBuilder, genericMethods);

--- a/src/NodeApi.Generator/TypeDefinitionsGenerator.cs
+++ b/src/NodeApi.Generator/TypeDefinitionsGenerator.cs
@@ -603,7 +603,11 @@ import { Duplex } from 'stream';
             {
                 // Extending generic collection interfaces gets tricky because of the way
                 // those are projected to JS types. For now, those are just omitted here.
-                implements += prefix + GetTSType(interfaceType, nullability: null);
+                string tsType = GetTSType(interfaceType, nullability: null);
+                if (tsType != "unknown")
+                {
+                    implements += prefix + tsType;
+                }
             }
         }
 
@@ -1311,9 +1315,6 @@ import { Duplex } from 'stream';
         if (memberElement == null || summaryElement == null ||
             string.IsNullOrWhiteSpace(summaryElement.Value))
         {
-#if DEBUG
-            s += $"/** [{memberDocName}] **/";
-#endif
             return;
         }
 

--- a/src/NodeApi/Interop/JSInterface.cs
+++ b/src/NodeApi/Interop/JSInterface.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Reflection;
 
 namespace Microsoft.JavaScript.NodeApi.Interop;
 
@@ -34,7 +35,7 @@ public abstract class JSInterface
 
     /// <summary>
     /// Dynamically invokes an interface method JS adapter delegate after obtaining the JS `this`
-    /// value from the reference.
+    /// value from the reference. Automatically switches to the JS thread if needed.
     /// </summary>
     /// <param name="interfaceMethod">Interface method JS adapter delegate.</param>
     /// <param name="args">Array of method arguments starting at index 1. Index 0 is reserved
@@ -48,6 +49,31 @@ public abstract class JSInterface
         {
             args[0] = value;
             return interfaceMethod.DynamicInvoke(args);
+        });
+    }
+
+    /// <summary>
+    /// Dynamically invokes an interface method JS adapter delegate after obtaining the JS `this`
+    /// value from the reference. Automatically switches to the JS thread if needed.
+    /// </summary>
+    /// <param name="interfaceMethod">Interface method to invoke.</param>
+    /// <param name="delegateProvider">Callback function that returns a JS adapter delegate
+    /// for the interface method. The callback runs on the JS thread.</param>
+    /// <param name="args">Array of method arguments starting at index 1. Index 0 is reserved
+    /// for the JS `this` value.</param>
+    /// <remarks>
+    /// This method is used by the dynamically-emitted interface marshalling code.
+    /// </remarks>
+    protected object? DynamicInvoke(
+        MethodInfo interfaceMethod,
+        Func<MethodInfo, Delegate> delegateProvider,
+        object?[] args)
+    {
+        return ValueReference.Run((value) =>
+        {
+            args[0] = value;
+            Delegate interfaceMethodDelegate = delegateProvider(interfaceMethod);
+            return interfaceMethodDelegate.DynamicInvoke(args);
         });
     }
 }

--- a/test/TypeDefsGeneratorTests.cs
+++ b/test/TypeDefsGeneratorTests.cs
@@ -181,7 +181,7 @@ export interface GenericInterface$1<T> {
         {
             ["T:GenericInterface`1"] = "generic-interface",
             ["P:GenericInterface`1.TestProperty"] = "instance-property",
-            ["M:GenericInterface`1.TestMethod(T)"] = "instance-method",
+            ["M:GenericInterface`1.TestMethod(`0)"] = "instance-method",
         }));
     }
 
@@ -224,11 +224,11 @@ export interface GenericClass$1<T> {
         GenerateTypeDefinition(typeof(GenericClass<>), new Dictionary<string, string>
         {
             ["T:GenericClass`1"] = "generic-class",
-            ["M:GenericClass`1.#ctor(T)"] = "constructor",
+            ["M:GenericClass`1.#ctor(`0)"] = "constructor",
             ["P:GenericClass`1.TestStaticProperty"] = "static-property",
-            ["M:GenericClass`1.TestStaticMethod(T)"] = "static-method",
+            ["M:GenericClass`1.TestStaticMethod(`0)"] = "static-method",
             ["P:GenericClass`1.TestProperty"] = "instance-property",
-            ["M:GenericClass`1.TestMethod(T)"] = "instance-method",
+            ["M:GenericClass`1.TestMethod(`0)"] = "instance-method",
         }));
     }
 


### PR DESCRIPTION
Fixes #151 

 - Fix a bug in the dynamic type exporter that caused it to skip exporting parameter types referenced by interface methods.
 - Automatically switch to the JS thread when calling form .NET to a JS interface method.
 - Emit stubs for `add_` and `remove_` event methods when dynamically generating a JS proxy for an interface. Events are still [not yet supported](https://github.com/microsoft/node-api-dotnet/issues/59), but this fix prevents events on an interface from blocking other members of the interface from being used.
 - Include base interfaces (`extends` clause) when generating interface type definitions.
 - Fix doc-comment lookup for generic methods when generating type definitions.
 - Update the example to Semantic version 0.24.
    - It has been a while since the last update, so there were several API changes that required updating the `example.js` code.
    - It has a new way of [dynamically loading the `PromptTemplateEngine` assembly](https://github.com/microsoft/semantic-kernel/blob/3451a4ebbc9db0d049f48804c12791c681a326cb/dotnet/src/SemanticKernel.Core/KernelBuilder.cs#L279) which requires a minor workaround. That took me a while to figure out why the input string wasn't getting incorporated in the request: because when that assembly was not loaded the null prompt engine ignored the input.