### PR TITLE
Update to .NET 8.0 rc2

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -61,7 +61,9 @@ jobs:
           displayName: Install .NET SDK using global.json
           inputs:
             packageType: sdk
-            useGlobalJson: true
+            useGlobalJson: false # Switch to true and remove explicit version after .NET 8 release
+            version: 8.0.x
+            includePreviewVersions: true
 
         - script: env
           displayName: Print environment
@@ -131,7 +133,9 @@ jobs:
         displayName: Install .NET SDK using global.json
         inputs:
           packageType: sdk
-          useGlobalJson: true
+          useGlobalJson: false # Switch to true and remove explicit version after .NET 8 release
+          version: 8.0.x
+          includePreviewVersions: true
 
       - script: env
         displayName: Print environment

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.100-rc.1",
+    "version": "8.0.100-rc.2",
     "allowPrerelease": true,
     "rollForward": "latestPatch"
   }


### PR DESCRIPTION
This should also fix the broken release pipeline. Apparently the `UseDotNet@2` task does not support prerelease versions when using `global.json`, regardless of the `includePreviewVersions` value in the YAML or the `allowPrerelease` value in `global.json`.