### PR TITLE
Use released .Net 8 version 8.0.100

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -61,8 +61,7 @@ jobs:
           displayName: Install .NET SDK using global.json
           inputs:
             packageType: sdk
-            useGlobalJson: false # Switch to true and remove explicit version after .NET 8 release
-            version: 8.0.x
+            useGlobalJson: true
             includePreviewVersions: true
 
         - script: env
@@ -135,8 +134,7 @@ jobs:
         displayName: Install .NET SDK using global.json
         inputs:
           packageType: sdk
-          useGlobalJson: false # Switch to true and remove explicit version after .NET 8 release
-          version: 8.0.x
+          useGlobalJson: true
           includePreviewVersions: true
 
       - script: env

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.100-rc.2",
+    "version": "8.0.100",
     "allowPrerelease": true,
     "rollForward": "latestPatch"
   }

--- a/src/NodeApi.Generator/ModuleGenerator.cs
+++ b/src/NodeApi.Generator/ModuleGenerator.cs
@@ -38,7 +38,7 @@ public class ModuleGenerator : SourceGenerator, ISourceGenerator
 
     public GeneratorExecutionContext Context { get; protected set; }
 
-    public void Initialize(GeneratorInitializationContext context)
+    public void Initialize(GeneratorInitializationContext _ /*context*/)
     {
         // Note source generators cannot be directly launched in a debugger,
         // because the generator runs at build time, not at application run-time.


### PR DESCRIPTION
.Net 8 was released last week on 11/14/2023.
This PR updates the `global.json` to use the released .Net 8 version 8.0.100.
