### PR TITLE
Fix nullability context for typedefs generator

### DIFF
--- a/src/NodeApi.Generator/Program.cs
+++ b/src/NodeApi.Generator/Program.cs
@@ -224,6 +224,7 @@ public static class Program
             }
             string dotnetRootDirectory = Path.GetDirectoryName(Path.GetDirectoryName(
                 Path.GetDirectoryName(runtimeDirectory)!)!)!;
+
             string refAssemblyDirectory = Path.Combine(
                 dotnetRootDirectory,
                 "packs",


### PR DESCRIPTION
Fixes #147

This took a while to diagnose... The nullability context was not loading correctly for value-types (such as `DateTime`), because `IsValueType` was incorrectly returning `false`, because the referenced `System.ValueType` was loaded from a reference assembly instead of a runtime assembly. I added a workaround in the TS generator that fixes the problem.