### PR TITLE
Add benchmarks, GC handle tracking test

### DIFF
--- a/bench/Benchmarks.cs
+++ b/bench/Benchmarks.cs
@@ -7,80 +7,265 @@ using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Running;
+using Microsoft.JavaScript.NodeApi.DotNetHost;
+using Microsoft.JavaScript.NodeApi.Interop;
 using Microsoft.JavaScript.NodeApi.Runtimes;
 using static Microsoft.JavaScript.NodeApi.JSNativeApi.Interop;
 using static Microsoft.JavaScript.NodeApi.Test.TestUtils;
 
 namespace Microsoft.JavaScript.NodeApi.Bench;
 
+/// <summary>
+/// Micro-benchmarks for various .NET + JS interop operations.
+/// </summary>
+/// <remarks>
+/// These benchmarks run both .NET and Node.js code, and call between them. The benchmark
+/// runner manages the GC for the .NET runtime, but it doesn't know anything about the JS runtime.
+/// To avoid heavy JS GC pressure from millions of operations (which may each allocate objects),
+/// these benchmarks use the `ShortRunJob` attribute (which sacrifices some precision but also
+/// doesn't take as long to run).
+/// </remarks>
+[IterationCount(5)]
+[WarmupCount(1)]
 public abstract class Benchmarks
 {
     public static void Main(string[] args)
     {
-        // Example: dotnet run -c Release --filter aot
+#if DEBUG
+        IConfig config = new DebugBuildConfig();
+#else
+        IConfig config = DefaultConfig.Instance;
+#endif
+
+        // Example: dotnet run -c Release --filter clr
         // If no filter is specified, the switcher will prompt.
         BenchmarkSwitcher.FromAssembly(typeof(Benchmarks).Assembly).Run(args,
-            ManualConfig.Create(DefaultConfig.Instance).WithOptions(ConfigOptions.JoinSummary));
-    }
-
-    public class NonAot : Benchmarks
-    {
-        // Non-AOT-only benchmarks may go here
-    }
-
-    [SimpleJob(RuntimeMoniker.NativeAot70)]
-    public class Aot : Benchmarks
-    {
-        // AOT-only benchmarks may go here
+            ManualConfig.Create(config)
+            .WithOptions(ConfigOptions.JoinSummary));
     }
 
     private static string LibnodePath { get; } = Path.Combine(
         GetRepoRootDirectory(),
         "bin",
-        "win-x64", // TODO
+        GetCurrentPlatformRuntimeIdentifier(),
         "libnode" + GetSharedLibraryExtension());
 
     private napi_env _env;
-    private JSValue _function;
-    private JSValue _callback;
+    private JSFunction _jsFunction;
+    private JSFunction _jsFunctionWithArgs;
+    private JSFunction _jsFunctionWithCallback;
+    private JSObject _jsInstance;
+    private JSFunction _dotnetFunction;
+    private JSFunction _dotnetFunctionWithArgs;
+    private JSObject _dotnetClass;
+    private JSObject _dotnetInstance;
+    private JSFunction _jsFunctionCreateInstance;
+    private JSFunction _jsFunctionCallMethod;
+    private JSFunction _jsFunctionCallMethodWithArgs;
     private JSReference _reference = null!;
 
-    [GlobalSetup]
-    public void Setup()
+    /// <summary>
+    /// Simple class that is exported to JS and used in some benchmarks.
+    /// </summary>
+    private class DotnetClass
     {
-        NodejsPlatform platform = new(LibnodePath);
+        public DotnetClass() { }
+
+        public string Property { get; set; } = string.Empty;
+
+#pragma warning disable CA1822 // Method does not access instance data and can be marked as static
+        public static void Method() { }
+#pragma warning restore CA1822
+    }
+
+    /// <summary>
+    /// Setup shared by both CLR and AOT benchmarks.
+    /// </summary>
+    protected void Setup()
+    {
+        NodejsPlatform platform = new(LibnodePath/*, args: new[] { "node", "--expose-gc" }*/);
 
         // This setup avoids using NodejsEnvironment so benchmarks can run on the same thread.
         // NodejsEnvironment creates a separate thread that would slow down the micro-benchmarks.
-        _env = JSNativeApi.CreateEnvironment(
-            (napi_platform)platform, (error) => Console.WriteLine(error), null);
+        _env = JSNativeApi.CreateEnvironment(platform, (error) => Console.WriteLine(error), null);
 
         // The new scope instance saves itself as the thread-local JSValueScope.Current.
         JSValueScope scope = new(JSValueScopeType.Root, _env);
 
         // Create some JS values that will be used by the benchmarks.
 
-        _function = JSNativeApi.RunScript("function callMeBack(cb) { cb(); }; callMeBack");
-        _callback = JSValue.CreateFunction("callback", (args) => JSValue.Undefined);
+        _jsFunction = (JSFunction)JSNativeApi.RunScript("function jsFunction() { }; jsFunction");
+        _jsFunctionWithArgs = (JSFunction)JSNativeApi.RunScript(
+            "function jsFunctionWithArgs(a, b, c) { }; jsFunctionWithArgs");
+        _jsFunctionWithCallback = (JSFunction)JSNativeApi.RunScript(
+            "function jsFunctionWithCallback(cb, ...args) { cb(...args); }; " +
+            "jsFunctionWithCallback");
+        _jsInstance = (JSObject)JSNativeApi.RunScript(
+            "const jsInstance = { method: (...args) => {} }; jsInstance");
 
-        _reference = new JSReference(_function);
+        _dotnetFunction = (JSFunction)JSValue.CreateFunction(
+            "dotnetFunction", (args) => JSValue.Undefined);
+        _dotnetFunctionWithArgs = (JSFunction)JSValue.CreateFunction(
+            "dotnetFunctionWithArgs", (args) =>
+            {
+                for (int i = 0; i < args.Length; i++)
+                {
+                    _ = args[i];
+                }
+
+                return JSValue.Undefined;
+            });
+
+        var classBuilder = new JSClassBuilder<DotnetClass>(
+            nameof(DotnetClass), () => new DotnetClass());
+        classBuilder.AddProperty(
+            "property",
+            (x) => x.Property,
+            (x, value) => x.Property = (string)value);
+        classBuilder.AddMethod("method", (x) => (args) => DotnetClass.Method());
+        _dotnetClass = (JSObject)classBuilder.DefineClass();
+        _dotnetInstance = (JSObject)JSNativeApi.CallAsConstructor(_dotnetClass);
+
+        _jsFunctionCreateInstance = (JSFunction)JSNativeApi.RunScript(
+            "function jsFunctionCreateInstance(Class) { new Class() }; " +
+            "jsFunctionCreateInstance");
+        _jsFunctionCallMethod = (JSFunction)JSNativeApi.RunScript(
+            "function jsFunctionCallMethod(instance) { instance.method(); }; " +
+            "jsFunctionCallMethod");
+        _jsFunctionCallMethodWithArgs = (JSFunction)JSNativeApi.RunScript(
+            "function jsFunctionCallMethodWithArgs(instance, ...args) " +
+            "{ instance.method(...args); }; " +
+            "jsFunctionCallMethodWithArgs");
+
+        _reference = new JSReference(_jsFunction);
     }
 
+    private static JSValueScope NewJSScope() => new(JSValueScopeType.Callback);
+
+    // Benchmarks in the base class run in both CLR and AOT environments.
+
     [Benchmark]
-    public void CallJS()
+    public void CallJSFunction()
     {
-        _function.Call(thisArg: default, _callback);
+        _jsFunction.CallAsStatic();
     }
 
     [Benchmark]
-    public void GetReference()
+    public void CallJSFunctionWithArgs()
+    {
+        _jsFunctionWithArgs.CallAsStatic("1", "2", "3");
+    }
+
+    [Benchmark]
+    public void CallJSMethod()
+    {
+        _jsInstance.CallMethod("method");
+    }
+
+    [Benchmark]
+    public void CallJSMethodWithArgs()
+    {
+        _jsInstance.CallMethod("method", "1", "2", "3");
+    }
+
+    [Benchmark]
+    public void CallDotnetFunction()
+    {
+        _jsFunctionWithCallback.CallAsStatic(_dotnetFunction);
+    }
+
+    [Benchmark]
+    public void CallDotnetFunctionWithArgs()
+    {
+        _jsFunctionWithCallback.CallAsStatic(_dotnetFunctionWithArgs, "1", "2", "3");
+    }
+
+    [Benchmark]
+    public void CallDotnetConstructor()
+    {
+        _jsFunctionCreateInstance.CallAsStatic(_dotnetClass);
+    }
+
+    [Benchmark]
+    public void CallDotnetMethod()
+    {
+        _jsFunctionCallMethod.CallAsStatic(_dotnetInstance);
+    }
+
+    [Benchmark]
+    public void CallDotnetMethodWithArgs()
+    {
+        _jsFunctionCallMethodWithArgs.CallAsStatic(_dotnetInstance, "1", "2", "3");
+    }
+
+    [Benchmark]
+    public void ReferenceGet()
     {
         _ = _reference.GetValue()!.Value;
     }
 
     [Benchmark]
-    public void CreateAndDiposeReference()
+    public void ReferenceCreateAndDipose()
     {
-        using JSReference reference = new(_function);
+        using JSReference reference = new(_jsFunction);
+    }
+
+    [ShortRunJob]
+    [MemoryDiagnoser(displayGenColumns: false)]
+    public class Clr : Benchmarks
+    {
+        private JSObject _jsHost;
+        private JSFunction _jsFunctionCallMethodDynamic;
+        private JSFunction _jsFunctionCallMethodDynamicInterface;
+
+        [GlobalSetup]
+        public new void Setup()
+        {
+            base.Setup();
+
+            // CLR-only (non-AOT) setup
+
+            JSObject hostModule = new();
+            _ = new ManagedHost(hostModule);
+            _jsHost = hostModule;
+            _jsFunctionCallMethodDynamic = (JSFunction)JSNativeApi.RunScript(
+                "function jsFunctionCallMethodDynamic(dotnet) " +
+                "{ dotnet.System.Object.ReferenceEquals(null, null); }; " +
+                "jsFunctionCallMethodDynamic");
+
+            // Implement IFormatProvider in JS and pass it to a .NET method.
+            _jsFunctionCallMethodDynamicInterface = (JSFunction)JSNativeApi.RunScript(
+                "function jsFunctionCallMethodDynamicInterface(dotnet)  {" +
+                "    const formatProvider = { GetFormat: (type) => null };" +
+                "    dotnet.System.String.Format(formatProvider, '', null, null);" +
+                "}; " +
+                "jsFunctionCallMethodDynamicInterface");
+        }
+
+        // CLR-only (non-AOT) benchmarks
+
+        [Benchmark]
+        public void DynamicCallDotnetMethod()
+        {
+            _jsFunctionCallMethodDynamic.CallAsStatic(_jsHost);
+        }
+
+        [Benchmark]
+        public void DynamicCallDotnetMethodWithInterface()
+        {
+            _jsFunctionCallMethodDynamicInterface.CallAsStatic(_jsHost);
+        }
+    }
+
+    [ShortRunJob(RuntimeMoniker.NativeAot80)]
+    public class Aot : Benchmarks
+    {
+        [GlobalSetup]
+        public new void Setup()
+        {
+            base.Setup();
+        }
+
+        // AOT-only benchmarks
     }
 }

--- a/bench/NodeApi.Bench.csproj
+++ b/bench/NodeApi.Bench.csproj
@@ -13,6 +13,7 @@
 
   <ItemGroup>
     <Compile Include="../test/TestUtils.cs" Link="TestUtils.cs" />
+    <None Remove="BenchmarkDotNet.Artifacts/**" />
   </ItemGroup>
 
   <ItemGroup>

--- a/bench/README.md
+++ b/bench/README.md
@@ -1,0 +1,26 @@
+# Micro-benchmarks for node-api-dotnet APIs
+
+This project contains a set of micro-benchmarks for .NET + JS interop operations, driven by
+[BenchmarkDotNet](https://benchmarkdotnet.org/). Most benchmarks run in both CLR and AOT modes,
+though the "Dynamic" benchmarks are CLR-only.
+
+### Run all benchmarks
+```
+dotnet run -c Release -f net8.0 --filter *
+```
+
+### Run only CLR or only AOT benchmarks
+```
+dotnet run -c Release -f net8.0 --filter *clr.*
+dotnet run -c Release -f net8.0 --filter *aot.*
+```
+
+### Run a specific benchmark
+```
+dotnet run -c Release -f net8.0 --filter *clr.CallDotnetFunction
+```
+
+### List benchmarks
+```
+dotnet run -c Release -f net8.0 --list flat
+```

--- a/src/NodeApi.DotNetHost/JSMarshaller.cs
+++ b/src/NodeApi.DotNetHost/JSMarshaller.cs
@@ -1860,10 +1860,10 @@ public class JSMarshaller
             // public type is passed to JS and then passed back to .NET as `object` type.
 
             /*
-             * (T)(value.TryUnwrap() ?? value.GetValueExternal());
+             * (T)(value.TryUnwrap() ?? value.TryGetValueExternal());
              */
             MethodInfo getExternalMethod =
-                typeof(JSNativeApi).GetStaticMethod(nameof(JSNativeApi.GetValueExternal));
+                typeof(JSNativeApi).GetStaticMethod(nameof(JSNativeApi.TryGetValueExternal));
             statements = new[]
             {
                 Expression.Convert(

--- a/src/NodeApi.DotNetHost/ManagedHost.cs
+++ b/src/NodeApi.DotNetHost/ManagedHost.cs
@@ -98,7 +98,12 @@ public sealed class ManagedHost : JSEventEmitter, IDisposable
     /// </remarks>
     private readonly Dictionary<string, JSReference> _loadedModules = new();
 
-    private ManagedHost(JSObject exports)
+    /// <summary>
+    /// Creates a new instance of a <see cref="ManagedHost" /> that supports loading and
+    /// invoking managed .NET assemblies in a JavaScript process.
+    /// </summary>
+    /// <param name="exports">JS object on which the managed host APIs will be exported.</param>
+    public ManagedHost(JSObject exports)
     {
 #if NETFRAMEWORK
         AppDomain.CurrentDomain.AssemblyResolve += OnResolvingAssembly;

--- a/src/NodeApi.DotNetHost/TypeExporter.cs
+++ b/src/NodeApi.DotNetHost/TypeExporter.cs
@@ -477,7 +477,6 @@ internal class TypeExporter
 
         if (type.IsPointer ||
             type == typeof(void) ||
-            type == typeof(Type) ||
             type.Namespace == "System.Reflection" ||
             (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Memory<>)) ||
             (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(ReadOnlyMemory<>)) ||

--- a/src/NodeApi/Interop/JSRuntimeContext.cs
+++ b/src/NodeApi/Interop/JSRuntimeContext.cs
@@ -612,7 +612,7 @@ public sealed class JSRuntimeContext : IDisposable
         references.Clear();
     }
 
-    
+
     private long _gcHandleCount;
 
     /// <summary>
@@ -627,7 +627,7 @@ public sealed class JSRuntimeContext : IDisposable
     /// </remarks>
     public long GCHandleCount => _gcHandleCount;
 
-    #if DEBUG
+#if DEBUG
 
     /// <summary>
     /// Records the target object and allocation stack trace of a GC handle.
@@ -646,7 +646,7 @@ public sealed class JSRuntimeContext : IDisposable
     public Dictionary<nint, GCHandleInfo> GCHandleMap { get; }
         = new Dictionary<nint, GCHandleInfo>();
 
-    #endif
+#endif
 
     /// <summary>
     /// Allocates a GC handle and tracks the allocation on the current runtime context. Call this
@@ -694,7 +694,7 @@ public sealed class JSRuntimeContext : IDisposable
             // JSRuntimeContext is not in the map because its constructor calls SetInstanceData()
             // before it can be assigned to the root JSValueScope.
             if (!currentContext.GCHandleMap.Remove((nint)handle) &&
-                !(handle.Target is JSRuntimeContext))
+                handle.Target is not JSRuntimeContext)
             {
                 throw new InvalidOperationException("Freed GC handle was not in the handle map.");
             }

--- a/src/NodeApi/JSObject.cs
+++ b/src/NodeApi/JSObject.cs
@@ -74,6 +74,24 @@ public readonly partial struct JSObject : IDictionary<JSValue, JSValue>, IEquata
         set => _value.SetProperty(name, value);
     }
 
+    public JSValue CallMethod(JSValue methodName)
+        => _value.GetProperty(methodName).Call(_value);
+
+    public JSValue CallMethod(JSValue methodName, JSValue arg0)
+        => _value.GetProperty(methodName).Call(_value, arg0);
+
+    public JSValue CallMethod(JSValue methodName, JSValue arg0, JSValue arg1)
+        => _value.GetProperty(methodName).Call(_value, arg0, arg1);
+
+    public JSValue CallMethod(JSValue methodName, JSValue arg0, JSValue arg1, JSValue arg2)
+        => _value.GetProperty(methodName).Call(_value, arg0, arg1, arg2);
+
+    public JSValue CallMethod(JSValue methodName, params JSValue[] args)
+        => _value.GetProperty(methodName).Call(_value, args);
+
+    public JSValue CallMethod(JSValue methodName, ReadOnlySpan<JSValue> args)
+        => _value.GetProperty(methodName).Call(_value, args);
+
     public void Add(JSValue key, JSValue value) => _value.SetProperty(key, value);
 
     public bool ContainsKey(JSValue key) => _value.HasProperty(key);

--- a/src/NodeApi/JSValue.cs
+++ b/src/NodeApi/JSValue.cs
@@ -164,7 +164,7 @@ public readonly struct JSValue : IEquatable<JSValue>
     public static unsafe JSValue CreateFunction(
         ReadOnlySpan<byte> utf8Name, JSCallback callback, object? callbackData = null)
     {
-        GCHandle descriptorHandle = GCHandle.Alloc(
+        GCHandle descriptorHandle = JSRuntimeContext.AllocGCHandle(
             new JSCallbackDescriptor(callback, callbackData));
         JSValue func = CreateFunction(
             utf8Name,
@@ -179,7 +179,7 @@ public readonly struct JSValue : IEquatable<JSValue>
     private static unsafe JSValue CreateFunction(
         byte* utf8Name, int utf8NameLength, JSCallback callback, object? callbackData = null)
     {
-        GCHandle descriptorHandle = GCHandle.Alloc(
+        GCHandle descriptorHandle = JSRuntimeContext.AllocGCHandle(
             new JSCallbackDescriptor(callback, callbackData));
         JSValue func = napi_create_function(
             Env,
@@ -236,7 +236,7 @@ public readonly struct JSValue : IEquatable<JSValue>
 
     public static unsafe JSValue CreateExternal(object value)
     {
-        GCHandle valueHandle = GCHandle.Alloc(value);
+        GCHandle valueHandle = JSRuntimeContext.AllocGCHandle(value);
         return napi_create_external(
             Env,
             (nint)valueHandle,
@@ -271,7 +271,7 @@ public readonly struct JSValue : IEquatable<JSValue>
             (nuint)pinnedMemory.Length,
             // We pass object to finalize as a hint parameter
             new napi_finalize(s_finalizeHintHandle),
-            (nint)GCHandle.Alloc(pinnedMemory),
+            (nint)JSRuntimeContext.AllocGCHandle(pinnedMemory),
             out napi_value result)
             .ThrowIfFailed(result);
     }

--- a/src/NodeApi/JSValueScope.cs
+++ b/src/NodeApi/JSValueScope.cs
@@ -56,6 +56,16 @@ public enum JSValueScopeType
     Escapable,
 }
 
+/// <summary>
+/// A scope that controls the lifetime of JS values. When the scope is disposed, any
+/// JS values created within the scope are released unless they are held by a strong
+/// <see cref="JSReference" />.
+/// </summary>
+/// <remarks>
+/// Every call from JS to .NET creates a separate scope for the duration of the call.
+/// That means any JS values created during the call are released when the call returns,
+/// unless they are returned to JS or held by a strong <see cref="JSReference" />.
+/// </remarks>
 public sealed class JSValueScope : IDisposable
 {
     private readonly JSValueScope? _parentScope;
@@ -67,12 +77,19 @@ public sealed class JSValueScope : IDisposable
 
     public JSValueScopeType ScopeType { get; }
 
+    /// <summary>
+    /// Gets the current JS value scope.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">No scope was established for the current
+    /// thread.</exception>
     public static JSValueScope Current => s_currentScope ??
         throw new InvalidOperationException("No current scope.");
 
     public bool IsDisposed { get; private set; }
 
     public JSRuntimeContext RuntimeContext { get; }
+
+    internal static JSRuntimeContext? CurrentRuntimeContext => s_currentScope?.RuntimeContext;
 
     public JSModuleContext? ModuleContext { get; internal set; }
 

--- a/src/NodeApi/Runtimes/NodejsEnvironment.cs
+++ b/src/NodeApi/Runtimes/NodejsEnvironment.cs
@@ -274,4 +274,30 @@ public sealed class NodejsEnvironment : IDisposable
     /// not initialized.</exception>
     public JSValue Import(string? module, string? property = null)
         => _scope.RuntimeContext.Import(module, property);
+
+    /// <summary>
+    /// Runs garbage collection in the JS environment.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">The Node.js platform was not initialized
+    /// with the --expose-gc option.</exception>
+    public void GC()
+    {
+        bool result = SynchronizationContext.Run(() =>
+        {
+            JSValue gcFunction = JSValue.Global["gc"];
+            if (gcFunction.TypeOf() != JSValueType.Function)
+            {
+                return false;
+            }
+
+            gcFunction.Call();
+            return true;
+        });
+        
+        if (!result)
+        {
+            throw new InvalidOperationException("The global gc() function was not found. " +
+                "Make sure the Node.js platform was initialized with the `--enable-gc` option.");
+        }
+    }
 }

--- a/src/NodeApi/Runtimes/NodejsEnvironment.cs
+++ b/src/NodeApi/Runtimes/NodejsEnvironment.cs
@@ -293,7 +293,7 @@ public sealed class NodejsEnvironment : IDisposable
             gcFunction.Call();
             return true;
         });
-        
+
         if (!result)
         {
             throw new InvalidOperationException("The global gc() function was not found. " +

--- a/src/NodeApi/Runtimes/NodejsPlatform.cs
+++ b/src/NodeApi/Runtimes/NodejsPlatform.cs
@@ -22,7 +22,7 @@ public sealed class NodejsPlatform : IDisposable
 {
     private readonly napi_platform _platform;
 
-    public static explicit operator napi_platform(NodejsPlatform platform) => platform._platform;
+    public static implicit operator napi_platform(NodejsPlatform platform) => platform._platform;
 
     /// <summary>
     /// Initializes the Node.js platform.

--- a/test/GCTests.cs
+++ b/test/GCTests.cs
@@ -1,0 +1,90 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.IO;
+using Microsoft.JavaScript.NodeApi.Interop;
+using Microsoft.JavaScript.NodeApi.Runtimes;
+using Xunit;
+using static Microsoft.JavaScript.NodeApi.Test.TestUtils;
+
+namespace Microsoft.JavaScript.NodeApi.Test;
+
+public class GCTests
+{
+    private static string LibnodePath { get; } = GetLibnodePath();
+
+    // The Node.js platform may only be initialized once per process.
+    private static NodejsPlatform? NodejsPlatform { get; } =
+        File.Exists(LibnodePath) ? new(LibnodePath, args: new[] { "node", "--expose-gc" }) : null;
+
+    [SkippableFact]
+    public void GCTest()
+    {
+        Skip.If(NodejsPlatform == null, "Node shared library not found at " + LibnodePath);
+        using NodejsEnvironment nodejs = NodejsPlatform.CreateEnvironment();
+
+        long gcHandleCount = 0;
+        nodejs.SynchronizationContext.Run(() =>
+        {
+            Assert.Equal(0, JSRuntimeContext.Current.GCHandleCount);
+
+            JSClassBuilder<DotnetClass> classBuilder =
+                new(nameof(DotnetClass), () => new DotnetClass());
+            classBuilder.AddProperty(
+                "property",
+                (x) => x.Property,
+                (x, value) => x.Property = (string)value);
+            classBuilder.AddMethod("method", (x) => (args) => DotnetClass.Method());
+            JSObject dotnetClass = (JSObject)classBuilder.DefineClass();
+
+            JSFunction jsCreateInstanceFunction = (JSFunction)JSNativeApi.RunScript(
+                "function jsCreateInstanceFunction(Class) { new Class() }; " +
+                "jsCreateInstanceFunction");
+
+            // 5 GC handles are expected
+            // - Type: DotnetClass
+            // - JSCallback: DotnetClass.constructor
+            // - JSPropertyDescriptor: DotnetClass.property
+            // - JSPropertyDescriptor: DotnetClass.method
+            // - JSPropertyDescriptor: DotnetClass.toString
+            Assert.Equal(5, JSRuntimeContext.Current.GCHandleCount);
+
+            using JSValueScope innerScope = new JSValueScope(JSValueScopeType.Callback);
+            jsCreateInstanceFunction.CallAsStatic(dotnetClass);
+
+            gcHandleCount = JSRuntimeContext.Current.GCHandleCount;
+        });
+
+        // Some GC handles should have been allocated by the JS create-instance function call.
+        Assert.True(gcHandleCount > 5);
+
+        nodejs.GC();
+
+        // After GC, the handle count should have reverted back to the original set.
+        gcHandleCount = nodejs.SynchronizationContext.Run(
+                () => JSRuntimeContext.Current.GCHandleCount);
+        Assert.Equal(5, gcHandleCount);
+    }
+
+    private class DotnetClass
+    {
+        public static ulong Instances;
+
+        public DotnetClass()
+        {
+            ++Instances;
+        }
+
+        public string Property { get; set; } = string.Empty;
+
+#pragma warning disable CA1822 // Method does not access instance data and can be marked as static
+        public static void Method() { }
+#pragma warning restore CA1822
+
+        ~DotnetClass()
+        {
+            --Instances;
+        }
+    }
+}

--- a/test/GCTests.cs
+++ b/test/GCTests.cs
@@ -50,7 +50,7 @@ public class GCTests
             // - JSPropertyDescriptor: DotnetClass.toString
             Assert.Equal(5, JSRuntimeContext.Current.GCHandleCount);
 
-            using JSValueScope innerScope = new JSValueScope(JSValueScopeType.Callback);
+            using JSValueScope innerScope = new(JSValueScopeType.Callback);
             jsCreateInstanceFunction.CallAsStatic(dotnetClass);
 
             gcHandleCount = JSRuntimeContext.Current.GCHandleCount;


### PR DESCRIPTION
 - Add more micro-benchmarks covering a variety of basic .NET <-> JS calls.
 - Add GC handle tracking: track just a handle count in release mode, and allocation stack in debug mode.
 - Add a test case that uses the handle-tracking to verify proper GC after constructing a .NET instance from JS, then releasing it.
 - Implement string array marshalling for `napi_create_platform` (to support `--enable-gc` option)
 - Add `TryGetValueExternal()` API, which returns `null` if the value is not an external. This fixes a bug in marshalling that arose when constructing a `ManagedHost` instance for benchmarks.

I added GC handle tracking because I was struggling with GC pressure during the many iterations that BenchmarkDotNet likes to run. First I thought there was a leak, but the test confirmed there is not. The problem is just that BenchmarkDotNet can run millions of iterations, which may each allocate and release objects, and JS GC does not keep up, so successive iterations get gradually slower. I couldn't figure out a way to explicitly run the JS GC during tests without distorting the benchmark results. (The test runner carefully manages the .NET GC, but doesn't know anything about JS.) So the workaround for now is to reduce the number of iterations.