### PR TITLE
Fix parsing quoted empty arg in response file

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,6 +100,7 @@ jobs:
         name: test-logs-${{ matrix.os }}-node${{ matrix.node-version }}-${{ matrix.configuration }}
         path: |
           out/obj/${{ matrix.configuration }}/**/*.log
+          out/obj/${{ matrix.configuration }}/**/*.rsp
           out/test/**/*.trx
 
     - name: Check formatting

--- a/src/NodeApi.Generator/ModuleGenerator.cs
+++ b/src/NodeApi.Generator/ModuleGenerator.cs
@@ -38,7 +38,9 @@ public class ModuleGenerator : SourceGenerator, ISourceGenerator
 
     public GeneratorExecutionContext Context { get; protected set; }
 
+#pragma warning disable IDE0060 // Unused parameter
     public void Initialize(GeneratorInitializationContext context)
+#pragma warning restore IDE0060
     {
         // Note source generators cannot be directly launched in a debugger,
         // because the generator runs at build time, not at application run-time.

--- a/src/NodeApi.Generator/Program.cs
+++ b/src/NodeApi.Generator/Program.cs
@@ -281,17 +281,20 @@ public static class Program
     {
         StringBuilder s = new();
         bool inQuotes = false;
+        bool foundQuotes = false;
         foreach (char c in line)
         {
             if (c == '"')
             {
                 inQuotes = !inQuotes;
+                foundQuotes = true;
             }
             else if (c == ' ' && !inQuotes)
             {
-                if (s.Length > 0)
+                if (s.Length > 0 || foundQuotes)
                 {
                     yield return s.ToString();
+                    foundQuotes = false;
                     s.Clear();
                 }
             }
@@ -301,7 +304,7 @@ public static class Program
             }
         }
 
-        if (s.Length > 0)
+        if (s.Length > 0 || foundQuotes)
         {
             yield return s.ToString();
         }
@@ -344,7 +347,7 @@ public static class Program
         {
             if (targetingPacks.Count == 0)
             {
-                // If no targeting packs were specified, use the deafult targeting pack for .NET.
+                // If no targeting packs were specified, use the default targeting pack for .NET.
                 targetingPacks.Add("Microsoft.NETCore.App");
             }
 


### PR DESCRIPTION
This fixes a build break for .NET Framework 4.x, where the response file has `--packs ""` (because .NET Framework doesn't have the concept of "targeting packs"). The empty quoted argument broke the parser. I'm not sure how that bug got past a PR build originally.

This fix had been included in #180 but that PR is taking longer to finish, and is unrelated anyway. I'm splitting out this fix to unblock builds of other PRs.

Also I'm adding the generated `.rsp` file to the build logs archive, to help with diagnosing future issues related to this area.