### PR TITLE
Update example to SK 1.1, fix TS generator and marshaller bugs

### DIFF
--- a/examples/semantic-kernel/semantic-kernel.csproj
+++ b/examples/semantic-kernel/semantic-kernel.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SemanticKernel" Version="1.0.0-beta8" />
+    <PackageReference Include="Microsoft.SemanticKernel" Version="1.1.0" />
     <PackageReference Include="Microsoft.JavaScript.NodeApi.Generator" Version="0.4.*-*" />
   </ItemGroup>
 

--- a/src/NodeApi.DotNetHost/JSMarshaller.cs
+++ b/src/NodeApi.DotNetHost/JSMarshaller.cs
@@ -351,7 +351,7 @@ public class JSMarshaller
 
         for (int i = 0; i < parameters.Length; i++)
         {
-            argVariables[i] = Expression.Variable(parameters[i].ParameterType, parameters[i].Name);
+            argVariables[i] = Variable(parameters[i]);
             statements.Add(Expression.Assign(argVariables[i],
                 BuildArgumentExpression(i, parameters[i])));
         }
@@ -1859,10 +1859,10 @@ public class JSMarshaller
             // public type is passed to JS and then passed back to .NET as `object` type.
 
             /*
-             * (T)(value.TryUnwrap() ?? value.TryGetValueExternal());
+             * (T)(value.TryUnwrap() ?? value.GetValueExternalOrPrimitive());
              */
-            MethodInfo getExternalMethod =
-                typeof(JSNativeApi).GetStaticMethod(nameof(JSNativeApi.TryGetValueExternal));
+            MethodInfo getExternalMethod = typeof(JSNativeApi).GetStaticMethod(
+                nameof(JSNativeApi.GetValueExternalOrPrimitive));
             statements = new[]
             {
                 Expression.Convert(

--- a/src/NodeApi.DotNetHost/ManagedHost.cs
+++ b/src/NodeApi.DotNetHost/ManagedHost.cs
@@ -175,12 +175,14 @@ public sealed class ManagedHost : JSEventEmitter, IDisposable
     }
 
     public static bool IsTracingEnabled { get; } =
+        Debugger.IsAttached ||
         Environment.GetEnvironmentVariable("TRACE_NODE_API_HOST") == "1";
 
     public static void Trace(string msg)
     {
         if (IsTracingEnabled)
         {
+            Debug.WriteLine(msg);
             Console.WriteLine(msg);
             Console.Out.Flush();
         }
@@ -213,7 +215,8 @@ public sealed class ManagedHost : JSEventEmitter, IDisposable
 
         JSRuntime runtime = new NodejsRuntime();
 
-        if (Environment.GetEnvironmentVariable("TRACE_NODE_API_RUNTIME") != null)
+        if (Debugger.IsAttached ||
+            Environment.GetEnvironmentVariable("TRACE_NODE_API_RUNTIME") != null)
         {
             TraceSource trace = new(typeof(JSValue).Namespace!);
             trace.Switch.Level = SourceLevels.All;

--- a/src/NodeApi.DotNetHost/TypeExporter.cs
+++ b/src/NodeApi.DotNetHost/TypeExporter.cs
@@ -94,6 +94,9 @@ internal class TypeExporter
 
     private JSReference ExportClass(Type type)
     {
+        string typeName = type.Name;
+        Trace($"### ExportClass({typeName}");
+
         if (_exportedTypes.TryGetValue(type, out JSReference? classObjectReference))
         {
             return classObjectReference;
@@ -101,55 +104,68 @@ internal class TypeExporter
 
         Trace($"> {nameof(TypeExporter)}.ExportClass({type.FormatName()})");
 
-        bool isStatic = type.IsAbstract && type.IsSealed;
-        Type classBuilderType =
-            (type.IsValueType ? typeof(JSStructBuilder<>) : typeof(JSClassBuilder<>))
-            .MakeGenericType(isStatic ? typeof(object) : type);
+        // Add a temporary null entry to the dictionary while exporting this type, in case the
+        // type is encountered while exporting members. It will be non-null by the time this method returns
+        // (or removed if an exception is thrown).
+        _exportedTypes.Add(type, null!);
+        try
+        {
+            bool isStatic = type.IsAbstract && type.IsSealed;
+            Type classBuilderType =
+                (type.IsValueType ? typeof(JSStructBuilder<>) : typeof(JSClassBuilder<>))
+                .MakeGenericType(isStatic ? typeof(object) : type);
 
-        object classBuilder;
-        if (type.IsInterface || isStatic || type.IsValueType)
-        {
-            classBuilder = classBuilderType.CreateInstance(
-                new[] { typeof(string) }, new[] { type.Name });
-        }
-        else
-        {
-            ConstructorInfo[] constructors =
-                type.GetConstructors(BindingFlags.Public | BindingFlags.Instance)
-                .Where(IsSupportedConstructor)
-                .ToArray();
-            JSCallbackDescriptor constructorDescriptor;
-            if (constructors.Length == 1 &&
-                !constructors[0].GetParameters().Any((p) => p.IsOptional))
+            object classBuilder;
+            if (type.IsInterface || isStatic || type.IsValueType)
             {
-                constructorDescriptor =
-                    _marshaller.BuildFromJSConstructorExpression(constructors[0]).Compile();
+                classBuilder = classBuilderType.CreateInstance(
+                    new[] { typeof(string) }, new[] { type.Name });
             }
             else
             {
-                // Multiple constructors or optional parameters require overload resolution.
-                constructorDescriptor =
-                    _marshaller.BuildConstructorOverloadDescriptor(constructors);
+                ConstructorInfo[] constructors =
+                    type.GetConstructors(BindingFlags.Public | BindingFlags.Instance)
+                    .Where(IsSupportedConstructor)
+                    .ToArray();
+                JSCallbackDescriptor constructorDescriptor;
+                if (constructors.Length == 1 &&
+                    !constructors[0].GetParameters().Any((p) => p.IsOptional))
+                {
+                    constructorDescriptor =
+                        _marshaller.BuildFromJSConstructorExpression(constructors[0]).Compile();
+                }
+                else
+                {
+                    // Multiple constructors or optional parameters require overload resolution.
+                    constructorDescriptor =
+                        _marshaller.BuildConstructorOverloadDescriptor(constructors);
+                }
+
+                classBuilder = classBuilderType.CreateInstance(
+                    new[] { typeof(string), typeof(JSCallbackDescriptor) },
+                    new object[] { type.Name, constructorDescriptor });
             }
 
-            classBuilder = classBuilderType.CreateInstance(
-                new[] { typeof(string), typeof(JSCallbackDescriptor) },
-                new object[] { type.Name, constructorDescriptor });
+            ExportProperties(type, classBuilder);
+            ExportMethods(type, classBuilder);
+            ExportNestedTypes(type, classBuilder);
+
+            string defineMethodName = type.IsInterface ? "DefineInterface" :
+                isStatic ? "DefineStaticClass" : type.IsValueType ? "DefineStruct" : "DefineClass";
+            MethodInfo defineClassMethod = classBuilderType.GetInstanceMethod(defineMethodName);
+            JSValue classObject = (JSValue)defineClassMethod.Invoke(
+                classBuilder,
+                defineClassMethod.GetParameters().Select((_) => (object?)null).ToArray())!;
+
+            classObjectReference = new JSReference(classObject);
+            _exportedTypes[type] = classObjectReference;
         }
-
-        ExportProperties(type, classBuilder);
-        ExportMethods(type, classBuilder);
-        ExportNestedTypes(type, classBuilder);
-
-        string defineMethodName = type.IsInterface ? "DefineInterface" :
-            isStatic ? "DefineStaticClass" : type.IsValueType ? "DefineStruct" : "DefineClass";
-        MethodInfo defineClassMethod = classBuilderType.GetInstanceMethod(defineMethodName);
-        JSValue classObject = (JSValue)defineClassMethod.Invoke(
-            classBuilder,
-            defineClassMethod.GetParameters().Select((_) => (object?)null).ToArray())!;
-
-        classObjectReference = new JSReference(classObject);
-        _exportedTypes.Add(type, classObjectReference);
+        catch
+        {
+            // Clean up the temporary null entry.
+            _exportedTypes.Remove(type);
+            throw;
+        }
 
         // Also export any types returned by properties or methods of this type, because
         // they might otherwise not be referenced by JS before they are used.

--- a/src/NodeApi.Generator/SourceGenerator.cs
+++ b/src/NodeApi.Generator/SourceGenerator.cs
@@ -24,6 +24,8 @@ public abstract class SourceGenerator
 
     private static readonly Regex s_paragraphBreakRegex = new(@" *\<para */\> *");
 
+    protected const char nonBreakingSpace = (char)0xA0;
+
     public enum DiagnosticId
     {
         NoExports = 1000,
@@ -193,11 +195,11 @@ public abstract class SourceGenerator
                     }
                 }
 
-                yield return comment.Substring(0, i).TrimEnd();
+                yield return comment.Substring(0, i).TrimEnd().Replace(nonBreakingSpace, ' ');
                 comment = comment.Substring(i + 1);
             }
 
-            yield return comment.TrimEnd();
+            yield return comment.TrimEnd().Replace(nonBreakingSpace, ' ');
         }
     }
 }

--- a/src/NodeApi.Generator/SourceGenerator.cs
+++ b/src/NodeApi.Generator/SourceGenerator.cs
@@ -24,7 +24,7 @@ public abstract class SourceGenerator
 
     private static readonly Regex s_paragraphBreakRegex = new(@" *\<para */\> *");
 
-    protected const char nonBreakingSpace = (char)0xA0;
+    protected const char NonBreakingSpace = (char)0xA0;
 
     public enum DiagnosticId
     {
@@ -195,11 +195,11 @@ public abstract class SourceGenerator
                     }
                 }
 
-                yield return comment.Substring(0, i).TrimEnd().Replace(nonBreakingSpace, ' ');
+                yield return comment.Substring(0, i).TrimEnd().Replace(NonBreakingSpace, ' ');
                 comment = comment.Substring(i + 1);
             }
 
-            yield return comment.TrimEnd().Replace(nonBreakingSpace, ' ');
+            yield return comment.TrimEnd().Replace(NonBreakingSpace, ' ');
         }
     }
 }

--- a/src/NodeApi.Generator/TypeDefinitionsGenerator.cs
+++ b/src/NodeApi.Generator/TypeDefinitionsGenerator.cs
@@ -796,7 +796,11 @@ import { Duplex } from 'stream';
         int genericMarkerIndex = methodNamePrefix.IndexOf('`');
         if (genericMarkerIndex >= 0)
         {
+#if NETFRAMEWORK
             methodNamePrefix = methodNamePrefix.Substring(0, genericMarkerIndex) + '<';
+#else
+            methodNamePrefix = string.Concat(methodNamePrefix.AsSpan(0, genericMarkerIndex), "<");
+#endif
         }
         else
         {

--- a/src/NodeApi.Generator/TypeDefinitionsGenerator.cs
+++ b/src/NodeApi.Generator/TypeDefinitionsGenerator.cs
@@ -789,21 +789,24 @@ import { Duplex } from 'stream';
             interfaceType = interfaceType.GetGenericTypeDefinition();
         }
 
-        // Get the interface type name with generic type parameters for matching.
+        // Get the interface type name prefix for matching the method name.
         // It would be more precise to match the generic type params also,
         // but also more complicated.
-        string interfaceTypeName = interfaceType.FullName!;
-        int genericMarkerIndex = interfaceTypeName.IndexOf('`');
+        string methodNamePrefix = interfaceType.FullName!;
+        int genericMarkerIndex = methodNamePrefix.IndexOf('`');
         if (genericMarkerIndex >= 0)
         {
-            interfaceTypeName = interfaceTypeName.Substring(0, genericMarkerIndex);
+            methodNamePrefix = methodNamePrefix.Substring(0, genericMarkerIndex) + '<';
+        }
+        else
+        {
+            methodNamePrefix += '.';
         }
 
         foreach (MethodInfo method in type.GetMethods(
             BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly))
         {
-            if (method.IsFinal && method.IsPrivate &&
-                method.Name.StartsWith(interfaceTypeName + "."))
+            if (method.IsFinal && method.IsPrivate && method.Name.StartsWith(methodNamePrefix))
             {
                 return true;
             }

--- a/src/NodeApi.Generator/TypeDefinitionsGenerator.cs
+++ b/src/NodeApi.Generator/TypeDefinitionsGenerator.cs
@@ -975,7 +975,7 @@ import { Duplex } from 'stream';
     private static bool IsExcludedMember(MethodBase method)
     {
         // Exclude "special" methods like property get/set and event add/remove.
-        if (method.IsSpecialName)
+        if (method is MethodInfo && method.IsSpecialName)
         {
             return true;
         }
@@ -1613,7 +1613,11 @@ import { Duplex } from 'stream';
             }
             else
             {
-                return string.Join(" ", element.Nodes().Select(FormatDocText));
+                return string.Join(" ", element.Nodes().Select(FormatDocText))
+                    .Replace("} ,", "},")
+                    .Replace("} .", "}.")
+                    .Replace("` ,", "`,")
+                    .Replace("` .", "`.");
             }
         }
 

--- a/src/NodeApi.Generator/TypeDefinitionsGenerator.cs
+++ b/src/NodeApi.Generator/TypeDefinitionsGenerator.cs
@@ -997,7 +997,7 @@ import { Duplex } from 'stream';
 
         // Exclude methods that have pointer parameters because they can't be marshalled to JS.
         if (method.GetParameters().Any((p) => p.ParameterType.IsPointer) ||
-            (method as MethodInfo)?.ReturnParameter.ParameterType.IsPointer == true)
+            method is MethodInfo { ReturnParameter.ParameterType.IsPointer: true })
         {
             return true;
         }
@@ -1548,7 +1548,7 @@ import { Duplex } from 'stream';
 
         if (string.IsNullOrEmpty(remarks) && summary.Length < 83 && summary.IndexOf('\n') < 0)
         {
-            s += $"/** {summary.Replace(nonBreakingSpace, ' ')} */";
+            s += $"/** {summary.Replace(NonBreakingSpace, ' ')} */";
         }
         else
         {
@@ -1599,7 +1599,7 @@ import { Duplex } from 'stream';
 
                 // Use a non-breaking space char to prevent wrapping from breaking the link.
                 // It will be replaced with by a regular space char in the final output.
-                return $"{{@link {target}}}".Replace(' ', nonBreakingSpace);
+                return $"{{@link {target}}}".Replace(' ', NonBreakingSpace);
             }
             else if (element.Name == "see" && element.Attribute("langword") != null)
             {

--- a/src/NodeApi/Native/JSNativeApi.cs
+++ b/src/NodeApi/Native/JSNativeApi.cs
@@ -611,6 +611,27 @@ public static partial class JSNativeApi
         return GCHandle.FromIntPtr(result).Target!;
     }
 
+    /// <summary>
+    /// Gets the .NET external value or primitive object value (string, boolean, or double)
+    /// for a JS value, or null if the JS value is not convertible to one of those types.
+    /// </summary>
+    /// <remarks>
+    /// This is useful when marshalling where a JS value must be converted to some .NET type,
+    /// but the target type is unknown (object).
+    /// </remarks>
+    public static unsafe object? GetValueExternalOrPrimitive(this JSValue thisValue)
+    {
+        return thisValue.TypeOf() switch
+        {
+            JSValueType.String => thisValue.GetValueStringUtf16(),
+            JSValueType.Boolean => thisValue.GetValueBool(),
+            JSValueType.Number => thisValue.GetValueDouble(),
+            JSValueType.External => thisValue.GetValueExternal(),
+            _ => null,
+        };
+
+    }
+
     public static JSReference CreateReference(this JSValue thisValue)
         => new(thisValue);
 

--- a/src/NodeApi/Runtime/TracingJSRuntime.cs
+++ b/src/NodeApi/Runtime/TracingJSRuntime.cs
@@ -2000,7 +2000,7 @@ public class TracingJSRuntime : JSRuntime
         return status;
     }
 
-    public unsafe override napi_status DefineClass(
+    public override unsafe napi_status DefineClass(
         napi_env env,
         string name,
         napi_callback constructor,

--- a/src/NodeApi/Runtime/TracingJSRuntime.cs
+++ b/src/NodeApi/Runtime/TracingJSRuntime.cs
@@ -2000,7 +2000,7 @@ public class TracingJSRuntime : JSRuntime
         return status;
     }
 
-    public override napi_status DefineClass(
+    public unsafe override napi_status DefineClass(
         napi_env env,
         string name,
         napi_callback constructor,
@@ -2016,11 +2016,30 @@ public class TracingJSRuntime : JSRuntime
             $"[{string.Join(", ", properties.ToArray().Select((p) => Format(env, p)))}]",
         });
 
+        // Replace property callbacks with the tracing callbacks.
+        var tracedProperties = new napi_property_descriptor[properties.Length];
+        for (int i = 0; i < properties.Length; i++)
+        {
+            tracedProperties[i] = properties[i];
+            if (properties[i].getter == new napi_callback(JSNativeApi.s_invokeJSGetter))
+            {
+                tracedProperties[i].method = new napi_callback(s_traceGetterCallback);
+            }
+            if (properties[i].setter == new napi_callback(JSNativeApi.s_invokeJSSetter))
+            {
+                tracedProperties[i].method = new napi_callback(s_traceSetterCallback);
+            }
+            if (properties[i].method == new napi_callback(JSNativeApi.s_invokeJSMethod))
+            {
+                tracedProperties[i].method = new napi_callback(s_traceMethodCallback);
+            }
+        }
+
         napi_status status;
         try
         {
             status = _runtime.DefineClass(
-                env, name, constructor, data, properties, out result);
+                env, name, constructor, data, tracedProperties, out result);
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
 - `examples/semantic-kernel`:
   - Update `Microsoft.SemanticKernel` package reference to `1.1.0`
   - Update JS code for SK API changes.
 - TS generator fixes:
   - Improve the logic for merging nuget package references with system assembly references.
   - Omit explicit interface implementations for value types (as was already done for classes).
   - Omit members with pointer parameter types.
   - Convert `<see cref="..."/>` to JSDoc `{@link ...}`
 - Marshalling fixes:
   - Fix an exception caused by certain kinds of circular references among exported types.
   - Enable marshalling primitive JS value types to .NET `object` type. Necessary to support some SK APIs such as [KernelArguments(IDictionary<string, object?> source)](https://github.com/microsoft/semantic-kernel/blob/b2bbd410c07739767b5aad48961a8ced5b4cf4a4/dotnet/src/SemanticKernel.Abstractions/Functions/KernelArguments.cs#L47C49-L47C49) where the expectation is a JS string value in a `Map` should get marshalled to a NET string value in the dictionary.
 - Tracing improvements:
   - Automatically turn on tracing when a debugger is attached.
   - Enable callback tracing for getters, setters, and methods. Previously the callback tracing only worked for regular functions.