### PR TITLE
Update to latest SK version, fix type exporter bug

### DIFF
--- a/examples/semantic-kernel/example.js
+++ b/examples/semantic-kernel/example.js
@@ -5,12 +5,8 @@
 
 import dotnet from 'node-api-dotnet';
 import './bin/Microsoft.SemanticKernel.Core.js';
+import './bin/Microsoft.SemanticKernel.Functions.Semantic.js';
 import './bin/Microsoft.SemanticKernel.Connectors.AI.OpenAI.js';
-
-// The PromptTemplateEngine assembly must be explicitly loaded here, because
-// SK KernelBuilder uses Assembly.Load() to load it, and that is not detected
-// by the JS exporter.
-import './bin/Microsoft.SemanticKernel.TemplateEngine.PromptTemplateEngine.js';
 
 const SK = dotnet.Microsoft.SemanticKernel;
 const Logging = dotnet.Microsoft.Extensions.Logging;
@@ -56,9 +52,10 @@ does not conflict with the First or Second Law.
 `;
 
 // The JS marshaller does not yet support extension methods.
-const summaryFunction = SK.InlineFunctionsDefinitionExtension
+const summaryFunction = SK.KernelSemanticFunctionExtensions
   .CreateSemanticFunction(kernel, skPrompt);
 
-const summary = await SK.SKFunctionExtensions.InvokeAsync(summaryFunction, textToSummarize);
+const summary = await SK.SKFunctionExtensions.InvokeAsync(
+  summaryFunction, textToSummarize, kernel);
 
 console.log(summary.toString());

--- a/examples/semantic-kernel/semantic-kernel.csproj
+++ b/examples/semantic-kernel/semantic-kernel.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SemanticKernel" Version="0.24.230918.1-preview" />
+    <PackageReference Include="Microsoft.SemanticKernel" Version="1.0.0-beta2" />
     <PackageReference Include="Microsoft.JavaScript.NodeApi.Generator" Version="0.4.*-*" />
   </ItemGroup>
 

--- a/src/NodeApi.DotNetHost/JSMarshaller.cs
+++ b/src/NodeApi.DotNetHost/JSMarshaller.cs
@@ -159,8 +159,7 @@ public class JSMarshaller
         }
 
         if (type.IsGenericTypeDefinition &&
-            (type == typeof(Task<>) ||
-            type == typeof(CancellationToken) ||
+            (type == typeof(CancellationToken) ||
             type == typeof(IEnumerable<>) ||
             type == typeof(IAsyncEnumerable<>) ||
             type == typeof(ICollection<>) ||

--- a/src/NodeApi.DotNetHost/TypeExporter.cs
+++ b/src/NodeApi.DotNetHost/TypeExporter.cs
@@ -172,6 +172,7 @@ internal class TypeExporter
             {
                 Type genericTypeDefinition = dependencyType.GetGenericTypeDefinition();
                 if (genericTypeDefinition == typeof(Nullable<>) ||
+                    genericTypeDefinition == typeof(Task<>) ||
                     genericTypeDefinition.Namespace == typeof(IList<>).Namespace)
                 {
                     foreach (Type typeArg in dependencyType.GetGenericArguments())
@@ -217,6 +218,8 @@ internal class TypeExporter
                 {
                     ExportTypeIfSupported(interfaceMethodParameter.ParameterType);
                 }
+
+                ExportTypeIfSupported(interfaceMethod.ReturnType);
             }
         }
     }


### PR DESCRIPTION
If a parameter or return type of an exported method was `Task<>`, the type argument did not get auto-exported, which caused an error message "Type not registered for JS export". 