### PR TITLE
Update SK example, fix bugs

### DIFF
--- a/examples/semantic-kernel/semantic-kernel.csproj
+++ b/examples/semantic-kernel/semantic-kernel.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SemanticKernel" Version="1.0.0-beta2" />
+    <PackageReference Include="Microsoft.SemanticKernel" Version="1.0.0-beta8" />
     <PackageReference Include="Microsoft.JavaScript.NodeApi.Generator" Version="0.4.*-*" />
   </ItemGroup>
 

--- a/src/NodeApi.DotNetHost/JSMarshaller.cs
+++ b/src/NodeApi.DotNetHost/JSMarshaller.cs
@@ -2166,7 +2166,8 @@ public class JSMarshaller
             Type[]? genericArguments = fromType.IsGenericType ?
                 fromType.GetGenericArguments() : null;
 
-            if (genericTypeDefinition == typeof(Memory<>))
+            if (genericTypeDefinition == typeof(Memory<>) ||
+                genericTypeDefinition == typeof(ReadOnlyMemory<>))
             {
                 Type elementType = fromType.GenericTypeArguments[0];
                 if (!IsTypedArrayType(elementType))
@@ -2564,8 +2565,9 @@ public class JSMarshaller
         foreach (PropertyInfo property in toType.GetProperties(
             BindingFlags.Public | BindingFlags.Instance))
         {
-            if (property.SetMethod == null)
+            if (property.SetMethod == null || property.SetMethod.GetParameters().Length > 0)
             {
+                // Skip indexed properties, where the setter takes one or more parameters. 
                 continue;
             }
 
@@ -2616,6 +2618,12 @@ public class JSMarshaller
         foreach (PropertyInfo property in fromType.GetProperties(
             BindingFlags.Public | BindingFlags.Instance))
         {
+            if (property.GetMethod == null || property.GetMethod.GetParameters().Length > 0)
+            {
+                // Skip indexed properties, where the getter takes one or more parameters. 
+                continue;
+            }
+
             Expression propertyName = Expression.Constant(ToCamelCase(property.Name));
             yield return Expression.Assign(
                 Expression.Property(jsValueVariable, s_valueItem, propertyName),

--- a/src/NodeApi.DotNetHost/JSMarshaller.cs
+++ b/src/NodeApi.DotNetHost/JSMarshaller.cs
@@ -2565,7 +2565,7 @@ public class JSMarshaller
         foreach (PropertyInfo property in toType.GetProperties(
             BindingFlags.Public | BindingFlags.Instance))
         {
-            if (property.SetMethod == null || property.SetMethod.GetParameters().Length > 0)
+            if (property.SetMethod == null || property.SetMethod.GetParameters().Length > 1)
             {
                 // Skip indexed properties, where the setter takes one or more parameters. 
                 continue;

--- a/src/NodeApi/Interop/JSCallbackOverload.cs
+++ b/src/NodeApi/Interop/JSCallbackOverload.cs
@@ -169,9 +169,12 @@ public readonly struct JSCallbackOverload
                 bool isMatch = true;
                 for (int i = 0; i < argsCount; i++)
                 {
-                    if (!IsArgumentTypeMatch(argTypes[i], overload.ParameterTypes[i]))
+                    Type parameterType = overload.ParameterTypes[i];
+                    isMatch = parameterType.IsArray ?
+                        argTypes[i] == JSValueType.Object && args[i].IsArray() :
+                        IsArgumentTypeMatch(argTypes[i], overload.ParameterTypes[i]);
+                    if (!isMatch)
                     {
-                        isMatch = false;
                         break;
                     }
                 }


### PR DESCRIPTION
 - Update Semantic Kernel package in the example to 1.0.0-beta8, and revise JS code for API changes
 - Skip indexed properties when marshalling structs. SK added a reference to `System.Text.Json.JsonElement` which is a struct with an indexed property that returns (another) `JsonElement`. This caused a stack overflow: #181. Skipping indexed properties is correct anyway and is a convenient way to avoid the crash for now, though structs with non-indexed self-referential properties may still trigger it. (I have not found any yet.)
 - Add limited support for marshalling `ReadOnlyMemory<T>`, only when the memory was originally allocated by a JS typed array. SK added some APIs that referenced `ReadOnlyMemory<T>` and that was causing an exception due to indirect references to `Span<T>` (which isn't supported and is normally skipped by the marshaller). Adding this special handling for `ReadOnlyMemory<T>` resolves the issue.
 - Improve overload resolution for array parameters. SK loves to overload their APIs. (We don't yet handle resolution of overloads that differ only in object class: #134)