### PR TITLE
Fix importing specific version of .NET

### DIFF
--- a/Docs/dynamic-invoke.md
+++ b/Docs/dynamic-invoke.md
@@ -56,6 +56,13 @@ For examples of this scenario, see
     const dotnet = require('node-api-dotnet');
     ```
 
+   To load a specific version of .NET, append the target framework moniker to the module name.
+   A `.js` suffix is required when using ES modules, optional with CommonJS.
+   ```JavaScript
+   import dotnet from 'node-api-dotnet/net6.0.js'
+   ```
+   Currently the supported target frameworks are `net472`, `net6.0`, and `net8.0`.
+
 4. Load one or more .NET packages using the generated `.js` files:
    ```JavaScript
    require('./bin/Example.Package.js');

--- a/Docs/node-module.md
+++ b/Docs/node-module.md
@@ -59,14 +59,28 @@ For a minimal example of this scenario, see
     [build it from source](../README-DEV.md).<br>Then get the package from
     `out/pkg/node-api-dotnet-{version}.tgz`.
 
-6. Import the `node-api-dotnet` package in your JavaScript code:
-    ```JavaScript
-    const dotnet = require('node-api-dotnet');
-    ```
-    Or if using ES modules:
+6. Import the `node-api-dotnet` package in your JavaScript or TypeScript code. The import syntax
+   depends on the [module system](https://nodejs.org/api/esm.html) the current project is using.
+
+   ES modules (TypeScript or JavaScript):
     ```JavaScript
     import dotnet from 'node-api-dotnet';
     ```
+   CommonJS modules (TypeScript):
+    ```TypeScript
+    import * as dotnet from 'node-api-dotnet';
+    ```
+   CommonJS modules (JavaScript):
+    ```JavaScript
+    const dotnet = require('node-api-dotnet');
+    ```
+
+   To load a specific version of .NET, append the target framework moniker to the module name.
+   A `.js` suffix is required when using ES modules, optional with CommonJS.
+   ```JavaScript
+   import dotnet from 'node-api-dotnet/net6.0.js'
+   ```
+   Currently the supported target frameworks are `net472`, `net6.0`, and `net8.0`.
 
 7. Load your .NET module assembly from its path using the `dotnet.require()` function. Also provide
     a hint about type definitions (from the same path):

--- a/src/NodeApi.DotNetHost/ManagedHost.cs
+++ b/src/NodeApi.DotNetHost/ManagedHost.cs
@@ -138,8 +138,8 @@ public sealed class ManagedHost : JSEventEmitter, IDisposable
         }
 
         exports.DefineProperties(
-            JSPropertyDescriptor.Accessor("runtimeVersion", GetRuntimeVersion),
-            JSPropertyDescriptor.Accessor("frameworkMoniker", GetFrameworkMoniker),
+            JSPropertyDescriptor.Accessor("runtimeVersion", ManagedHost.GetRuntimeVersion),
+            JSPropertyDescriptor.Accessor("frameworkMoniker", ManagedHost.GetFrameworkMoniker),
 
             // The require() method loads a .NET assembly that was built to be a Node API module.
             // It uses static binding to the APIs the module specifically exports to JS.
@@ -330,12 +330,12 @@ public sealed class ManagedHost : JSEventEmitter, IDisposable
         return default;
     }
 
-    public JSValue GetRuntimeVersion(JSCallbackArgs _)
+    public static JSValue GetRuntimeVersion(JSCallbackArgs _)
     {
         return Environment.Version.ToString();
     }
 
-    public JSValue GetFrameworkMoniker(JSCallbackArgs _)
+    public static JSValue GetFrameworkMoniker(JSCallbackArgs _)
     {
         Version runtimeVersion = Environment.Version;
 

--- a/src/NodeApi.Generator/TypeDefinitionsGenerator.cs
+++ b/src/NodeApi.Generator/TypeDefinitionsGenerator.cs
@@ -991,16 +991,15 @@ import { Duplex } from 'stream';
     {
         // These namespaces contain APIs that are problematic for TS generation.
         // (Mostly old .NET Framework APIs.)
-        switch (ns)
+        return ns switch
         {
-            case "System.Runtime.InteropServices":
-            case "System.Runtime.Remoting.Messaging":
-            case "System.Runtime.Serialization":
-            case "System.Security.AccessControl":
-            case "System.Security.Policy":
-                return true;
-            default: return false;
-        }
+            "System.Runtime.InteropServices" or
+            "System.Runtime.Remoting.Messaging" or
+            "System.Runtime.Serialization" or
+            "System.Security.AccessControl" or
+            "System.Security.Policy" => true,
+            _ => false,
+        };
     }
 
     private static bool IsExcludedMember(PropertyInfo property)

--- a/src/NodeApi.Generator/TypeDefinitionsGenerator.cs
+++ b/src/NodeApi.Generator/TypeDefinitionsGenerator.cs
@@ -378,6 +378,11 @@ dotnet.load(assemblyName);
 
     private bool IsTypeExported(Type type)
     {
+        if (IsExcludedNamespace(type.Namespace))
+        {
+            return false;
+        }
+
         // Types not in the current assembly are not exported from this TS module.
         // (But support mscorlib and System.Runtime forwarding to System.Private.CoreLib.)
         if (type.Assembly != _assembly &&
@@ -627,7 +632,8 @@ import { Duplex } from 'stream';
                 foreach (PropertyInfo property in type.GetProperties(
                     BindingFlags.Public | BindingFlags.Static))
                 {
-                    if (!IsExcludedMember(property))
+                    // Indexed properties are not implemented.
+                    if (!IsExcludedMember(property) && property.GetIndexParameters().Length == 0)
                     {
                         if (isFirstMember) isFirstMember = false; else s++;
                         ExportTypeMember(ref s, property);
@@ -666,7 +672,11 @@ import { Duplex } from 'stream';
             string prefix = (implements.Length == 0 ? $" {implementsKind}" : ",") +
                 (interfaceTypes.Length > 1 ? "\n\t" : " ");
 
-            if (isStreamSubclass &&
+            if (!interfaceType.IsPublic || IsExcludedNamespace(interfaceType.Namespace))
+            {
+                continue;
+            }
+            else if (isStreamSubclass &&
                 (interfaceType.Name == nameof(IDisposable) ||
                 interfaceType.Name == nameof(IAsyncDisposable)))
             {
@@ -726,7 +736,8 @@ import { Duplex } from 'stream';
                 (isStaticClass ? BindingFlags.DeclaredOnly : default) |
                 (type.IsInterface || isGenericTypeDefinition ? default : BindingFlags.Static)))
             {
-                if (!IsExcludedMember(property))
+                // Indexed properties are not implemented.
+                if (!IsExcludedMember(property) && property.GetIndexParameters().Length == 0)
                 {
                     if (isFirstMember) isFirstMember = false; else s++;
                     ExportTypeMember(ref s, property);
@@ -764,7 +775,9 @@ import { Duplex } from 'stream';
                 type.GetInterfaces().Any((i) => i.Name == typeof(IComparable<>).Name)) ||
                 (interfaceType.Name == "ISpanFormattable" &&
                 (type.Name == "INumberBase`1" ||
-                type.GetInterfaces().Any((i) => i.Name == "INumberBase`1"))))
+                type.GetInterfaces().Any((i) => i.Name == "INumberBase`1"))) ||
+                (interfaceType.Name == "ICollection" &&
+                type.Name == "IProducerConsumerCollection`1"))
             {
                 // TS interfaces cannot extend multiple interfaces that have non-identical methods
                 // with the same name. This is most commonly an issue with IComparable and
@@ -774,10 +787,10 @@ import { Duplex } from 'stream';
 
             return false;
         }
-        else if (type.Name == "TypeDelegator" && interfaceType.Name == "IReflectableType")
+        else if (interfaceType.Name == "IReflectableType")
         {
-            // Special case: TypeDelegator has an explicit implementation of this interface,
-            // but it isn't detected by reflection due to the runtime type delegation.
+            // Special case: Reflectable types have explicit implementations of this interface,
+            // but they aren't detected by reflection due to the runtime type delegation.
             return true;
         }
 
@@ -822,6 +835,11 @@ import { Duplex } from 'stream';
             {
                 return true;
             }
+        }
+
+        if (type.BaseType != null && type.BaseType != typeof(object))
+        {
+            return HasExplicitInterfaceImplementations(type.BaseType!, interfaceType);
         }
 
         return false;
@@ -966,6 +984,22 @@ import { Duplex } from 'stream';
         if (type.Namespace != null || type.IsNested)
         {
             s += "}";
+        }
+    }
+
+    private static bool IsExcludedNamespace(string? ns)
+    {
+        // These namespaces contain APIs that are problematic for TS generation.
+        // (Mostly old .NET Framework APIs.)
+        switch (ns)
+        {
+            case "System.Runtime.InteropServices":
+            case "System.Runtime.Remoting.Messaging":
+            case "System.Runtime.Serialization":
+            case "System.Security.AccessControl":
+            case "System.Security.Policy":
+                return true;
+            default: return false;
         }
     }
 

--- a/src/NodeApi/Runtime/PooledBuffer.cs
+++ b/src/NodeApi/Runtime/PooledBuffer.cs
@@ -6,21 +6,43 @@ namespace Microsoft.JavaScript.NodeApi.Runtime;
 
 internal struct PooledBuffer : IDisposable
 {
-    private ArrayPool<byte>? _pool;
-    public static readonly PooledBuffer Empty = new(null, [], 0);
+    public static readonly PooledBuffer Empty = new();
 
-    public PooledBuffer(ArrayPool<byte> pool, int length)
-        : this(pool, pool.Rent(length), length) { }
-
-    public PooledBuffer(ArrayPool<byte> pool, int length, int bufferMinimumLength)
-        : this(pool, pool.Rent(bufferMinimumLength), length) { }
-
-    private PooledBuffer(ArrayPool<byte>? pool, byte[] buffer, int length)
+    public PooledBuffer()
     {
-        _pool = pool;
-        Buffer = buffer;
+        Buffer = Array.Empty<byte>();
+        Length = 0;
+    }
+
+#if NETFRAMEWORK
+    // Avoid a dependency on System.Buffers with .NET Framwork.
+    // It is available as a nuget package, but might not be installed in the application.
+    // In this case the buffer is not actually pooled.
+
+    public PooledBuffer(int length) : this(length, length) { }
+
+    public PooledBuffer(int length, int bufferMinimumLength)
+    {
+        Buffer = new byte[bufferMinimumLength];
         Length = length;
     }
+
+#else
+    private ArrayPool<byte>? _pool;
+
+    private PooledBuffer(int length)
+        : this(ArrayPool<byte>.Shared, length, length) { }
+
+    private PooledBuffer(int length, int bufferMinimumLength)
+        : this(ArrayPool<byte>.Shared, length, bufferMinimumLength) { }
+
+    private PooledBuffer(ArrayPool<byte> pool, int length, int bufferMinimumLength)
+    {
+        _pool = pool;
+        Buffer = pool.Rent(bufferMinimumLength);
+        Length = length;
+    }
+#endif
 
     public int Length { get; private set; }
 
@@ -32,11 +54,13 @@ internal struct PooledBuffer : IDisposable
 
     public void Dispose()
     {
+#if !NETFRAMEWORK
         if (_pool != null)
         {
             _pool.Return(Buffer!);
             _pool = null;
         }
+#endif
     }
 
     public static unsafe PooledBuffer FromStringUtf8(string? value)
@@ -47,15 +71,8 @@ internal struct PooledBuffer : IDisposable
         }
 
         int byteLength = Encoding.UTF8.GetByteCount(value);
-        PooledBuffer buffer = new(ArrayPool<byte>.Shared, byteLength, byteLength + 1);
-
-        fixed (char* pChars = value)
-        fixed (byte* pBuffer = buffer.Buffer)
-        {
-            // The Span<byte> overload of GetBytes() would be nicer, but is not available on .NET 4.
-            Encoding.UTF8.GetBytes(pChars, value!.Length, pBuffer, byteLength);
-            pBuffer[byteLength] = 0;
-        }
+        PooledBuffer buffer = new(byteLength, byteLength + 1);
+        Encoding.UTF8.GetBytes(value, 0, value!.Length, buffer.Buffer, 0);
 
         return buffer;
     }

--- a/src/node-api-dotnet/index.d.ts
+++ b/src/node-api-dotnet/index.d.ts
@@ -7,6 +7,17 @@
 declare module 'node-api-dotnet' {
 
 /**
+ * Gets the current .NET runtime version, for example "8.0.1".
+ */
+export const runtimeVersion: string;
+
+/**
+ * Gets the framework monikier corresponding to the current .NET runtime version,
+ * for example "net8.0" or "net472".
+ */
+export const frameworkMoniker: string;
+
+/**
  * Loads a .NET assembly that was built to be a Node API module, using static binding to
  * the APIs the module specifically exports to JS.
  * @param dotnetAssemblyFilePath Path to the .NET assembly DLL file.

--- a/test/TestBuilder.cs
+++ b/test/TestBuilder.cs
@@ -170,7 +170,7 @@ internal static class TestBuilder
     {
         if (GetNoBuild()) return;
 
-        StreamWriter logWriter = new(File.Open(
+        using StreamWriter logWriter = new(File.Open(
             logFilePath, FileMode.Create, FileAccess.Write, FileShare.Read));
 
         List<string> arguments = new()
@@ -225,7 +225,7 @@ internal static class TestBuilder
         // This assumes the `node` executable is on the current PATH.
         string nodeExe = "node";
 
-        StreamWriter logWriter = new(File.Open(
+        using StreamWriter logWriter = new(File.Open(
             logFilePath, FileMode.Create, FileAccess.Write, FileShare.Read));
 
         var startInfo = new ProcessStartInfo(nodeExe, $"--expose-gc {jsFilePath}")

--- a/test/TestCases/projects/js-cjs/default.js
+++ b/test/TestCases/projects/js-cjs/default.js
@@ -6,4 +6,4 @@ const dotnet = require('node-api-dotnet');
 require('./bin/System.Runtime');
 require('./bin/System.Console');
 
-dotnet.System.Console.WriteLine('Test!');
+dotnet.System.Console.WriteLine(`Hello from .NET ${dotnet.runtimeVersion}!`);

--- a/test/TestCases/projects/js-cjs/net472.js
+++ b/test/TestCases/projects/js-cjs/net472.js
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+const assert = require('assert');
+const dotnet = require('node-api-dotnet/net472');
+
+require('./bin/mscorlib');
+
+dotnet.System.Console.WriteLine(`Hello from .NET ${dotnet.runtimeVersion}!`);
+assert.strictEqual(dotnet.frameworkMoniker, 'net472');

--- a/test/TestCases/projects/js-cjs/net6.0.js
+++ b/test/TestCases/projects/js-cjs/net6.0.js
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+const assert = require('assert');
+const dotnet = require('node-api-dotnet/net6.0');
+
+require('./bin/System.Runtime');
+require('./bin/System.Console');
+
+dotnet.System.Console.WriteLine(`Hello from .NET ${dotnet.runtimeVersion}!`);
+assert.strictEqual(dotnet.frameworkMoniker, 'net6.0');

--- a/test/TestCases/projects/js-cjs/net8.0.js
+++ b/test/TestCases/projects/js-cjs/net8.0.js
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+const assert = require('assert');
+const dotnet = require('node-api-dotnet/net8.0');
+
+require('./bin/System.Runtime');
+require('./bin/System.Console');
+
+dotnet.System.Console.WriteLine(`Hello from .NET ${dotnet.runtimeVersion}!`);
+assert.strictEqual(dotnet.frameworkMoniker, 'net8.0');

--- a/test/TestCases/projects/js-cjs/tsconfig.json
+++ b/test/TestCases/projects/js-cjs/tsconfig.json
@@ -7,5 +7,5 @@
     "noEmit": true
   },
   "include": ["*.js", "bin/*.js"],
-  "exclude": ["node_modules"]
+  "exclude": ["net472.js", "node_modules"]
 }

--- a/test/TestCases/projects/js-cjs/tsconfig.net472.json
+++ b/test/TestCases/projects/js-cjs/tsconfig.net472.json
@@ -4,8 +4,8 @@
     "target": "ES2022",
     "allowJs": true,
     "checkJs": true,
-    "outDir": "out"
+    "noEmit": true
   },
-  "include": ["*.ts", "bin/*.js"],
-  "exclude": ["net472.ts", "node_modules"]
+  "include": ["net472.js", "bin/*.js"],
+  "exclude": ["node_modules"]
 }

--- a/test/TestCases/projects/js-esm/default.js
+++ b/test/TestCases/projects/js-esm/default.js
@@ -6,4 +6,4 @@ import dotnet from 'node-api-dotnet';
 import './bin/System.Runtime.js';
 import './bin/System.Console.js';
 
-dotnet.System.Console.WriteLine('Test!');
+dotnet.System.Console.WriteLine(`Hello from .NET ${dotnet.runtimeVersion}!`);

--- a/test/TestCases/projects/js-esm/net472.js
+++ b/test/TestCases/projects/js-esm/net472.js
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import assert from 'assert';
+import dotnet from 'node-api-dotnet/net472.js';
+
+import './bin/mscorlib.js';
+
+dotnet.System.Console.WriteLine(`Hello from .NET ${dotnet.runtimeVersion}!`);
+assert.strictEqual(dotnet.frameworkMoniker, 'net472');

--- a/test/TestCases/projects/js-esm/net6.0.js
+++ b/test/TestCases/projects/js-esm/net6.0.js
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import assert from 'assert';
+import dotnet from 'node-api-dotnet/net6.0.js';
+
+import './bin/System.Runtime.js';
+import './bin/System.Console.js';
+
+dotnet.System.Console.WriteLine(`Hello from .NET ${dotnet.runtimeVersion}!`);
+assert.strictEqual(dotnet.frameworkMoniker, 'net6.0');

--- a/test/TestCases/projects/js-esm/net8.0.js
+++ b/test/TestCases/projects/js-esm/net8.0.js
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import assert from 'assert';
+import dotnet from 'node-api-dotnet/net8.0.js';
+
+import './bin/System.Runtime.js';
+import './bin/System.Console.js';
+
+dotnet.System.Console.WriteLine(`Hello from .NET ${dotnet.runtimeVersion}!`);
+assert.strictEqual(dotnet.frameworkMoniker, 'net8.0');

--- a/test/TestCases/projects/js-esm/tsconfig.net472.json
+++ b/test/TestCases/projects/js-esm/tsconfig.net472.json
@@ -6,6 +6,6 @@
     "checkJs": true,
     "noEmit": true
   },
-  "include": ["*.js", "bin/*.js"],
-  "exclude": ["net472.js", "node_modules"]
+  "include": ["net472.js", "bin/*.js"],
+  "exclude": ["node_modules"]
 }

--- a/test/TestCases/projects/ts-cjs/default.ts
+++ b/test/TestCases/projects/ts-cjs/default.ts
@@ -6,4 +6,4 @@ import * as dotnet from 'node-api-dotnet';
 import './bin/System.Runtime';
 import './bin/System.Console';
 
-dotnet.System.Console.WriteLine('Test!');
+dotnet.System.Console.WriteLine(`Hello from .NET ${dotnet.runtimeVersion}!`);

--- a/test/TestCases/projects/ts-cjs/net472.ts
+++ b/test/TestCases/projects/ts-cjs/net472.ts
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import * as assert from 'assert';
+import * as dotnet from 'node-api-dotnet/net472';
+
+import './bin/mscorlib';
+
+dotnet.System.Console.WriteLine(`Hello from .NET ${dotnet.runtimeVersion}!`);
+assert.strictEqual(dotnet.frameworkMoniker, 'net472');

--- a/test/TestCases/projects/ts-cjs/net6.0.ts
+++ b/test/TestCases/projects/ts-cjs/net6.0.ts
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import * as assert from 'assert';
+import * as dotnet from 'node-api-dotnet/net6.0';
+
+import './bin/System.Runtime';
+import './bin/System.Console';
+
+dotnet.System.Console.WriteLine(`Hello from .NET ${dotnet.runtimeVersion}!`);
+assert.strictEqual(dotnet.frameworkMoniker, 'net6.0');

--- a/test/TestCases/projects/ts-cjs/net8.0.ts
+++ b/test/TestCases/projects/ts-cjs/net8.0.ts
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import * as assert from 'assert';
+import * as dotnet from 'node-api-dotnet/net8.0';
+
+import './bin/System.Runtime';
+import './bin/System.Console';
+
+dotnet.System.Console.WriteLine(`Hello from .NET ${dotnet.runtimeVersion}!`);
+assert.strictEqual(dotnet.frameworkMoniker, 'net8.0');

--- a/test/TestCases/projects/ts-cjs/tsconfig.net472.json
+++ b/test/TestCases/projects/ts-cjs/tsconfig.net472.json
@@ -6,6 +6,6 @@
     "checkJs": true,
     "outDir": "out"
   },
-  "include": ["*.ts", "bin/*.js"],
-  "exclude": ["net472.ts", "node_modules"]
+  "include": ["net472.ts", "bin/*.js"],
+  "exclude": ["node_modules"]
 }

--- a/test/TestCases/projects/ts-esm/default.ts
+++ b/test/TestCases/projects/ts-esm/default.ts
@@ -6,4 +6,4 @@ import dotnet from 'node-api-dotnet';
 import './bin/System.Runtime.js';
 import './bin/System.Console.js';
 
-dotnet.System.Console.WriteLine('Test!');
+dotnet.System.Console.WriteLine(`Hello from .NET ${dotnet.runtimeVersion}!`);

--- a/test/TestCases/projects/ts-esm/net472.ts
+++ b/test/TestCases/projects/ts-esm/net472.ts
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import * as assert from 'assert';
+import dotnet from 'node-api-dotnet/net472.js';
+
+import './bin/mscorlib.js';
+
+dotnet.System.Console.WriteLine(`Hello from .NET ${dotnet.runtimeVersion}!`);
+assert.strictEqual(dotnet.frameworkMoniker, 'net472');

--- a/test/TestCases/projects/ts-esm/net6.0.ts
+++ b/test/TestCases/projects/ts-esm/net6.0.ts
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import * as assert from 'assert';
+import dotnet from 'node-api-dotnet/net6.0.js';
+
+import './bin/System.Runtime.js';
+import './bin/System.Console.js';
+
+dotnet.System.Console.WriteLine(`Hello from .NET ${dotnet.runtimeVersion}!`);
+assert.strictEqual(dotnet.frameworkMoniker, 'net6.0');

--- a/test/TestCases/projects/ts-esm/net8.0.ts
+++ b/test/TestCases/projects/ts-esm/net8.0.ts
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import * as assert from 'assert';
+import dotnet from 'node-api-dotnet/net8.0.js';
+
+import './bin/System.Runtime.js';
+import './bin/System.Console.js';
+
+dotnet.System.Console.WriteLine(`Hello from .NET ${dotnet.runtimeVersion}!`);
+assert.strictEqual(dotnet.frameworkMoniker, 'net8.0');

--- a/test/TestCases/projects/ts-esm/tsconfig.json
+++ b/test/TestCases/projects/ts-esm/tsconfig.json
@@ -7,5 +7,5 @@
     "outDir": "out"
   },
   "include": ["*.ts", "bin/*.js"],
-  "exclude": ["node_modules"]
+  "exclude": ["net472.ts", "node_modules"]
 }

--- a/test/TestCases/projects/ts-esm/tsconfig.net472.json
+++ b/test/TestCases/projects/ts-esm/tsconfig.net472.json
@@ -1,11 +1,11 @@
 {
   "compilerOptions": {
-    "module": "CommonJS",
+    "module": "Node16",
     "target": "ES2022",
     "allowJs": true,
     "checkJs": true,
     "outDir": "out"
   },
-  "include": ["*.ts", "bin/*.js"],
-  "exclude": ["net472.ts", "node_modules"]
+  "include": ["net472.ts", "bin/*.js"],
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
The intended design of the `node-api-dotnet` npm package is to allow JS code to import a specific major version of .NET by appending the TFM to the imported module name:

```JavaScript
import * as dotnet from 'node-api-dotnet/net6.0'; // TypeScript CommonJS syntax
```

However that capability was never fully implemented or tested. This PR fixes that.

Summary of changes:
 - Improve the build-time `pack.js` script (that creates the `node-api-dotnet` npm package) to generate `.js` and `.d.ts` stubs for all the supported target framework monikers.
 - Improve the run-time `init.js` script to return the already-loaded instance of .NET, unless a different version was requested. Default to `net8.0` if a specific TFM was not requested and no version is loaded yet.
 - Fix a few issues in the TS generator, and skip some problematic namespaces, to handle .NET Framework 4.x APIs. The TS generation was never tested much with .NET 4.x before.
 - Add `runtimeVersion` and `frameworkMoniker` properties to the top-level exports of the `node-api-dotnet` module, in case applications need to check what version was actually loaded.
 - Add project test cases for all 3 supported TFMs, covering the matrix of JS/TS and CommonJS/ESM module systems. Each of these test cases does the following steps:
    1. Run `dotnet build` for the target framework, which generates type-definitions for .NET system APIs for the target framework version.
    2. Run `tsc` which checks the generated type-definitions and their use in the JS or TS test code.
    3. Run the `.js` code (which for TS projects was generated by `tsc`) and verify that the expected version of .NET was loaded and `Console.WriteLine()` works.
    
Fixes #190