### PR TITLE
Implement strongly typed cast from/to JSValue

### DIFF
--- a/src/NodeApi/IJSValue.cs
+++ b/src/NodeApi/IJSValue.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#if !NET7_0_OR_GREATER
+using System;
+using System.Reflection;
+#endif
+
+namespace Microsoft.JavaScript.NodeApi;
+
+#if NET7_0_OR_GREATER
+// A static interface that helps with the conversion of JSValue to a specific type.
+public interface IJSValue<TSelf> where TSelf : struct, IJSValue<TSelf>
+{
+    public static abstract bool CanBeConvertedFrom(JSValue value);
+
+    public static abstract TSelf CreateUnchecked(JSValue value);
+}
+#else
+// A static class that helps with the conversion of JSValue to a specific type.
+public static class IJSValueShim<T> where T : struct
+{
+    private static readonly Func<JSValue, bool> s_canBeConvertedFrom =
+        (Func<JSValue, bool>)Delegate.CreateDelegate(
+            typeof(Func<JSValue, bool>),
+            typeof(T).GetMethod(
+                nameof(JSObject.CanBeConvertedFrom),
+                BindingFlags.Static | BindingFlags.Public)!);
+
+    private static readonly Func<JSValue, T>s_createUnchecked =
+        (Func<JSValue, T>)Delegate.CreateDelegate(
+            typeof(Func<JSValue, T>),
+            typeof(T).GetMethod(
+                nameof(JSObject.CreateUnchecked),
+                BindingFlags.Static | BindingFlags.Public)!);
+
+    public static bool CanBeConvertedFrom(JSValue value) => s_canBeConvertedFrom(value);
+
+    public static T CreateUnchecked(JSValue value) => s_createUnchecked(value);
+}
+#endif

--- a/src/NodeApi/IJSValue.cs
+++ b/src/NodeApi/IJSValue.cs
@@ -18,17 +18,47 @@ namespace Microsoft.JavaScript.NodeApi;
 public interface IJSValue<TSelf> : IEquatable<JSValue> where TSelf : struct, IJSValue<TSelf>
 {
     /// <summary>
-    /// Converts the derived struct `TSelf` to a <see cref="JSValue"/> with
-    /// the same `napi_value` handle.
+    /// Checks if the T struct can be created from this instance`.
     /// </summary>
+    /// <typeparam name="T">A struct that implements IJSValue interface.</typeparam>
     /// <returns>
-    /// <see cref="JSValue"/> with the same `napi_value` handle as the derived struct.
+    /// `true` if the T struct can be created from this instance. Otherwise it returns `false`.
     /// </returns>
-    JSValue AsJSValue();
+    bool Is<T>() where T : struct, IJSValue<T>;
+
+    /// <summary>
+    /// Tries to create a T struct from this instance.
+    /// It returns `null` if the T struct cannot be created.
+    /// </summary>
+    /// <typeparam name="T">A struct that implements IJSValue interface.</typeparam>
+    /// <returns>
+    /// Nullable value that contains T struct if it was successfully created
+    /// or `null` if it was failed.
+    /// </returns>
+    T? As<T>() where T : struct, IJSValue<T>;
+
+    /// <summary>
+    /// Creates a T struct from this instance without checking the enclosed handle type.
+    /// It must be used only when the handle type is known to be correct.
+    /// </summary>
+    /// <typeparam name="T">A struct that implements IJSValue interface.</typeparam>
+    /// <returns>T struct created based on this instance.</returns>
+    T AsUnchecked<T>() where T : struct, IJSValue<T>;
+
+    /// <summary>
+    /// Creates a T struct from this instance.
+    /// It throws `InvalidCastException` in case of failure.
+    /// </summary>
+    /// <typeparam name="T">A struct that implements IJSValue interface.</typeparam>
+    /// <returns>T struct created based on this instance.</returns>
+    /// <exception cref="InvalidCastException">
+    /// Thrown when the T struct cannot be crated based on this instance.
+    /// </exception>
+    T CastTo<T>() where T : struct, IJSValue<T>;
 
 #if NET7_0_OR_GREATER
     /// <summary>
-    /// Checks id the derived struct `TSelf` can be created from a <see cref="JSValue"/>.
+    /// Checks if the derived struct `TSelf` can be created from a <see cref="JSValue"/>.
     /// </summary>
     static abstract bool CanCreateFrom(JSValue value);
 
@@ -50,27 +80,27 @@ internal static class IJSValueShim<T> where T : struct, IJSValue<T>
     /// <summary>
     /// A static field to keep a reference to the CanCreateFrom private method.
     /// </summary>
-    private static readonly Func<JSValue, bool> s_canBeCreatedFrom =
+    private static readonly Func<JSValue, bool> s_canCreateFrom =
         (Func<JSValue, bool>)Delegate.CreateDelegate(
             typeof(Func<JSValue, bool>),
             typeof(T).GetMethod(
-                "CanCreateFrom",
+                nameof(CanCreateFrom),
                 BindingFlags.Static | BindingFlags.NonPublic)!);
 
     /// <summary>
     /// A static field to keep a reference to the CreateUnchecked private method.
     /// </summary>
-    private static readonly Func<JSValue, T>s_createUnchecked =
+    private static readonly Func<JSValue, T> s_createUnchecked =
         (Func<JSValue, T>)Delegate.CreateDelegate(
             typeof(Func<JSValue, T>),
             typeof(T).GetMethod(
-                "CreateUnchecked",
+                nameof(CreateUnchecked),
                 BindingFlags.Static | BindingFlags.NonPublic)!);
 
     /// <summary>
     /// Invokes `T.CanCreateFrom` static public method.
     /// </summary>
-    public static bool CanCreateFrom(JSValue value) => s_canBeCreatedFrom(value);
+    public static bool CanCreateFrom(JSValue value) => s_canCreateFrom(value);
 
     /// <summary>
     /// Invokes `T.CreateUnchecked` static private method.

--- a/src/NodeApi/IJSValue.cs
+++ b/src/NodeApi/IJSValue.cs
@@ -48,14 +48,14 @@ public interface IJSValue<TSelf> : IEquatable<JSValue> where TSelf : struct, IJS
 internal static class IJSValueShim<T> where T : struct, IJSValue<T>
 {
     /// <summary>
-    /// A static field to keep a reference to the CanCreateFrom public method.
+    /// A static field to keep a reference to the CanCreateFrom private method.
     /// </summary>
     private static readonly Func<JSValue, bool> s_canBeCreatedFrom =
         (Func<JSValue, bool>)Delegate.CreateDelegate(
             typeof(Func<JSValue, bool>),
             typeof(T).GetMethod(
                 "CanCreateFrom",
-                BindingFlags.Static | BindingFlags.Public)!);
+                BindingFlags.Static | BindingFlags.NonPublic)!);
 
     /// <summary>
     /// A static field to keep a reference to the CreateUnchecked private method.

--- a/src/NodeApi/IJSValue.cs
+++ b/src/NodeApi/IJSValue.cs
@@ -9,22 +9,47 @@ using System.Reflection;
 
 namespace Microsoft.JavaScript.NodeApi;
 
-// A static interface that helps with the conversion of JSValue to a specific type.
+/// <summary>
+/// A base interface for a struct that represents a JavaScript value type or a built-in
+/// object type. It provides functionality for converting between the struct
+/// and <see cref="JSValue"/>.
+/// </summary>
+/// <typeparam name="TSelf">The derived struct type.</typeparam>
 public interface IJSValue<TSelf> : IEquatable<JSValue> where TSelf : struct, IJSValue<TSelf>
 {
-    public JSValue AsJSValue();
+    /// <summary>
+    /// Converts the derived struct `TSelf` to a <see cref="JSValue"/> with
+    /// the same `napi_value` handle.
+    /// </summary>
+    /// <returns>
+    /// <see cref="JSValue"/> with the same `napi_value` handle as the derived struct.
+    /// </returns>
+    JSValue AsJSValue();
 
 #if NET7_0_OR_GREATER
-    public static abstract bool CanCreateFrom(JSValue value);
+    /// <summary>
+    /// Checks id the derived struct `TSelf` can be created from a <see cref="JSValue"/>.
+    /// </summary>
+    static abstract bool CanCreateFrom(JSValue value);
 
-    public static abstract TSelf CreateUnchecked(JSValue value);
+    /// <summary>
+    /// Creates a new instance of the derived struct `TSelf` from a <see cref="JSValue"/> without
+    /// checking the enclosed handle type.
+    /// </summary>
+    static abstract TSelf CreateUnchecked(JSValue value);
 #endif
 }
 
 #if !NET7_0_OR_GREATER
-// A static class that helps with the conversion of JSValue to a specific type.
-internal static class IJSValueShim<T> where T : struct
+/// <summary>
+/// Implements IJSValue interface static functions for the previous .Net versions.
+/// </summary>
+/// <typeparam name="T"></typeparam>
+internal static class IJSValueShim<T> where T : struct, IJSValue<T>
 {
+    /// <summary>
+    /// A static field to keep a reference to the CanCreateFrom public method.
+    /// </summary>
     private static readonly Func<JSValue, bool> s_canBeCreatedFrom =
         (Func<JSValue, bool>)Delegate.CreateDelegate(
             typeof(Func<JSValue, bool>),
@@ -32,6 +57,9 @@ internal static class IJSValueShim<T> where T : struct
                 "CanCreateFrom",
                 BindingFlags.Static | BindingFlags.Public)!);
 
+    /// <summary>
+    /// A static field to keep a reference to the CreateUnchecked private method.
+    /// </summary>
     private static readonly Func<JSValue, T>s_createUnchecked =
         (Func<JSValue, T>)Delegate.CreateDelegate(
             typeof(Func<JSValue, T>),
@@ -39,8 +67,14 @@ internal static class IJSValueShim<T> where T : struct
                 "CreateUnchecked",
                 BindingFlags.Static | BindingFlags.NonPublic)!);
 
+    /// <summary>
+    /// Invokes `T.CanCreateFrom` static public method.
+    /// </summary>
     public static bool CanCreateFrom(JSValue value) => s_canBeCreatedFrom(value);
 
+    /// <summary>
+    /// Invokes `T.CreateUnchecked` static private method.
+    /// </summary>
     public static T CreateUnchecked(JSValue value) => s_createUnchecked(value);
 }
 #endif

--- a/src/NodeApi/Interop/JSAbortSignal.cs
+++ b/src/NodeApi/Interop/JSAbortSignal.cs
@@ -23,7 +23,7 @@ public readonly struct JSAbortSignal : IJSValue<JSAbortSignal>
     /// Implicitly converts a <see cref="JSAbortSignal" /> to a <see cref="JSValue" />.
     /// </summary>
     /// <param name="value">The <see cref="JSAbortSignal" /> to convert.</param>
-    public static implicit operator JSValue(JSAbortSignal value) => value.AsJSValue();
+    public static implicit operator JSValue(JSAbortSignal signal) => signal._value;
 
     /// <summary>
     /// Explicitly converts a <see cref="JSValue" /> to a nullable <see cref="JSAbortSignal" />.
@@ -64,12 +64,43 @@ public readonly struct JSAbortSignal : IJSValue<JSAbortSignal>
     #region IJSValue<JSAbortSignal> implementation
 
     /// <summary>
-    /// Converts the <see cref="JSAbortSignal" /> to a <see cref="JSValue" />.
+    /// Checks if the T struct can be created from this instance`.
     /// </summary>
+    /// <typeparam name="T">A struct that implements IJSValue interface.</typeparam>
     /// <returns>
-    /// The <see cref="JSValue" /> representation of the <see cref="JSAbortSignal" />.
+    /// `true` if the T struct can be created from this instance. Otherwise it returns `false`.
     /// </returns>
-    public JSValue AsJSValue() => _value;
+    public bool Is<T>() where T : struct, IJSValue<T> => _value.Is<T>();
+
+    /// <summary>
+    /// Tries to create a T struct from this instance.
+    /// It returns `null` if the T struct cannot be created.
+    /// </summary>
+    /// <typeparam name="T">A struct that implements IJSValue interface.</typeparam>
+    /// <returns>
+    /// Nullable value that contains T struct if it was successfully created
+    /// or `null` if it was failed.
+    /// </returns>
+    public T? As<T>() where T : struct, IJSValue<T> => _value.As<T>();
+
+    /// <summary>
+    /// Creates a T struct from this instance without checking the enclosed handle type.
+    /// It must be used only when the handle type is known to be correct.
+    /// </summary>
+    /// <typeparam name="T">A struct that implements IJSValue interface.</typeparam>
+    /// <returns>T struct created based on this instance.</returns>
+    public T AsUnchecked<T>() where T : struct, IJSValue<T> => _value.AsUnchecked<T>();
+
+    /// <summary>
+    /// Creates a T struct from this instance.
+    /// It throws `InvalidCastException` in case of failure.
+    /// </summary>
+    /// <typeparam name="T">A struct that implements IJSValue interface.</typeparam>
+    /// <returns>T struct created based on this instance.</returns>
+    /// <exception cref="InvalidCastException">
+    /// Thrown when the T struct cannot be crated based on this instance.
+    /// </exception>
+    public T CastTo<T>() where T : struct, IJSValue<T> => _value.CastTo<T>();
 
     /// <summary>
     /// Determines whether a <see cref="JSAbortSignal" /> can be created from

--- a/src/NodeApi/Interop/JSAbortSignal.cs
+++ b/src/NodeApi/Interop/JSAbortSignal.cs
@@ -64,6 +64,14 @@ public readonly struct JSAbortSignal : IJSValue<JSAbortSignal>
     #region IJSValue<JSAbortSignal> implementation
 
     /// <summary>
+    /// Converts the <see cref="JSAbortSignal" /> to a <see cref="JSValue" />.
+    /// </summary>
+    /// <returns>
+    /// The <see cref="JSValue" /> representation of the <see cref="JSAbortSignal" />.
+    /// </returns>
+    public JSValue AsJSValue() => _value;
+
+    /// <summary>
     /// Determines whether a <see cref="JSAbortSignal" /> can be created from
     /// the specified <see cref="JSValue" />.
     /// </summary>
@@ -72,8 +80,14 @@ public readonly struct JSAbortSignal : IJSValue<JSAbortSignal>
     /// <c>true</c> if a <see cref="JSAbortSignal" /> can be created from
     /// the specified <see cref="JSValue" />; otherwise, <c>false</c>.
     /// </returns>
-    public static bool CanCreateFrom(JSValue value) =>
-        value.IsObject() && value.InstanceOf(JSValue.Global["AbortSignal"]);
+#if NET7_0_OR_GREATER
+    static bool IJSValue<JSAbortSignal>.CanCreateFrom(JSValue value)
+#else
+#pragma warning disable IDE0051 // It is used by the IJSValueShim<T> class through reflection.
+    private static bool CanCreateFrom(JSValue value)
+#pragma warning restore IDE0051
+#endif
+        => value.IsObject() && value.InstanceOf(JSValue.Global["AbortSignal"]);
 
     /// <summary>
     /// Creates a new instance of <see cref="JSAbortSignal" /> from
@@ -93,14 +107,6 @@ public readonly struct JSAbortSignal : IJSValue<JSAbortSignal>
     private static JSAbortSignal CreateUnchecked(JSValue value) => new(value);
 #pragma warning restore IDE0051
 #endif
-
-    /// <summary>
-    /// Converts the <see cref="JSAbortSignal" /> to a <see cref="JSValue" />.
-    /// </summary>
-    /// <returns>
-    /// The <see cref="JSValue" /> representation of the <see cref="JSAbortSignal" />.
-    /// </returns>
-    public JSValue AsJSValue() => _value;
 
     #endregion
 

--- a/src/NodeApi/Interop/JSAbortSignal.cs
+++ b/src/NodeApi/Interop/JSAbortSignal.cs
@@ -41,10 +41,9 @@ public readonly struct JSAbortSignal : IJSValue<JSAbortSignal>
 
     #region IJSValue<JSAbortSignal> implementation
 
-    public static bool CanCreateFrom(JSValue value) => value.IsObject();
+    public static bool CanCreateFrom(JSValue value) => value.IsObject() && value.InstanceOf(JSValue.Global["JSAbortSignal"]);
 
 #if NET7_0_OR_GREATER
-    // TODO: (vmoroz) Implement
     static JSAbortSignal IJSValue<JSAbortSignal>.CreateUnchecked(JSValue value) => new(value);
 #else
 #pragma warning disable IDE0051 // It is used by the IJSValueShim<T> class through reflection.

--- a/src/NodeApi/Interop/JSAbortSignal.cs
+++ b/src/NodeApi/Interop/JSAbortSignal.cs
@@ -24,7 +24,7 @@ public readonly struct JSAbortSignal : IJSValue<JSAbortSignal>
     public static explicit operator JSAbortSignal(JSValue value) => value.CastTo<JSAbortSignal>();
 
     public static explicit operator JSAbortSignal(JSObject obj) => (JSAbortSignal)(JSValue)obj;
-    public static implicit operator JSObject(JSAbortSignal promise) => (JSObject)promise._value;
+    public static implicit operator JSObject(JSAbortSignal signal) => (JSObject)signal._value;
 
     private JSAbortSignal(JSValue value)
     {
@@ -41,7 +41,8 @@ public readonly struct JSAbortSignal : IJSValue<JSAbortSignal>
 
     #region IJSValue<JSAbortSignal> implementation
 
-    public static bool CanCreateFrom(JSValue value) => value.IsObject() && value.InstanceOf(JSValue.Global["JSAbortSignal"]);
+    public static bool CanCreateFrom(JSValue value)
+        => value.IsObject() && value.InstanceOf(JSValue.Global["AbortSignal"]);
 
 #if NET7_0_OR_GREATER
     static JSAbortSignal IJSValue<JSAbortSignal>.CreateUnchecked(JSValue value) => new(value);

--- a/src/NodeApi/Interop/JSAbortSignal.cs
+++ b/src/NodeApi/Interop/JSAbortSignal.cs
@@ -16,11 +16,17 @@ namespace Microsoft.JavaScript.NodeApi.Interop;
 /// https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
 /// </remarks>
 public readonly struct JSAbortSignal : IEquatable<JSValue>
+#if NET7_0_OR_GREATER
+    , IJSValue<JSAbortSignal>
+#endif
 {
     private readonly JSValue _value;
 
-    public static explicit operator JSAbortSignal(JSValue value) => new(value);
-    public static implicit operator JSValue(JSAbortSignal promise) => promise._value;
+    public static implicit operator JSValue(JSAbortSignal value) => value.AsJSValue();
+    public static explicit operator JSAbortSignal?(JSValue value) => value.As<JSAbortSignal>();
+    public static explicit operator JSAbortSignal(JSValue value)
+        => value.As<JSAbortSignal>()
+        ?? throw new InvalidCastException("JSValue is not an AbortSignal.");
 
     public static explicit operator JSAbortSignal(JSObject obj) => (JSAbortSignal)(JSValue)obj;
     public static implicit operator JSObject(JSAbortSignal promise) => (JSObject)promise._value;
@@ -37,6 +43,17 @@ public readonly struct JSAbortSignal : IEquatable<JSValue>
         => FromCancellationToken(cancellation);
     public static explicit operator JSAbortSignal(CancellationToken? cancellation)
         => cancellation.HasValue ? FromCancellationToken(cancellation.Value) : default;
+
+    #region IJSValue<JSAbortSignal> implementation
+
+    // TODO: (vmoroz) Implement
+    public static bool CanBeConvertedFrom(JSValue value) => value.IsObject();
+
+    public static JSAbortSignal CreateUnchecked(JSValue value) => new(value);
+
+    #endregion
+
+    public JSValue AsJSValue() => _value;
 
     private CancellationToken ToCancellationToken()
     {

--- a/src/NodeApi/Interop/JSAbortSignal.cs
+++ b/src/NodeApi/Interop/JSAbortSignal.cs
@@ -19,8 +19,29 @@ public readonly struct JSAbortSignal : IJSValue<JSAbortSignal>
 {
     private readonly JSValue _value;
 
+    /// <summary>
+    /// Implicitly converts a <see cref="JSAbortSignal" /> to a <see cref="JSValue" />.
+    /// </summary>
+    /// <param name="value">The <see cref="JSAbortSignal" /> to convert.</param>
     public static implicit operator JSValue(JSAbortSignal value) => value.AsJSValue();
+
+    /// <summary>
+    /// Explicitly converts a <see cref="JSValue" /> to a nullable <see cref="JSAbortSignal" />.
+    /// </summary>
+    /// <param name="value">The <see cref="JSValue" /> to convert.</param>
+    /// <returns>
+    /// The <see cref="JSAbortSignal" /> if it was successfully created or `null` if it was failed.
+    /// </returns>
     public static explicit operator JSAbortSignal?(JSValue value) => value.As<JSAbortSignal>();
+
+    /// <summary>
+    /// Explicitly converts a <see cref="JSValue" /> to a <see cref="JSAbortSignal" />.
+    /// </summary>
+    /// <param name="value">The <see cref="JSValue" /> to convert.</param>
+    /// <returns><see cref="JSAbortSignal" /> struct created based on this `JSValue`.</returns>
+    /// <exception cref="InvalidCastException">
+    /// Thrown when the T struct cannot be created based on this `JSValue`.
+    /// </exception>
     public static explicit operator JSAbortSignal(JSValue value) => value.CastTo<JSAbortSignal>();
 
     public static explicit operator JSAbortSignal(JSObject obj) => (JSAbortSignal)(JSValue)obj;
@@ -36,14 +57,35 @@ public readonly struct JSAbortSignal : IJSValue<JSAbortSignal>
 
     public static explicit operator JSAbortSignal(CancellationToken cancellation)
         => FromCancellationToken(cancellation);
+
     public static explicit operator JSAbortSignal(CancellationToken? cancellation)
         => cancellation.HasValue ? FromCancellationToken(cancellation.Value) : default;
 
     #region IJSValue<JSAbortSignal> implementation
 
-    public static bool CanCreateFrom(JSValue value)
-        => value.IsObject() && value.InstanceOf(JSValue.Global["AbortSignal"]);
+    /// <summary>
+    /// Determines whether a <see cref="JSAbortSignal" /> can be created from
+    /// the specified <see cref="JSValue" />.
+    /// </summary>
+    /// <param name="value">The <see cref="JSValue" /> to check.</param>
+    /// <returns>
+    /// <c>true</c> if a <see cref="JSAbortSignal" /> can be created from
+    /// the specified <see cref="JSValue" />; otherwise, <c>false</c>.
+    /// </returns>
+    public static bool CanCreateFrom(JSValue value) =>
+        value.IsObject() && value.InstanceOf(JSValue.Global["AbortSignal"]);
 
+    /// <summary>
+    /// Creates a new instance of <see cref="JSAbortSignal" /> from
+    /// the specified <see cref="JSValue" />.
+    /// </summary>
+    /// <param name="value">
+    /// The <see cref="JSValue" /> to create a <see cref="JSAbortSignal" /> from.
+    /// </param>
+    /// <returns>
+    /// A new instance of <see cref="JSAbortSignal" /> created from
+    /// the specified <see cref="JSValue" />.
+    /// </returns>
 #if NET7_0_OR_GREATER
     static JSAbortSignal IJSValue<JSAbortSignal>.CreateUnchecked(JSValue value) => new(value);
 #else
@@ -52,6 +94,12 @@ public readonly struct JSAbortSignal : IJSValue<JSAbortSignal>
 #pragma warning restore IDE0051
 #endif
 
+    /// <summary>
+    /// Converts the <see cref="JSAbortSignal" /> to a <see cref="JSValue" />.
+    /// </summary>
+    /// <returns>
+    /// The <see cref="JSValue" /> representation of the <see cref="JSAbortSignal" />.
+    /// </returns>
     public JSValue AsJSValue() => _value;
 
     #endregion

--- a/src/NodeApi/Interop/JSAbortSignal.cs
+++ b/src/NodeApi/Interop/JSAbortSignal.cs
@@ -47,12 +47,14 @@ public readonly struct JSAbortSignal : IJSValue<JSAbortSignal>
     // TODO: (vmoroz) Implement
     static JSAbortSignal IJSValue<JSAbortSignal>.CreateUnchecked(JSValue value) => new(value);
 #else
+#pragma warning disable IDE0051 // It is used by the IJSValueShim<T> class through reflection.
     private static JSAbortSignal CreateUnchecked(JSValue value) => new(value);
+#pragma warning restore IDE0051
 #endif
 
     public JSValue AsJSValue() => _value;
 
-#endregion
+    #endregion
 
     private CancellationToken ToCancellationToken()
     {

--- a/src/NodeApi/Interop/JSAbortSignal.cs
+++ b/src/NodeApi/Interop/JSAbortSignal.cs
@@ -15,18 +15,13 @@ namespace Microsoft.JavaScript.NodeApi.Interop;
 /// https://nodejs.org/api/globals.html#class-abortsignal
 /// https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
 /// </remarks>
-public readonly struct JSAbortSignal : IEquatable<JSValue>
-#if NET7_0_OR_GREATER
-    , IJSValue<JSAbortSignal>
-#endif
+public readonly struct JSAbortSignal : IJSValue<JSAbortSignal>
 {
     private readonly JSValue _value;
 
     public static implicit operator JSValue(JSAbortSignal value) => value.AsJSValue();
     public static explicit operator JSAbortSignal?(JSValue value) => value.As<JSAbortSignal>();
-    public static explicit operator JSAbortSignal(JSValue value)
-        => value.As<JSAbortSignal>()
-        ?? throw new InvalidCastException("JSValue is not an AbortSignal.");
+    public static explicit operator JSAbortSignal(JSValue value) => value.CastTo<JSAbortSignal>();
 
     public static explicit operator JSAbortSignal(JSObject obj) => (JSAbortSignal)(JSValue)obj;
     public static implicit operator JSObject(JSAbortSignal promise) => (JSObject)promise._value;
@@ -46,14 +41,18 @@ public readonly struct JSAbortSignal : IEquatable<JSValue>
 
     #region IJSValue<JSAbortSignal> implementation
 
+    public static bool CanCreateFrom(JSValue value) => value.IsObject();
+
+#if NET7_0_OR_GREATER
     // TODO: (vmoroz) Implement
-    public static bool CanBeConvertedFrom(JSValue value) => value.IsObject();
-
-    public static JSAbortSignal CreateUnchecked(JSValue value) => new(value);
-
-    #endregion
+    static JSAbortSignal IJSValue<JSAbortSignal>.CreateUnchecked(JSValue value) => new(value);
+#else
+    private static JSAbortSignal CreateUnchecked(JSValue value) => new(value);
+#endif
 
     public JSValue AsJSValue() => _value;
+
+#endregion
 
     private CancellationToken ToCancellationToken()
     {

--- a/src/NodeApi/JSArray.cs
+++ b/src/NodeApi/JSArray.cs
@@ -70,6 +70,14 @@ public readonly partial struct JSArray : IJSValue<JSArray>, IList<JSValue>
     #region IJSValue<JSArray> implementation
 
     /// <summary>
+    /// Converts the <see cref="JSArray" /> to a <see cref="JSValue" />.
+    /// </summary>
+    /// <returns>
+    /// The <see cref="JSValue" /> representation of the <see cref="JSArray" />.
+    /// </returns>
+    public JSValue AsJSValue() => _value;
+
+    /// <summary>
     /// Determines whether a <see cref="JSArray" /> can be created from
     /// the specified <see cref="JSValue" />.
     /// </summary>
@@ -78,7 +86,14 @@ public readonly partial struct JSArray : IJSValue<JSArray>, IList<JSValue>
     /// <c>true</c> if a <see cref="JSArray" /> can be created from
     /// the specified <see cref="JSValue" />; otherwise, <c>false</c>.
     /// </returns>
-    public static bool CanCreateFrom(JSValue value) => value.IsArray();
+#if NET7_0_OR_GREATER
+    static bool IJSValue<JSArray>.CanCreateFrom(JSValue value)
+#else
+#pragma warning disable IDE0051 // It is used by the IJSValueShim<T> class through reflection.
+    private static bool CanCreateFrom(JSValue value)
+#pragma warning restore IDE0051
+#endif
+        => value.IsArray();
 
     /// <summary>
     /// Creates a new instance of <see cref="JSArray" /> from
@@ -98,14 +113,6 @@ public readonly partial struct JSArray : IJSValue<JSArray>, IList<JSValue>
     private static JSArray CreateUnchecked(JSValue value) => new(value);
 #pragma warning restore IDE0051
 #endif
-
-    /// <summary>
-    /// Converts the <see cref="JSArray" /> to a <see cref="JSValue" />.
-    /// </summary>
-    /// <returns>
-    /// The <see cref="JSValue" /> representation of the <see cref="JSArray" />.
-    /// </returns>
-    public JSValue AsJSValue() => _value;
 
     #endregion
 

--- a/src/NodeApi/JSArray.cs
+++ b/src/NodeApi/JSArray.cs
@@ -16,7 +16,7 @@ public readonly partial struct JSArray : IJSValue<JSArray>, IList<JSValue>
     /// Implicitly converts a <see cref="JSArray" /> to a <see cref="JSValue" />.
     /// </summary>
     /// <param name="value">The <see cref="JSArray" /> to convert.</param>
-    public static implicit operator JSValue(JSArray arr) => arr.AsJSValue();
+    public static implicit operator JSValue(JSArray arr) => arr._value;
 
     /// <summary>
     /// Explicitly converts a <see cref="JSValue" /> to a nullable <see cref="JSArray" />.
@@ -70,12 +70,43 @@ public readonly partial struct JSArray : IJSValue<JSArray>, IList<JSValue>
     #region IJSValue<JSArray> implementation
 
     /// <summary>
-    /// Converts the <see cref="JSArray" /> to a <see cref="JSValue" />.
+    /// Checks if the T struct can be created from this instance`.
     /// </summary>
+    /// <typeparam name="T">A struct that implements IJSValue interface.</typeparam>
     /// <returns>
-    /// The <see cref="JSValue" /> representation of the <see cref="JSArray" />.
+    /// `true` if the T struct can be created from this instance. Otherwise it returns `false`.
     /// </returns>
-    public JSValue AsJSValue() => _value;
+    public bool Is<T>() where T : struct, IJSValue<T> => _value.Is<T>();
+
+    /// <summary>
+    /// Tries to create a T struct from this instance.
+    /// It returns `null` if the T struct cannot be created.
+    /// </summary>
+    /// <typeparam name="T">A struct that implements IJSValue interface.</typeparam>
+    /// <returns>
+    /// Nullable value that contains T struct if it was successfully created
+    /// or `null` if it was failed.
+    /// </returns>
+    public T? As<T>() where T : struct, IJSValue<T> => _value.As<T>();
+
+    /// <summary>
+    /// Creates a T struct from this instance without checking the enclosed handle type.
+    /// It must be used only when the handle type is known to be correct.
+    /// </summary>
+    /// <typeparam name="T">A struct that implements IJSValue interface.</typeparam>
+    /// <returns>T struct created based on this instance.</returns>
+    public T AsUnchecked<T>() where T : struct, IJSValue<T> => _value.AsUnchecked<T>();
+
+    /// <summary>
+    /// Creates a T struct from this instance.
+    /// It throws `InvalidCastException` in case of failure.
+    /// </summary>
+    /// <typeparam name="T">A struct that implements IJSValue interface.</typeparam>
+    /// <returns>T struct created based on this instance.</returns>
+    /// <exception cref="InvalidCastException">
+    /// Thrown when the T struct cannot be crated based on this instance.
+    /// </exception>
+    public T CastTo<T>() where T : struct, IJSValue<T> => _value.CastTo<T>();
 
     /// <summary>
     /// Determines whether a <see cref="JSArray" /> can be created from

--- a/src/NodeApi/JSArray.cs
+++ b/src/NodeApi/JSArray.cs
@@ -53,7 +53,9 @@ public readonly partial struct JSArray : IJSValue<JSArray>, IList<JSValue>
 #if NET7_0_OR_GREATER
     static JSArray IJSValue<JSArray>.CreateUnchecked(JSValue value) => new(value);
 #else
+#pragma warning disable IDE0051 // It is used by the IJSValueShim<T> class through reflection.
     private static JSArray CreateUnchecked(JSValue value) => new(value);
+#pragma warning restore IDE0051
 #endif
 
     public JSValue AsJSValue() => _value;

--- a/src/NodeApi/JSArray.cs
+++ b/src/NodeApi/JSArray.cs
@@ -5,21 +5,16 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using static Microsoft.JavaScript.NodeApi.Runtime.JSRuntime;
 
 namespace Microsoft.JavaScript.NodeApi;
 
-public readonly partial struct JSArray : IList<JSValue>, IEquatable<JSValue>
-#if NET7_0_OR_GREATER
-    , IJSValue<JSArray>
-#endif
+public readonly partial struct JSArray : IJSValue<JSArray>, IList<JSValue>
 {
     private readonly JSValue _value;
 
     public static implicit operator JSValue(JSArray arr) => arr.AsJSValue();
     public static explicit operator JSArray?(JSValue value) => value.As<JSArray>();
-    public static explicit operator JSArray(JSValue value)
-        => value.As<JSArray>() ?? throw new InvalidCastException("JSValue is not an Array");
+    public static explicit operator JSArray(JSValue value) => value.CastTo<JSArray>();
 
     public static explicit operator JSArray(JSObject obj) => (JSArray)(JSValue)obj;
     public static implicit operator JSObject(JSArray arr) => (JSObject)arr._value;
@@ -53,13 +48,17 @@ public readonly partial struct JSArray : IList<JSValue>, IEquatable<JSValue>
 
     #region IJSValue<JSArray> implementation
 
-    public static bool CanBeConvertedFrom(JSValue value) => value.IsArray();
+    public static bool CanCreateFrom(JSValue value) => value.IsArray();
 
-    public static JSArray CreateUnchecked(JSValue value) => new(value);
-
-    #endregion
+#if NET7_0_OR_GREATER
+    static JSArray IJSValue<JSArray>.CreateUnchecked(JSValue value) => new(value);
+#else
+    private static JSArray CreateUnchecked(JSValue value) => new(value);
+#endif
 
     public JSValue AsJSValue() => _value;
+
+    #endregion
 
     /// <inheritdoc/>
     public int Length => _value.GetArrayLength();

--- a/src/NodeApi/JSArray.cs
+++ b/src/NodeApi/JSArray.cs
@@ -12,8 +12,29 @@ public readonly partial struct JSArray : IJSValue<JSArray>, IList<JSValue>
 {
     private readonly JSValue _value;
 
+    /// <summary>
+    /// Implicitly converts a <see cref="JSArray" /> to a <see cref="JSValue" />.
+    /// </summary>
+    /// <param name="value">The <see cref="JSArray" /> to convert.</param>
     public static implicit operator JSValue(JSArray arr) => arr.AsJSValue();
+
+    /// <summary>
+    /// Explicitly converts a <see cref="JSValue" /> to a nullable <see cref="JSArray" />.
+    /// </summary>
+    /// <param name="value">The <see cref="JSValue" /> to convert.</param>
+    /// <returns>
+    /// The <see cref="JSArray" /> if it was successfully created or `null` if it was failed.
+    /// </returns>
     public static explicit operator JSArray?(JSValue value) => value.As<JSArray>();
+
+    /// <summary>
+    /// Explicitly converts a <see cref="JSValue" /> to a <see cref="JSArray" />.
+    /// </summary>
+    /// <param name="value">The <see cref="JSValue" /> to convert.</param>
+    /// <returns><see cref="JSArray" /> struct created based on this `JSValue`.</returns>
+    /// <exception cref="InvalidCastException">
+    /// Thrown when the T struct cannot be created based on this `JSValue`.
+    /// </exception>
     public static explicit operator JSArray(JSValue value) => value.CastTo<JSArray>();
 
     public static explicit operator JSArray(JSObject obj) => (JSArray)(JSValue)obj;
@@ -48,8 +69,28 @@ public readonly partial struct JSArray : IJSValue<JSArray>, IList<JSValue>
 
     #region IJSValue<JSArray> implementation
 
+    /// <summary>
+    /// Determines whether a <see cref="JSArray" /> can be created from
+    /// the specified <see cref="JSValue" />.
+    /// </summary>
+    /// <param name="value">The <see cref="JSValue" /> to check.</param>
+    /// <returns>
+    /// <c>true</c> if a <see cref="JSArray" /> can be created from
+    /// the specified <see cref="JSValue" />; otherwise, <c>false</c>.
+    /// </returns>
     public static bool CanCreateFrom(JSValue value) => value.IsArray();
 
+    /// <summary>
+    /// Creates a new instance of <see cref="JSArray" /> from
+    /// the specified <see cref="JSValue" />.
+    /// </summary>
+    /// <param name="value">
+    /// The <see cref="JSValue" /> to create a <see cref="JSArray" /> from.
+    /// </param>
+    /// <returns>
+    /// A new instance of <see cref="JSArray" /> created from
+    /// the specified <see cref="JSValue" />.
+    /// </returns>
 #if NET7_0_OR_GREATER
     static JSArray IJSValue<JSArray>.CreateUnchecked(JSValue value) => new(value);
 #else
@@ -58,6 +99,12 @@ public readonly partial struct JSArray : IJSValue<JSArray>, IList<JSValue>
 #pragma warning restore IDE0051
 #endif
 
+    /// <summary>
+    /// Converts the <see cref="JSArray" /> to a <see cref="JSValue" />.
+    /// </summary>
+    /// <returns>
+    /// The <see cref="JSValue" /> representation of the <see cref="JSArray" />.
+    /// </returns>
     public JSValue AsJSValue() => _value;
 
     #endregion

--- a/src/NodeApi/JSAsyncIterable.cs
+++ b/src/NodeApi/JSAsyncIterable.cs
@@ -34,7 +34,9 @@ public readonly partial struct JSAsyncIterable :
 #if NET7_0_OR_GREATER
     static JSAsyncIterable IJSValue<JSAsyncIterable>.CreateUnchecked(JSValue value) => new(value);
 #else
+#pragma warning disable IDE0051 // It is used by the IJSValueShim<T> class through reflection.
     private static JSAsyncIterable CreateUnchecked(JSValue value) => new(value);
+#pragma warning restore IDE0051
 #endif
 
     public JSValue AsJSValue() => _value;

--- a/src/NodeApi/JSAsyncIterable.cs
+++ b/src/NodeApi/JSAsyncIterable.cs
@@ -13,8 +13,29 @@ public readonly partial struct JSAsyncIterable :
 {
     private readonly JSValue _value;
 
+    /// <summary>
+    /// Implicitly converts a <see cref="JSAsyncIterable" /> to a <see cref="JSValue" />.
+    /// </summary>
+    /// <param name="value">The <see cref="JSAsyncIterable" /> to convert.</param>
     public static implicit operator JSValue(JSAsyncIterable value) => value.AsJSValue();
+
+    /// <summary>
+    /// Explicitly converts a <see cref="JSValue" /> to a nullable <see cref="JSAsyncIterable" />.
+    /// </summary>
+    /// <param name="value">The <see cref="JSValue" /> to convert.</param>
+    /// <returns>
+    /// The <see cref="JSAsyncIterable" /> if it was successfully created or `null` if it was failed.
+    /// </returns>
     public static explicit operator JSAsyncIterable?(JSValue value) => value.As<JSAsyncIterable>();
+
+    /// <summary>
+    /// Explicitly converts a <see cref="JSValue" /> to a <see cref="JSAsyncIterable" />.
+    /// </summary>
+    /// <param name="value">The <see cref="JSValue" /> to convert.</param>
+    /// <returns><see cref="JSAsyncIterable" /> struct created based on this `JSValue`.</returns>
+    /// <exception cref="InvalidCastException">
+    /// Thrown when the T struct cannot be created based on this `JSValue`.
+    /// </exception>
     public static explicit operator JSAsyncIterable(JSValue value)
         => value.CastTo<JSAsyncIterable>();
 
@@ -28,9 +49,29 @@ public readonly partial struct JSAsyncIterable :
 
     #region IJSValue<JSAsyncIterable> implementation
 
+    /// <summary>
+    /// Determines whether a <see cref="JSAsyncIterable" /> can be created from
+    /// the specified <see cref="JSValue" />.
+    /// </summary>
+    /// <param name="value">The <see cref="JSValue" /> to check.</param>
+    /// <returns>
+    /// <c>true</c> if a <see cref="JSAsyncIterable" /> can be created from
+    /// the specified <see cref="JSValue" />; otherwise, <c>false</c>.
+    /// </returns>
     public static bool CanCreateFrom(JSValue value)
         => value.IsObject() && value.HasProperty(JSSymbol.AsyncIterator);
 
+    /// <summary>
+    /// Creates a new instance of <see cref="JSAsyncIterable" /> from
+    /// the specified <see cref="JSValue" />.
+    /// </summary>
+    /// <param name="value">
+    /// The <see cref="JSValue" /> to create a <see cref="JSAsyncIterable" /> from.
+    /// </param>
+    /// <returns>
+    /// A new instance of <see cref="JSAsyncIterable" /> created from
+    /// the specified <see cref="JSValue" />.
+    /// </returns>
 #if NET7_0_OR_GREATER
     static JSAsyncIterable IJSValue<JSAsyncIterable>.CreateUnchecked(JSValue value) => new(value);
 #else
@@ -39,6 +80,12 @@ public readonly partial struct JSAsyncIterable :
 #pragma warning restore IDE0051
 #endif
 
+    /// <summary>
+    /// Converts the <see cref="JSAsyncIterable" /> to a <see cref="JSValue" />.
+    /// </summary>
+    /// <returns>
+    /// The <see cref="JSValue" /> representation of the <see cref="JSAsyncIterable" />.
+    /// </returns>
     public JSValue AsJSValue() => _value;
 
     #endregion

--- a/src/NodeApi/JSAsyncIterable.cs
+++ b/src/NodeApi/JSAsyncIterable.cs
@@ -8,18 +8,15 @@ using System.Threading;
 
 namespace Microsoft.JavaScript.NodeApi;
 
-public readonly partial struct JSAsyncIterable : IAsyncEnumerable<JSValue>, IEquatable<JSValue>
-#if NET7_0_OR_GREATER
-    , IJSValue<JSAsyncIterable>
-#endif
+public readonly partial struct JSAsyncIterable :
+    IJSValue<JSAsyncIterable>, IAsyncEnumerable<JSValue>
 {
     private readonly JSValue _value;
 
     public static implicit operator JSValue(JSAsyncIterable value) => value.AsJSValue();
     public static explicit operator JSAsyncIterable?(JSValue value) => value.As<JSAsyncIterable>();
     public static explicit operator JSAsyncIterable(JSValue value)
-        => value.As<JSAsyncIterable>()
-        ?? throw new InvalidCastException("JSValue is not an AsyncIterable.");
+        => value.CastTo<JSAsyncIterable>();
 
     public static explicit operator JSAsyncIterable(JSObject obj) => (JSAsyncIterable)(JSValue)obj;
     public static implicit operator JSObject(JSAsyncIterable iterable) => (JSObject)iterable._value;
@@ -32,13 +29,17 @@ public readonly partial struct JSAsyncIterable : IAsyncEnumerable<JSValue>, IEqu
     #region IJSValue<JSAsyncIterable> implementation
 
     //TODO: (vmoroz) implement proper check using Symbol.asyncIterator
-    public static bool CanBeConvertedFrom(JSValue value) => value.IsObject();
+    public static bool CanCreateFrom(JSValue value) => value.IsObject();
 
-    public static JSAsyncIterable CreateUnchecked(JSValue value) => new(value);
-
-    #endregion
+#if NET7_0_OR_GREATER
+    static JSAsyncIterable IJSValue<JSAsyncIterable>.CreateUnchecked(JSValue value) => new(value);
+#else
+    private static JSAsyncIterable CreateUnchecked(JSValue value) => new(value);
+#endif
 
     public JSValue AsJSValue() => _value;
+
+    #endregion
 
 #pragma warning disable IDE0060 // Unused parameter
     public Enumerator GetAsyncEnumerator(CancellationToken cancellationToken = default)

--- a/src/NodeApi/JSAsyncIterable.cs
+++ b/src/NodeApi/JSAsyncIterable.cs
@@ -17,7 +17,7 @@ public readonly partial struct JSAsyncIterable :
     /// Implicitly converts a <see cref="JSAsyncIterable" /> to a <see cref="JSValue" />.
     /// </summary>
     /// <param name="value">The <see cref="JSAsyncIterable" /> to convert.</param>
-    public static implicit operator JSValue(JSAsyncIterable value) => value.AsJSValue();
+    public static implicit operator JSValue(JSAsyncIterable iterable) => iterable._value;
 
     /// <summary>
     /// Explicitly converts a <see cref="JSValue" /> to a nullable <see cref="JSAsyncIterable" />.
@@ -50,12 +50,43 @@ public readonly partial struct JSAsyncIterable :
     #region IJSValue<JSAsyncIterable> implementation
 
     /// <summary>
-    /// Converts the <see cref="JSAsyncIterable" /> to a <see cref="JSValue" />.
+    /// Checks if the T struct can be created from this instance`.
     /// </summary>
+    /// <typeparam name="T">A struct that implements IJSValue interface.</typeparam>
     /// <returns>
-    /// The <see cref="JSValue" /> representation of the <see cref="JSAsyncIterable" />.
+    /// `true` if the T struct can be created from this instance. Otherwise it returns `false`.
     /// </returns>
-    public JSValue AsJSValue() => _value;
+    public bool Is<T>() where T : struct, IJSValue<T> => _value.Is<T>();
+
+    /// <summary>
+    /// Tries to create a T struct from this instance.
+    /// It returns `null` if the T struct cannot be created.
+    /// </summary>
+    /// <typeparam name="T">A struct that implements IJSValue interface.</typeparam>
+    /// <returns>
+    /// Nullable value that contains T struct if it was successfully created
+    /// or `null` if it was failed.
+    /// </returns>
+    public T? As<T>() where T : struct, IJSValue<T> => _value.As<T>();
+
+    /// <summary>
+    /// Creates a T struct from this instance without checking the enclosed handle type.
+    /// It must be used only when the handle type is known to be correct.
+    /// </summary>
+    /// <typeparam name="T">A struct that implements IJSValue interface.</typeparam>
+    /// <returns>T struct created based on this instance.</returns>
+    public T AsUnchecked<T>() where T : struct, IJSValue<T> => _value.AsUnchecked<T>();
+
+    /// <summary>
+    /// Creates a T struct from this instance.
+    /// It throws `InvalidCastException` in case of failure.
+    /// </summary>
+    /// <typeparam name="T">A struct that implements IJSValue interface.</typeparam>
+    /// <returns>T struct created based on this instance.</returns>
+    /// <exception cref="InvalidCastException">
+    /// Thrown when the T struct cannot be crated based on this instance.
+    /// </exception>
+    public T CastTo<T>() where T : struct, IJSValue<T> => _value.CastTo<T>();
 
     /// <summary>
     /// Determines whether a <see cref="JSAsyncIterable" /> can be created from

--- a/src/NodeApi/JSAsyncIterable.cs
+++ b/src/NodeApi/JSAsyncIterable.cs
@@ -28,8 +28,8 @@ public readonly partial struct JSAsyncIterable :
 
     #region IJSValue<JSAsyncIterable> implementation
 
-    //TODO: (vmoroz) implement proper check using Symbol.asyncIterator
-    public static bool CanCreateFrom(JSValue value) => value.IsObject();
+    public static bool CanCreateFrom(JSValue value)
+        => value.IsObject() && value.HasProperty(JSValue.Global["Symbol"]["asyncIterator"]);
 
 #if NET7_0_OR_GREATER
     static JSAsyncIterable IJSValue<JSAsyncIterable>.CreateUnchecked(JSValue value) => new(value);

--- a/src/NodeApi/JSAsyncIterable.cs
+++ b/src/NodeApi/JSAsyncIterable.cs
@@ -29,7 +29,7 @@ public readonly partial struct JSAsyncIterable :
     #region IJSValue<JSAsyncIterable> implementation
 
     public static bool CanCreateFrom(JSValue value)
-        => value.IsObject() && value.HasProperty(JSValue.Global["Symbol"]["asyncIterator"]);
+        => value.IsObject() && value.HasProperty(JSSymbol.AsyncIterator);
 
 #if NET7_0_OR_GREATER
     static JSAsyncIterable IJSValue<JSAsyncIterable>.CreateUnchecked(JSValue value) => new(value);

--- a/src/NodeApi/JSAsyncIterable.cs
+++ b/src/NodeApi/JSAsyncIterable.cs
@@ -9,11 +9,17 @@ using System.Threading;
 namespace Microsoft.JavaScript.NodeApi;
 
 public readonly partial struct JSAsyncIterable : IAsyncEnumerable<JSValue>, IEquatable<JSValue>
+#if NET7_0_OR_GREATER
+    , IJSValue<JSAsyncIterable>
+#endif
 {
     private readonly JSValue _value;
 
-    public static explicit operator JSAsyncIterable(JSValue value) => new(value);
-    public static implicit operator JSValue(JSAsyncIterable iterable) => iterable._value;
+    public static implicit operator JSValue(JSAsyncIterable value) => value.AsJSValue();
+    public static explicit operator JSAsyncIterable?(JSValue value) => value.As<JSAsyncIterable>();
+    public static explicit operator JSAsyncIterable(JSValue value)
+        => value.As<JSAsyncIterable>()
+        ?? throw new InvalidCastException("JSValue is not an AsyncIterable.");
 
     public static explicit operator JSAsyncIterable(JSObject obj) => (JSAsyncIterable)(JSValue)obj;
     public static implicit operator JSObject(JSAsyncIterable iterable) => (JSObject)iterable._value;
@@ -22,6 +28,17 @@ public readonly partial struct JSAsyncIterable : IAsyncEnumerable<JSValue>, IEqu
     {
         _value = value;
     }
+
+    #region IJSValue<JSAsyncIterable> implementation
+
+    //TODO: (vmoroz) implement proper check using Symbol.asyncIterator
+    public static bool CanBeConvertedFrom(JSValue value) => value.IsObject();
+
+    public static JSAsyncIterable CreateUnchecked(JSValue value) => new(value);
+
+    #endregion
+
+    public JSValue AsJSValue() => _value;
 
 #pragma warning disable IDE0060 // Unused parameter
     public Enumerator GetAsyncEnumerator(CancellationToken cancellationToken = default)

--- a/src/NodeApi/JSAsyncIterable.cs
+++ b/src/NodeApi/JSAsyncIterable.cs
@@ -50,6 +50,14 @@ public readonly partial struct JSAsyncIterable :
     #region IJSValue<JSAsyncIterable> implementation
 
     /// <summary>
+    /// Converts the <see cref="JSAsyncIterable" /> to a <see cref="JSValue" />.
+    /// </summary>
+    /// <returns>
+    /// The <see cref="JSValue" /> representation of the <see cref="JSAsyncIterable" />.
+    /// </returns>
+    public JSValue AsJSValue() => _value;
+
+    /// <summary>
     /// Determines whether a <see cref="JSAsyncIterable" /> can be created from
     /// the specified <see cref="JSValue" />.
     /// </summary>
@@ -58,7 +66,13 @@ public readonly partial struct JSAsyncIterable :
     /// <c>true</c> if a <see cref="JSAsyncIterable" /> can be created from
     /// the specified <see cref="JSValue" />; otherwise, <c>false</c>.
     /// </returns>
-    public static bool CanCreateFrom(JSValue value)
+#if NET7_0_OR_GREATER
+    static bool IJSValue<JSAsyncIterable>.CanCreateFrom(JSValue value)
+#else
+#pragma warning disable IDE0051 // It is used by the IJSValueShim<T> class through reflection.
+    private static bool CanCreateFrom(JSValue value)
+#pragma warning restore IDE0051
+#endif
         => value.IsObject() && value.HasProperty(JSSymbol.AsyncIterator);
 
     /// <summary>
@@ -79,14 +93,6 @@ public readonly partial struct JSAsyncIterable :
     private static JSAsyncIterable CreateUnchecked(JSValue value) => new(value);
 #pragma warning restore IDE0051
 #endif
-
-    /// <summary>
-    /// Converts the <see cref="JSAsyncIterable" /> to a <see cref="JSValue" />.
-    /// </summary>
-    /// <returns>
-    /// The <see cref="JSValue" /> representation of the <see cref="JSAsyncIterable" />.
-    /// </returns>
-    public JSValue AsJSValue() => _value;
 
     #endregion
 

--- a/src/NodeApi/JSBigInt.cs
+++ b/src/NodeApi/JSBigInt.cs
@@ -47,7 +47,9 @@ public readonly struct JSBigInt : IJSValue<JSBigInt>
 #if NET7_0_OR_GREATER
     static JSBigInt IJSValue<JSBigInt>.CreateUnchecked(JSValue value) => new(value);
 #else
+#pragma warning disable IDE0051 // It is used by the IJSValueShim<T> class through reflection.
     private static JSBigInt CreateUnchecked(JSValue value) => new(value);
+#pragma warning restore IDE0051
 #endif
 
     public JSValue AsJSValue() => _value;

--- a/src/NodeApi/JSBigInt.cs
+++ b/src/NodeApi/JSBigInt.cs
@@ -8,11 +8,16 @@ using System.Numerics;
 namespace Microsoft.JavaScript.NodeApi;
 
 public readonly struct JSBigInt : IEquatable<JSValue>
+#if NET7_0_OR_GREATER
+    , IJSValue<JSBigInt>
+#endif
 {
     private readonly JSValue _value;
 
-    public static explicit operator JSBigInt(JSValue value) => new(value);
-    public static implicit operator JSValue(JSBigInt value) => value._value;
+    public static implicit operator JSValue(JSBigInt value) => value.AsJSValue();
+    public static explicit operator JSBigInt?(JSValue value) => value.As<JSBigInt>();
+    public static explicit operator JSBigInt(JSValue value)
+        => value.As<JSBigInt>() ?? throw new InvalidCastException("JSValue is not a BigInt");
 
     public static implicit operator JSBigInt(BigInteger value) => new(value);
     public static explicit operator BigInteger(JSBigInt value) => value.ToBigInteger();
@@ -39,12 +44,20 @@ public readonly struct JSBigInt : IEquatable<JSValue>
     {
     }
 
+    #region IJSValue<JSBigInt> implementation
+
+    public static bool CanBeConvertedFrom(JSValue value) => value.IsBigInt();
+
+    public static JSBigInt CreateUnchecked(JSValue value) => new(value);
+
+    #endregion
+
+    public JSValue AsJSValue() => _value;
+
     public int GetWordCount() => _value.GetBigIntWordCount();
 
     public void CopyTo(Span<ulong> destination, out int sign, out int wordCount)
         => _value.GetBigIntWords(destination, out sign, out wordCount);
-
-    public JSValue AsJSValue() => _value;
 
     public BigInteger ToBigInteger() => _value.ToBigInteger();
 

--- a/src/NodeApi/JSBigInt.cs
+++ b/src/NodeApi/JSBigInt.cs
@@ -15,7 +15,7 @@ public readonly struct JSBigInt : IJSValue<JSBigInt>
     /// Implicitly converts a <see cref="JSBigInt" /> to a <see cref="JSValue" />.
     /// </summary>
     /// <param name="value">The <see cref="JSBigInt" /> to convert.</param>
-    public static implicit operator JSValue(JSBigInt value) => value.AsJSValue();
+    public static implicit operator JSValue(JSBigInt value) => value._value;
 
     /// <summary>
     /// Explicitly converts a <see cref="JSValue" /> to a nullable <see cref="JSBigInt" />.
@@ -64,12 +64,43 @@ public readonly struct JSBigInt : IJSValue<JSBigInt>
     #region IJSValue<JSBigInt> implementation
 
     /// <summary>
-    /// Converts the <see cref="JSBigInt" /> to a <see cref="JSValue" />.
+    /// Checks if the T struct can be created from this instance`.
     /// </summary>
+    /// <typeparam name="T">A struct that implements IJSValue interface.</typeparam>
     /// <returns>
-    /// The <see cref="JSValue" /> representation of the <see cref="JSBigInt" />.
+    /// `true` if the T struct can be created from this instance. Otherwise it returns `false`.
     /// </returns>
-    public JSValue AsJSValue() => _value;
+    public bool Is<T>() where T : struct, IJSValue<T> => _value.Is<T>();
+
+    /// <summary>
+    /// Tries to create a T struct from this instance.
+    /// It returns `null` if the T struct cannot be created.
+    /// </summary>
+    /// <typeparam name="T">A struct that implements IJSValue interface.</typeparam>
+    /// <returns>
+    /// Nullable value that contains T struct if it was successfully created
+    /// or `null` if it was failed.
+    /// </returns>
+    public T? As<T>() where T : struct, IJSValue<T> => _value.As<T>();
+
+    /// <summary>
+    /// Creates a T struct from this instance without checking the enclosed handle type.
+    /// It must be used only when the handle type is known to be correct.
+    /// </summary>
+    /// <typeparam name="T">A struct that implements IJSValue interface.</typeparam>
+    /// <returns>T struct created based on this instance.</returns>
+    public T AsUnchecked<T>() where T : struct, IJSValue<T> => _value.AsUnchecked<T>();
+
+    /// <summary>
+    /// Creates a T struct from this instance.
+    /// It throws `InvalidCastException` in case of failure.
+    /// </summary>
+    /// <typeparam name="T">A struct that implements IJSValue interface.</typeparam>
+    /// <returns>T struct created based on this instance.</returns>
+    /// <exception cref="InvalidCastException">
+    /// Thrown when the T struct cannot be crated based on this instance.
+    /// </exception>
+    public T CastTo<T>() where T : struct, IJSValue<T> => _value.CastTo<T>();
 
     /// <summary>
     /// Determines whether a <see cref="JSBigInt" /> can be created from

--- a/src/NodeApi/JSBigInt.cs
+++ b/src/NodeApi/JSBigInt.cs
@@ -11,8 +11,29 @@ public readonly struct JSBigInt : IJSValue<JSBigInt>
 {
     private readonly JSValue _value;
 
+    /// <summary>
+    /// Implicitly converts a <see cref="JSBigInt" /> to a <see cref="JSValue" />.
+    /// </summary>
+    /// <param name="value">The <see cref="JSBigInt" /> to convert.</param>
     public static implicit operator JSValue(JSBigInt value) => value.AsJSValue();
+
+    /// <summary>
+    /// Explicitly converts a <see cref="JSValue" /> to a nullable <see cref="JSBigInt" />.
+    /// </summary>
+    /// <param name="value">The <see cref="JSValue" /> to convert.</param>
+    /// <returns>
+    /// The <see cref="JSBigInt" /> if it was successfully created or `null` if it was failed.
+    /// </returns>
     public static explicit operator JSBigInt?(JSValue value) => value.As<JSBigInt>();
+
+    /// <summary>
+    /// Explicitly converts a <see cref="JSValue" /> to a <see cref="JSBigInt" />.
+    /// </summary>
+    /// <param name="value">The <see cref="JSValue" /> to convert.</param>
+    /// <returns><see cref="JSBigInt" /> struct created based on this `JSValue`.</returns>
+    /// <exception cref="InvalidCastException">
+    /// Thrown when the T struct cannot be created based on this `JSValue`.
+    /// </exception>
     public static explicit operator JSBigInt(JSValue value) => value.CastTo<JSBigInt>();
 
     public static implicit operator JSBigInt(BigInteger value) => new(value);
@@ -42,8 +63,28 @@ public readonly struct JSBigInt : IJSValue<JSBigInt>
 
     #region IJSValue<JSBigInt> implementation
 
+    /// <summary>
+    /// Determines whether a <see cref="JSBigInt" /> can be created from
+    /// the specified <see cref="JSValue" />.
+    /// </summary>
+    /// <param name="value">The <see cref="JSValue" /> to check.</param>
+    /// <returns>
+    /// <c>true</c> if a <see cref="JSBigInt" /> can be created from
+    /// the specified <see cref="JSValue" />; otherwise, <c>false</c>.
+    /// </returns>
     public static bool CanCreateFrom(JSValue value) => value.IsBigInt();
 
+    /// <summary>
+    /// Creates a new instance of <see cref="JSBigInt" /> from
+    /// the specified <see cref="JSValue" />.
+    /// </summary>
+    /// <param name="value">
+    /// The <see cref="JSValue" /> to create a <see cref="JSBigInt" /> from.
+    /// </param>
+    /// <returns>
+    /// A new instance of <see cref="JSBigInt" /> created from
+    /// the specified <see cref="JSValue" />.
+    /// </returns>
 #if NET7_0_OR_GREATER
     static JSBigInt IJSValue<JSBigInt>.CreateUnchecked(JSValue value) => new(value);
 #else
@@ -52,6 +93,12 @@ public readonly struct JSBigInt : IJSValue<JSBigInt>
 #pragma warning restore IDE0051
 #endif
 
+    /// <summary>
+    /// Converts the <see cref="JSBigInt" /> to a <see cref="JSValue" />.
+    /// </summary>
+    /// <returns>
+    /// The <see cref="JSValue" /> representation of the <see cref="JSBigInt" />.
+    /// </returns>
     public JSValue AsJSValue() => _value;
 
     #endregion

--- a/src/NodeApi/JSBigInt.cs
+++ b/src/NodeApi/JSBigInt.cs
@@ -64,6 +64,14 @@ public readonly struct JSBigInt : IJSValue<JSBigInt>
     #region IJSValue<JSBigInt> implementation
 
     /// <summary>
+    /// Converts the <see cref="JSBigInt" /> to a <see cref="JSValue" />.
+    /// </summary>
+    /// <returns>
+    /// The <see cref="JSValue" /> representation of the <see cref="JSBigInt" />.
+    /// </returns>
+    public JSValue AsJSValue() => _value;
+
+    /// <summary>
     /// Determines whether a <see cref="JSBigInt" /> can be created from
     /// the specified <see cref="JSValue" />.
     /// </summary>
@@ -72,7 +80,14 @@ public readonly struct JSBigInt : IJSValue<JSBigInt>
     /// <c>true</c> if a <see cref="JSBigInt" /> can be created from
     /// the specified <see cref="JSValue" />; otherwise, <c>false</c>.
     /// </returns>
-    public static bool CanCreateFrom(JSValue value) => value.IsBigInt();
+#if NET7_0_OR_GREATER
+    static bool IJSValue<JSBigInt>.CanCreateFrom(JSValue value)
+#else
+#pragma warning disable IDE0051 // It is used by the IJSValueShim<T> class through reflection.
+    private static bool CanCreateFrom(JSValue value)
+#pragma warning restore IDE0051
+#endif
+        => value.IsBigInt();
 
     /// <summary>
     /// Creates a new instance of <see cref="JSBigInt" /> from
@@ -92,14 +107,6 @@ public readonly struct JSBigInt : IJSValue<JSBigInt>
     private static JSBigInt CreateUnchecked(JSValue value) => new(value);
 #pragma warning restore IDE0051
 #endif
-
-    /// <summary>
-    /// Converts the <see cref="JSBigInt" /> to a <see cref="JSValue" />.
-    /// </summary>
-    /// <returns>
-    /// The <see cref="JSValue" /> representation of the <see cref="JSBigInt" />.
-    /// </returns>
-    public JSValue AsJSValue() => _value;
 
     #endregion
 

--- a/src/NodeApi/JSBigInt.cs
+++ b/src/NodeApi/JSBigInt.cs
@@ -7,17 +7,13 @@ using System.Numerics;
 
 namespace Microsoft.JavaScript.NodeApi;
 
-public readonly struct JSBigInt : IEquatable<JSValue>
-#if NET7_0_OR_GREATER
-    , IJSValue<JSBigInt>
-#endif
+public readonly struct JSBigInt : IJSValue<JSBigInt>
 {
     private readonly JSValue _value;
 
     public static implicit operator JSValue(JSBigInt value) => value.AsJSValue();
     public static explicit operator JSBigInt?(JSValue value) => value.As<JSBigInt>();
-    public static explicit operator JSBigInt(JSValue value)
-        => value.As<JSBigInt>() ?? throw new InvalidCastException("JSValue is not a BigInt");
+    public static explicit operator JSBigInt(JSValue value) => value.CastTo<JSBigInt>();
 
     public static implicit operator JSBigInt(BigInteger value) => new(value);
     public static explicit operator BigInteger(JSBigInt value) => value.ToBigInteger();
@@ -46,13 +42,17 @@ public readonly struct JSBigInt : IEquatable<JSValue>
 
     #region IJSValue<JSBigInt> implementation
 
-    public static bool CanBeConvertedFrom(JSValue value) => value.IsBigInt();
+    public static bool CanCreateFrom(JSValue value) => value.IsBigInt();
 
-    public static JSBigInt CreateUnchecked(JSValue value) => new(value);
-
-    #endregion
+#if NET7_0_OR_GREATER
+    static JSBigInt IJSValue<JSBigInt>.CreateUnchecked(JSValue value) => new(value);
+#else
+    private static JSBigInt CreateUnchecked(JSValue value) => new(value);
+#endif
 
     public JSValue AsJSValue() => _value;
+
+    #endregion
 
     public int GetWordCount() => _value.GetBigIntWordCount();
 

--- a/src/NodeApi/JSDate.cs
+++ b/src/NodeApi/JSDate.cs
@@ -15,7 +15,7 @@ public readonly struct JSDate : IJSValue<JSDate>
     /// Implicitly converts a <see cref="JSDate" /> to a <see cref="JSValue" />.
     /// </summary>
     /// <param name="value">The <see cref="JSDate" /> to convert.</param>
-    public static implicit operator JSValue(JSDate value) => value.AsJSValue();
+    public static implicit operator JSValue(JSDate date) => date._value;
 
     /// <summary>
     /// Explicitly converts a <see cref="JSValue" /> to a nullable <see cref="JSDate" />.
@@ -61,12 +61,43 @@ public readonly struct JSDate : IJSValue<JSDate>
     #region IJSValue<JSDate> implementation
 
     /// <summary>
-    /// Converts the <see cref="JSDate" /> to a <see cref="JSValue" />.
+    /// Checks if the T struct can be created from this instance`.
     /// </summary>
+    /// <typeparam name="T">A struct that implements IJSValue interface.</typeparam>
     /// <returns>
-    /// The <see cref="JSValue" /> representation of the <see cref="JSDate" />.
+    /// `true` if the T struct can be created from this instance. Otherwise it returns `false`.
     /// </returns>
-    public JSValue AsJSValue() => _value;
+    public bool Is<T>() where T : struct, IJSValue<T> => _value.Is<T>();
+
+    /// <summary>
+    /// Tries to create a T struct from this instance.
+    /// It returns `null` if the T struct cannot be created.
+    /// </summary>
+    /// <typeparam name="T">A struct that implements IJSValue interface.</typeparam>
+    /// <returns>
+    /// Nullable value that contains T struct if it was successfully created
+    /// or `null` if it was failed.
+    /// </returns>
+    public T? As<T>() where T : struct, IJSValue<T> => _value.As<T>();
+
+    /// <summary>
+    /// Creates a T struct from this instance without checking the enclosed handle type.
+    /// It must be used only when the handle type is known to be correct.
+    /// </summary>
+    /// <typeparam name="T">A struct that implements IJSValue interface.</typeparam>
+    /// <returns>T struct created based on this instance.</returns>
+    public T AsUnchecked<T>() where T : struct, IJSValue<T> => _value.AsUnchecked<T>();
+
+    /// <summary>
+    /// Creates a T struct from this instance.
+    /// It throws `InvalidCastException` in case of failure.
+    /// </summary>
+    /// <typeparam name="T">A struct that implements IJSValue interface.</typeparam>
+    /// <returns>T struct created based on this instance.</returns>
+    /// <exception cref="InvalidCastException">
+    /// Thrown when the T struct cannot be crated based on this instance.
+    /// </exception>
+    public T CastTo<T>() where T : struct, IJSValue<T> => _value.CastTo<T>();
 
     /// <summary>
     /// Determines whether a <see cref="JSDate" /> can be created from

--- a/src/NodeApi/JSDate.cs
+++ b/src/NodeApi/JSDate.cs
@@ -4,21 +4,16 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.JavaScript.NodeApi.Interop;
-using static Microsoft.JavaScript.NodeApi.Runtime.JSRuntime;
 
 namespace Microsoft.JavaScript.NodeApi;
 
-public readonly struct JSDate : IEquatable<JSValue>
-#if NET7_0_OR_GREATER
-    , IJSValue<JSDate>
-#endif
+public readonly struct JSDate : IJSValue<JSDate>
 {
     private readonly JSValue _value;
 
     public static implicit operator JSValue(JSDate value) => value.AsJSValue();
     public static explicit operator JSDate?(JSValue value) => value.As<JSDate>();
-    public static explicit operator JSDate(JSValue value)
-        => value.As<JSDate>() ?? throw new InvalidCastException("JSValue is not a Date");
+    public static explicit operator JSDate(JSValue value) => value.CastTo<JSDate>();
 
     private JSDate(JSValue value)
     {
@@ -44,13 +39,18 @@ public readonly struct JSDate : IEquatable<JSValue>
 
     #region IJSValue<JSDate> implementation
 
-    public static bool CanBeConvertedFrom(JSValue value) => value.IsDate();
+    public static bool CanCreateFrom(JSValue value) => value.IsDate();
 
-    public static JSDate CreateUnchecked(JSValue value) => new(value);
+#if NET7_0_OR_GREATER
+    static JSDate IJSValue<JSDate>.CreateUnchecked(JSValue value) => new(value);
+#else
+    private static JSDate CreateUnchecked(JSValue value) => new(value);
+#endif
+
+    public JSValue AsJSValue() => _value;
 
     #endregion
 
-    public JSValue AsJSValue() => _value;
 
     public static JSDate FromDateTime(DateTime value)
     {

--- a/src/NodeApi/JSDate.cs
+++ b/src/NodeApi/JSDate.cs
@@ -4,15 +4,21 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.JavaScript.NodeApi.Interop;
+using static Microsoft.JavaScript.NodeApi.Runtime.JSRuntime;
 
 namespace Microsoft.JavaScript.NodeApi;
 
 public readonly struct JSDate : IEquatable<JSValue>
+#if NET7_0_OR_GREATER
+    , IJSValue<JSDate>
+#endif
 {
     private readonly JSValue _value;
 
-    public static explicit operator JSDate(JSValue value) => new(value);
-    public static implicit operator JSValue(JSDate date) => date._value;
+    public static implicit operator JSValue(JSDate value) => value.AsJSValue();
+    public static explicit operator JSDate?(JSValue value) => value.As<JSDate>();
+    public static explicit operator JSDate(JSValue value)
+        => value.As<JSDate>() ?? throw new InvalidCastException("JSValue is not a Date");
 
     private JSDate(JSValue value)
     {
@@ -35,6 +41,16 @@ public readonly struct JSDate : IEquatable<JSValue>
     }
 
     public long DateValue => (long)_value.CallMethod("valueOf");
+
+    #region IJSValue<JSDate> implementation
+
+    public static bool CanBeConvertedFrom(JSValue value) => value.IsDate();
+
+    public static JSDate CreateUnchecked(JSValue value) => new(value);
+
+    #endregion
+
+    public JSValue AsJSValue() => _value;
 
     public static JSDate FromDateTime(DateTime value)
     {

--- a/src/NodeApi/JSDate.cs
+++ b/src/NodeApi/JSDate.cs
@@ -44,7 +44,9 @@ public readonly struct JSDate : IJSValue<JSDate>
 #if NET7_0_OR_GREATER
     static JSDate IJSValue<JSDate>.CreateUnchecked(JSValue value) => new(value);
 #else
+#pragma warning disable IDE0051 // It is used by the IJSValueShim<T> class through reflection.
     private static JSDate CreateUnchecked(JSValue value) => new(value);
+#pragma warning restore IDE0051
 #endif
 
     public JSValue AsJSValue() => _value;

--- a/src/NodeApi/JSDate.cs
+++ b/src/NodeApi/JSDate.cs
@@ -61,6 +61,14 @@ public readonly struct JSDate : IJSValue<JSDate>
     #region IJSValue<JSDate> implementation
 
     /// <summary>
+    /// Converts the <see cref="JSDate" /> to a <see cref="JSValue" />.
+    /// </summary>
+    /// <returns>
+    /// The <see cref="JSValue" /> representation of the <see cref="JSDate" />.
+    /// </returns>
+    public JSValue AsJSValue() => _value;
+
+    /// <summary>
     /// Determines whether a <see cref="JSDate" /> can be created from
     /// the specified <see cref="JSValue" />.
     /// </summary>
@@ -69,7 +77,14 @@ public readonly struct JSDate : IJSValue<JSDate>
     /// <c>true</c> if a <see cref="JSDate" /> can be created from
     /// the specified <see cref="JSValue" />; otherwise, <c>false</c>.
     /// </returns>
-    public static bool CanCreateFrom(JSValue value) => value.IsDate();
+#if NET7_0_OR_GREATER
+    static bool IJSValue<JSDate>.CanCreateFrom(JSValue value)
+#else
+#pragma warning disable IDE0051 // It is used by the IJSValueShim<T> class through reflection.
+    private static bool CanCreateFrom(JSValue value)
+#pragma warning restore IDE0051
+#endif
+        => value.IsDate();
 
     /// <summary>
     /// Creates a new instance of <see cref="JSDate" /> from
@@ -89,14 +104,6 @@ public readonly struct JSDate : IJSValue<JSDate>
     private static JSDate CreateUnchecked(JSValue value) => new(value);
 #pragma warning restore IDE0051
 #endif
-
-    /// <summary>
-    /// Converts the <see cref="JSDate" /> to a <see cref="JSValue" />.
-    /// </summary>
-    /// <returns>
-    /// The <see cref="JSValue" /> representation of the <see cref="JSDate" />.
-    /// </returns>
-    public JSValue AsJSValue() => _value;
 
     #endregion
 

--- a/src/NodeApi/JSDate.cs
+++ b/src/NodeApi/JSDate.cs
@@ -11,8 +11,29 @@ public readonly struct JSDate : IJSValue<JSDate>
 {
     private readonly JSValue _value;
 
+    /// <summary>
+    /// Implicitly converts a <see cref="JSDate" /> to a <see cref="JSValue" />.
+    /// </summary>
+    /// <param name="value">The <see cref="JSDate" /> to convert.</param>
     public static implicit operator JSValue(JSDate value) => value.AsJSValue();
+
+    /// <summary>
+    /// Explicitly converts a <see cref="JSValue" /> to a nullable <see cref="JSDate" />.
+    /// </summary>
+    /// <param name="value">The <see cref="JSValue" /> to convert.</param>
+    /// <returns>
+    /// The <see cref="JSDate" /> if it was successfully created or `null` if it was failed.
+    /// </returns>
     public static explicit operator JSDate?(JSValue value) => value.As<JSDate>();
+
+    /// <summary>
+    /// Explicitly converts a <see cref="JSValue" /> to a <see cref="JSDate" />.
+    /// </summary>
+    /// <param name="value">The <see cref="JSValue" /> to convert.</param>
+    /// <returns><see cref="JSDate" /> struct created based on this `JSValue`.</returns>
+    /// <exception cref="InvalidCastException">
+    /// Thrown when the T struct cannot be created based on this `JSValue`.
+    /// </exception>
     public static explicit operator JSDate(JSValue value) => value.CastTo<JSDate>();
 
     private JSDate(JSValue value)
@@ -39,8 +60,28 @@ public readonly struct JSDate : IJSValue<JSDate>
 
     #region IJSValue<JSDate> implementation
 
+    /// <summary>
+    /// Determines whether a <see cref="JSDate" /> can be created from
+    /// the specified <see cref="JSValue" />.
+    /// </summary>
+    /// <param name="value">The <see cref="JSValue" /> to check.</param>
+    /// <returns>
+    /// <c>true</c> if a <see cref="JSDate" /> can be created from
+    /// the specified <see cref="JSValue" />; otherwise, <c>false</c>.
+    /// </returns>
     public static bool CanCreateFrom(JSValue value) => value.IsDate();
 
+    /// <summary>
+    /// Creates a new instance of <see cref="JSDate" /> from
+    /// the specified <see cref="JSValue" />.
+    /// </summary>
+    /// <param name="value">
+    /// The <see cref="JSValue" /> to create a <see cref="JSDate" /> from.
+    /// </param>
+    /// <returns>
+    /// A new instance of <see cref="JSDate" /> created from
+    /// the specified <see cref="JSValue" />.
+    /// </returns>
 #if NET7_0_OR_GREATER
     static JSDate IJSValue<JSDate>.CreateUnchecked(JSValue value) => new(value);
 #else
@@ -49,6 +90,12 @@ public readonly struct JSDate : IJSValue<JSDate>
 #pragma warning restore IDE0051
 #endif
 
+    /// <summary>
+    /// Converts the <see cref="JSDate" /> to a <see cref="JSValue" />.
+    /// </summary>
+    /// <returns>
+    /// The <see cref="JSValue" /> representation of the <see cref="JSDate" />.
+    /// </returns>
     public JSValue AsJSValue() => _value;
 
     #endregion

--- a/src/NodeApi/JSFunction.cs
+++ b/src/NodeApi/JSFunction.cs
@@ -292,6 +292,14 @@ public readonly struct JSFunction : IJSValue<JSFunction>
     #region IJSValue<JSFunction> implementation
 
     /// <summary>
+    /// Converts the <see cref="JSFunction" /> to a <see cref="JSValue" />.
+    /// </summary>
+    /// <returns>
+    /// The <see cref="JSValue" /> representation of the <see cref="JSFunction" />.
+    /// </returns>
+    public JSValue AsJSValue() => _value;
+
+    /// <summary>
     /// Determines whether a <see cref="JSFunction" /> can be created from
     /// the specified <see cref="JSValue" />.
     /// </summary>
@@ -300,7 +308,14 @@ public readonly struct JSFunction : IJSValue<JSFunction>
     /// <c>true</c> if a <see cref="JSFunction" /> can be created from
     /// the specified <see cref="JSValue" />; otherwise, <c>false</c>.
     /// </returns>
-    public static bool CanCreateFrom(JSValue value) => value.IsFunction();
+#if NET7_0_OR_GREATER
+    static bool IJSValue<JSFunction>.CanCreateFrom(JSValue value)
+#else
+#pragma warning disable IDE0051 // It is used by the IJSValueShim<T> class through reflection.
+    private static bool CanCreateFrom(JSValue value)
+#pragma warning restore IDE0051
+#endif
+        => value.IsFunction();
 
     /// <summary>
     /// Creates a new instance of <see cref="JSFunction" /> from
@@ -320,14 +335,6 @@ public readonly struct JSFunction : IJSValue<JSFunction>
     private static JSFunction CreateUnchecked(JSValue value) => new(value);
 #pragma warning restore IDE0051
 #endif
-
-    /// <summary>
-    /// Converts the <see cref="JSFunction" /> to a <see cref="JSValue" />.
-    /// </summary>
-    /// <returns>
-    /// The <see cref="JSValue" /> representation of the <see cref="JSFunction" />.
-    /// </returns>
-    public JSValue AsJSValue() => _value;
 
     #endregion
 

--- a/src/NodeApi/JSFunction.cs
+++ b/src/NodeApi/JSFunction.cs
@@ -275,12 +275,14 @@ public readonly struct JSFunction : IJSValue<JSFunction>
 #if NET7_0_OR_GREATER
     static JSFunction IJSValue<JSFunction>.CreateUnchecked(JSValue value) => new(value);
 #else
+#pragma warning disable IDE0051 // It is used by the IJSValueShim<T> class through reflection.
     private static JSFunction CreateUnchecked(JSValue value) => new(value);
+#pragma warning restore IDE0051
 #endif
 
     public JSValue AsJSValue() => _value;
 
-#endregion
+    #endregion
 
     /// <summary>
     /// Gets the name of the function, or an empty string if the function is unnamed.

--- a/src/NodeApi/JSFunction.cs
+++ b/src/NodeApi/JSFunction.cs
@@ -10,11 +10,16 @@ namespace Microsoft.JavaScript.NodeApi;
 /// Represents a JavaScript Function value.
 /// </summary>
 public readonly struct JSFunction : IEquatable<JSValue>
+#if NET7_0_OR_GREATER
+    , IJSValue<JSFunction>
+#endif
 {
     private readonly JSValue _value;
 
-    public static explicit operator JSFunction(JSValue value) => new(value);
-    public static implicit operator JSValue(JSFunction function) => function._value;
+    public static implicit operator JSValue(JSFunction value) => value.AsJSValue();
+    public static explicit operator JSFunction?(JSValue value) => value.As<JSFunction>();
+    public static explicit operator JSFunction(JSValue value)
+        => value.As<JSFunction>() ?? throw new InvalidCastException("JSValue is not a Function");
 
     private JSFunction(JSValue value)
     {
@@ -266,6 +271,16 @@ public readonly struct JSFunction : IEquatable<JSValue>
             callback(args[0], args[1], args[2], args[3], args[4])))
     {
     }
+
+    #region IJSValue<JSFunction> implementation
+
+    public static bool CanBeConvertedFrom(JSValue value) => value.IsFunction();
+
+    public static JSFunction CreateUnchecked(JSValue value) => new(value);
+
+    #endregion
+
+    public JSValue AsJSValue() => _value;
 
     /// <summary>
     /// Gets the name of the function, or an empty string if the function is unnamed.

--- a/src/NodeApi/JSFunction.cs
+++ b/src/NodeApi/JSFunction.cs
@@ -9,17 +9,13 @@ namespace Microsoft.JavaScript.NodeApi;
 /// <summary>
 /// Represents a JavaScript Function value.
 /// </summary>
-public readonly struct JSFunction : IEquatable<JSValue>
-#if NET7_0_OR_GREATER
-    , IJSValue<JSFunction>
-#endif
+public readonly struct JSFunction : IJSValue<JSFunction>
 {
     private readonly JSValue _value;
 
     public static implicit operator JSValue(JSFunction value) => value.AsJSValue();
     public static explicit operator JSFunction?(JSValue value) => value.As<JSFunction>();
-    public static explicit operator JSFunction(JSValue value)
-        => value.As<JSFunction>() ?? throw new InvalidCastException("JSValue is not a Function");
+    public static explicit operator JSFunction(JSValue value) => value.CastTo<JSFunction>();
 
     private JSFunction(JSValue value)
     {
@@ -274,13 +270,17 @@ public readonly struct JSFunction : IEquatable<JSValue>
 
     #region IJSValue<JSFunction> implementation
 
-    public static bool CanBeConvertedFrom(JSValue value) => value.IsFunction();
+    public static bool CanCreateFrom(JSValue value) => value.IsFunction();
 
-    public static JSFunction CreateUnchecked(JSValue value) => new(value);
-
-    #endregion
+#if NET7_0_OR_GREATER
+    static JSFunction IJSValue<JSFunction>.CreateUnchecked(JSValue value) => new(value);
+#else
+    private static JSFunction CreateUnchecked(JSValue value) => new(value);
+#endif
 
     public JSValue AsJSValue() => _value;
+
+#endregion
 
     /// <summary>
     /// Gets the name of the function, or an empty string if the function is unnamed.

--- a/src/NodeApi/JSFunction.cs
+++ b/src/NodeApi/JSFunction.cs
@@ -17,7 +17,7 @@ public readonly struct JSFunction : IJSValue<JSFunction>
     /// Implicitly converts a <see cref="JSFunction" /> to a <see cref="JSValue" />.
     /// </summary>
     /// <param name="value">The <see cref="JSFunction" /> to convert.</param>
-    public static implicit operator JSValue(JSFunction value) => value.AsJSValue();
+    public static implicit operator JSValue(JSFunction function) => function._value;
 
     /// <summary>
     /// Explicitly converts a <see cref="JSValue" /> to a nullable <see cref="JSFunction" />.
@@ -292,12 +292,43 @@ public readonly struct JSFunction : IJSValue<JSFunction>
     #region IJSValue<JSFunction> implementation
 
     /// <summary>
-    /// Converts the <see cref="JSFunction" /> to a <see cref="JSValue" />.
+    /// Checks if the T struct can be created from this instance`.
     /// </summary>
+    /// <typeparam name="T">A struct that implements IJSValue interface.</typeparam>
     /// <returns>
-    /// The <see cref="JSValue" /> representation of the <see cref="JSFunction" />.
+    /// `true` if the T struct can be created from this instance. Otherwise it returns `false`.
     /// </returns>
-    public JSValue AsJSValue() => _value;
+    public bool Is<T>() where T : struct, IJSValue<T> => _value.Is<T>();
+
+    /// <summary>
+    /// Tries to create a T struct from this instance.
+    /// It returns `null` if the T struct cannot be created.
+    /// </summary>
+    /// <typeparam name="T">A struct that implements IJSValue interface.</typeparam>
+    /// <returns>
+    /// Nullable value that contains T struct if it was successfully created
+    /// or `null` if it was failed.
+    /// </returns>
+    public T? As<T>() where T : struct, IJSValue<T> => _value.As<T>();
+
+    /// <summary>
+    /// Creates a T struct from this instance without checking the enclosed handle type.
+    /// It must be used only when the handle type is known to be correct.
+    /// </summary>
+    /// <typeparam name="T">A struct that implements IJSValue interface.</typeparam>
+    /// <returns>T struct created based on this instance.</returns>
+    public T AsUnchecked<T>() where T : struct, IJSValue<T> => _value.AsUnchecked<T>();
+
+    /// <summary>
+    /// Creates a T struct from this instance.
+    /// It throws `InvalidCastException` in case of failure.
+    /// </summary>
+    /// <typeparam name="T">A struct that implements IJSValue interface.</typeparam>
+    /// <returns>T struct created based on this instance.</returns>
+    /// <exception cref="InvalidCastException">
+    /// Thrown when the T struct cannot be crated based on this instance.
+    /// </exception>
+    public T CastTo<T>() where T : struct, IJSValue<T> => _value.CastTo<T>();
 
     /// <summary>
     /// Determines whether a <see cref="JSFunction" /> can be created from

--- a/src/NodeApi/JSFunction.cs
+++ b/src/NodeApi/JSFunction.cs
@@ -13,8 +13,29 @@ public readonly struct JSFunction : IJSValue<JSFunction>
 {
     private readonly JSValue _value;
 
+    /// <summary>
+    /// Implicitly converts a <see cref="JSFunction" /> to a <see cref="JSValue" />.
+    /// </summary>
+    /// <param name="value">The <see cref="JSFunction" /> to convert.</param>
     public static implicit operator JSValue(JSFunction value) => value.AsJSValue();
+
+    /// <summary>
+    /// Explicitly converts a <see cref="JSValue" /> to a nullable <see cref="JSFunction" />.
+    /// </summary>
+    /// <param name="value">The <see cref="JSValue" /> to convert.</param>
+    /// <returns>
+    /// The <see cref="JSFunction" /> if it was successfully created or `null` if it was failed.
+    /// </returns>
     public static explicit operator JSFunction?(JSValue value) => value.As<JSFunction>();
+
+    /// <summary>
+    /// Explicitly converts a <see cref="JSValue" /> to a <see cref="JSFunction" />.
+    /// </summary>
+    /// <param name="value">The <see cref="JSValue" /> to convert.</param>
+    /// <returns><see cref="JSFunction" /> struct created based on this `JSValue`.</returns>
+    /// <exception cref="InvalidCastException">
+    /// Thrown when the T struct cannot be created based on this `JSValue`.
+    /// </exception>
     public static explicit operator JSFunction(JSValue value) => value.CastTo<JSFunction>();
 
     private JSFunction(JSValue value)
@@ -270,8 +291,28 @@ public readonly struct JSFunction : IJSValue<JSFunction>
 
     #region IJSValue<JSFunction> implementation
 
+    /// <summary>
+    /// Determines whether a <see cref="JSFunction" /> can be created from
+    /// the specified <see cref="JSValue" />.
+    /// </summary>
+    /// <param name="value">The <see cref="JSValue" /> to check.</param>
+    /// <returns>
+    /// <c>true</c> if a <see cref="JSFunction" /> can be created from
+    /// the specified <see cref="JSValue" />; otherwise, <c>false</c>.
+    /// </returns>
     public static bool CanCreateFrom(JSValue value) => value.IsFunction();
 
+    /// <summary>
+    /// Creates a new instance of <see cref="JSFunction" /> from
+    /// the specified <see cref="JSValue" />.
+    /// </summary>
+    /// <param name="value">
+    /// The <see cref="JSValue" /> to create a <see cref="JSFunction" /> from.
+    /// </param>
+    /// <returns>
+    /// A new instance of <see cref="JSFunction" /> created from
+    /// the specified <see cref="JSValue" />.
+    /// </returns>
 #if NET7_0_OR_GREATER
     static JSFunction IJSValue<JSFunction>.CreateUnchecked(JSValue value) => new(value);
 #else
@@ -280,6 +321,12 @@ public readonly struct JSFunction : IJSValue<JSFunction>
 #pragma warning restore IDE0051
 #endif
 
+    /// <summary>
+    /// Converts the <see cref="JSFunction" /> to a <see cref="JSValue" />.
+    /// </summary>
+    /// <returns>
+    /// The <see cref="JSValue" /> representation of the <see cref="JSFunction" />.
+    /// </returns>
     public JSValue AsJSValue() => _value;
 
     #endregion

--- a/src/NodeApi/JSIterable.cs
+++ b/src/NodeApi/JSIterable.cs
@@ -12,8 +12,29 @@ public readonly partial struct JSIterable : IJSValue<JSIterable>, IEnumerable<JS
 {
     private readonly JSValue _value;
 
+    /// <summary>
+    /// Implicitly converts a <see cref="JSIterable" /> to a <see cref="JSValue" />.
+    /// </summary>
+    /// <param name="value">The <see cref="JSIterable" /> to convert.</param>
     public static implicit operator JSValue(JSIterable value) => value.AsJSValue();
+
+    /// <summary>
+    /// Explicitly converts a <see cref="JSValue" /> to a nullable <see cref="JSIterable" />.
+    /// </summary>
+    /// <param name="value">The <see cref="JSValue" /> to convert.</param>
+    /// <returns>
+    /// The <see cref="JSIterable" /> if it was successfully created or `null` if it was failed.
+    /// </returns>
     public static explicit operator JSIterable?(JSValue value) => value.As<JSIterable>();
+
+    /// <summary>
+    /// Explicitly converts a <see cref="JSValue" /> to a <see cref="JSIterable" />.
+    /// </summary>
+    /// <param name="value">The <see cref="JSValue" /> to convert.</param>
+    /// <returns><see cref="JSIterable" /> struct created based on this `JSValue`.</returns>
+    /// <exception cref="InvalidCastException">
+    /// Thrown when the T struct cannot be created based on this `JSValue`.
+    /// </exception>
     public static explicit operator JSIterable(JSValue value) => value.CastTo<JSIterable>();
 
     public static explicit operator JSIterable(JSObject obj) => (JSIterable)(JSValue)obj;
@@ -26,9 +47,29 @@ public readonly partial struct JSIterable : IJSValue<JSIterable>, IEnumerable<JS
 
     #region IJSValue<JSIterable> implementation
 
+    /// <summary>
+    /// Determines whether a <see cref="JSIterable" /> can be created from
+    /// the specified <see cref="JSValue" />.
+    /// </summary>
+    /// <param name="value">The <see cref="JSValue" /> to check.</param>
+    /// <returns>
+    /// <c>true</c> if a <see cref="JSIterable" /> can be created from
+    /// the specified <see cref="JSValue" />; otherwise, <c>false</c>.
+    /// </returns>
     public static bool CanCreateFrom(JSValue value)
         => value.IsObject() && value.HasProperty(JSSymbol.Iterator);
 
+    /// <summary>
+    /// Creates a new instance of <see cref="JSIterable" /> from
+    /// the specified <see cref="JSValue" />.
+    /// </summary>
+    /// <param name="value">
+    /// The <see cref="JSValue" /> to create a <see cref="JSIterable" /> from.
+    /// </param>
+    /// <returns>
+    /// A new instance of <see cref="JSIterable" /> created from
+    /// the specified <see cref="JSValue" />.
+    /// </returns>
 #if NET7_0_OR_GREATER
     static JSIterable IJSValue<JSIterable>.CreateUnchecked(JSValue value) => new(value);
 #else
@@ -37,6 +78,12 @@ public readonly partial struct JSIterable : IJSValue<JSIterable>, IEnumerable<JS
 #pragma warning restore IDE0051
 #endif
 
+    /// <summary>
+    /// Converts the <see cref="JSIterable" /> to a <see cref="JSValue" />.
+    /// </summary>
+    /// <returns>
+    /// The <see cref="JSValue" /> representation of the <see cref="JSIterable" />.
+    /// </returns>
     public JSValue AsJSValue() => _value;
 
     #endregion

--- a/src/NodeApi/JSIterable.cs
+++ b/src/NodeApi/JSIterable.cs
@@ -26,8 +26,8 @@ public readonly partial struct JSIterable : IJSValue<JSIterable>, IEnumerable<JS
 
     #region IJSValue<JSIterable> implementation
 
-    //TODO: (vmoroz) implement proper check using Symbol.iterator
-    public static bool CanCreateFrom(JSValue value) => value.IsObject();
+    public static bool CanCreateFrom(JSValue value)
+        => value.IsObject() && value.HasProperty(JSValue.Global["Symbol"]["iterator"]);
 
 #if NET7_0_OR_GREATER
     static JSIterable IJSValue<JSIterable>.CreateUnchecked(JSValue value) => new(value);

--- a/src/NodeApi/JSIterable.cs
+++ b/src/NodeApi/JSIterable.cs
@@ -16,7 +16,7 @@ public readonly partial struct JSIterable : IJSValue<JSIterable>, IEnumerable<JS
     /// Implicitly converts a <see cref="JSIterable" /> to a <see cref="JSValue" />.
     /// </summary>
     /// <param name="value">The <see cref="JSIterable" /> to convert.</param>
-    public static implicit operator JSValue(JSIterable value) => value.AsJSValue();
+    public static implicit operator JSValue(JSIterable iterable) => iterable._value;
 
     /// <summary>
     /// Explicitly converts a <see cref="JSValue" /> to a nullable <see cref="JSIterable" />.
@@ -48,12 +48,43 @@ public readonly partial struct JSIterable : IJSValue<JSIterable>, IEnumerable<JS
     #region IJSValue<JSIterable> implementation
 
     /// <summary>
-    /// Converts the <see cref="JSIterable" /> to a <see cref="JSValue" />.
+    /// Checks if the T struct can be created from this instance`.
     /// </summary>
+    /// <typeparam name="T">A struct that implements IJSValue interface.</typeparam>
     /// <returns>
-    /// The <see cref="JSValue" /> representation of the <see cref="JSIterable" />.
+    /// `true` if the T struct can be created from this instance. Otherwise it returns `false`.
     /// </returns>
-    public JSValue AsJSValue() => _value;
+    public bool Is<T>() where T : struct, IJSValue<T> => _value.Is<T>();
+
+    /// <summary>
+    /// Tries to create a T struct from this instance.
+    /// It returns `null` if the T struct cannot be created.
+    /// </summary>
+    /// <typeparam name="T">A struct that implements IJSValue interface.</typeparam>
+    /// <returns>
+    /// Nullable value that contains T struct if it was successfully created
+    /// or `null` if it was failed.
+    /// </returns>
+    public T? As<T>() where T : struct, IJSValue<T> => _value.As<T>();
+
+    /// <summary>
+    /// Creates a T struct from this instance without checking the enclosed handle type.
+    /// It must be used only when the handle type is known to be correct.
+    /// </summary>
+    /// <typeparam name="T">A struct that implements IJSValue interface.</typeparam>
+    /// <returns>T struct created based on this instance.</returns>
+    public T AsUnchecked<T>() where T : struct, IJSValue<T> => _value.AsUnchecked<T>();
+
+    /// <summary>
+    /// Creates a T struct from this instance.
+    /// It throws `InvalidCastException` in case of failure.
+    /// </summary>
+    /// <typeparam name="T">A struct that implements IJSValue interface.</typeparam>
+    /// <returns>T struct created based on this instance.</returns>
+    /// <exception cref="InvalidCastException">
+    /// Thrown when the T struct cannot be crated based on this instance.
+    /// </exception>
+    public T CastTo<T>() where T : struct, IJSValue<T> => _value.CastTo<T>();
 
     /// <summary>
     /// Determines whether a <see cref="JSIterable" /> can be created from

--- a/src/NodeApi/JSIterable.cs
+++ b/src/NodeApi/JSIterable.cs
@@ -9,14 +9,16 @@ using System.Diagnostics.CodeAnalysis;
 namespace Microsoft.JavaScript.NodeApi;
 
 public readonly partial struct JSIterable : IEnumerable<JSValue>, IEquatable<JSValue>
+#if NET7_0_OR_GREATER
+    , IJSValue<JSIterable>
+#endif
 {
     private readonly JSValue _value;
 
-    public static explicit operator JSIterable(JSValue value) => new(value);
-    public static implicit operator JSValue(JSIterable iterable) => iterable._value;
-
-    public static explicit operator JSArray(JSIterable iterable) => (JSArray)iterable._value;
-    public static implicit operator JSIterable(JSArray array) => (JSIterable)(JSValue)array;
+    public static implicit operator JSValue(JSIterable value) => value.AsJSValue();
+    public static explicit operator JSIterable?(JSValue value) => value.As<JSIterable>();
+    public static explicit operator JSIterable(JSValue value)
+        => value.As<JSIterable>() ?? throw new InvalidCastException("JSValue is not an Iterable.");
 
     public static explicit operator JSIterable(JSObject obj) => (JSIterable)(JSValue)obj;
     public static implicit operator JSObject(JSIterable iterable) => (JSObject)iterable._value;
@@ -25,6 +27,17 @@ public readonly partial struct JSIterable : IEnumerable<JSValue>, IEquatable<JSV
     {
         _value = value;
     }
+
+    #region IJSValue<JSIterable> implementation
+
+    //TODO: (vmoroz) implement proper check using Symbol.iterator
+    public static bool CanBeConvertedFrom(JSValue value) => value.IsObject();
+
+    public static JSIterable CreateUnchecked(JSValue value) => new(value);
+
+    #endregion
+
+    public JSValue AsJSValue() => _value;
 
     public Enumerator GetEnumerator() => new(_value);
 

--- a/src/NodeApi/JSIterable.cs
+++ b/src/NodeApi/JSIterable.cs
@@ -48,6 +48,14 @@ public readonly partial struct JSIterable : IJSValue<JSIterable>, IEnumerable<JS
     #region IJSValue<JSIterable> implementation
 
     /// <summary>
+    /// Converts the <see cref="JSIterable" /> to a <see cref="JSValue" />.
+    /// </summary>
+    /// <returns>
+    /// The <see cref="JSValue" /> representation of the <see cref="JSIterable" />.
+    /// </returns>
+    public JSValue AsJSValue() => _value;
+
+    /// <summary>
     /// Determines whether a <see cref="JSIterable" /> can be created from
     /// the specified <see cref="JSValue" />.
     /// </summary>
@@ -56,7 +64,13 @@ public readonly partial struct JSIterable : IJSValue<JSIterable>, IEnumerable<JS
     /// <c>true</c> if a <see cref="JSIterable" /> can be created from
     /// the specified <see cref="JSValue" />; otherwise, <c>false</c>.
     /// </returns>
-    public static bool CanCreateFrom(JSValue value)
+#if NET7_0_OR_GREATER
+    static bool IJSValue<JSIterable>.CanCreateFrom(JSValue value)
+#else
+#pragma warning disable IDE0051 // It is used by the IJSValueShim<T> class through reflection.
+    private static bool CanCreateFrom(JSValue value)
+#pragma warning restore IDE0051
+#endif
         => value.IsObject() && value.HasProperty(JSSymbol.Iterator);
 
     /// <summary>
@@ -77,14 +91,6 @@ public readonly partial struct JSIterable : IJSValue<JSIterable>, IEnumerable<JS
     private static JSIterable CreateUnchecked(JSValue value) => new(value);
 #pragma warning restore IDE0051
 #endif
-
-    /// <summary>
-    /// Converts the <see cref="JSIterable" /> to a <see cref="JSValue" />.
-    /// </summary>
-    /// <returns>
-    /// The <see cref="JSValue" /> representation of the <see cref="JSIterable" />.
-    /// </returns>
-    public JSValue AsJSValue() => _value;
 
     #endregion
 

--- a/src/NodeApi/JSIterable.cs
+++ b/src/NodeApi/JSIterable.cs
@@ -27,7 +27,7 @@ public readonly partial struct JSIterable : IJSValue<JSIterable>, IEnumerable<JS
     #region IJSValue<JSIterable> implementation
 
     public static bool CanCreateFrom(JSValue value)
-        => value.IsObject() && value.HasProperty(JSValue.Global["Symbol"]["iterator"]);
+        => value.IsObject() && value.HasProperty(JSSymbol.Iterator);
 
 #if NET7_0_OR_GREATER
     static JSIterable IJSValue<JSIterable>.CreateUnchecked(JSValue value) => new(value);

--- a/src/NodeApi/JSIterable.cs
+++ b/src/NodeApi/JSIterable.cs
@@ -8,17 +8,13 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.JavaScript.NodeApi;
 
-public readonly partial struct JSIterable : IEnumerable<JSValue>, IEquatable<JSValue>
-#if NET7_0_OR_GREATER
-    , IJSValue<JSIterable>
-#endif
+public readonly partial struct JSIterable : IJSValue<JSIterable>, IEnumerable<JSValue>
 {
     private readonly JSValue _value;
 
     public static implicit operator JSValue(JSIterable value) => value.AsJSValue();
     public static explicit operator JSIterable?(JSValue value) => value.As<JSIterable>();
-    public static explicit operator JSIterable(JSValue value)
-        => value.As<JSIterable>() ?? throw new InvalidCastException("JSValue is not an Iterable.");
+    public static explicit operator JSIterable(JSValue value) => value.CastTo<JSIterable>();
 
     public static explicit operator JSIterable(JSObject obj) => (JSIterable)(JSValue)obj;
     public static implicit operator JSObject(JSIterable iterable) => (JSObject)iterable._value;
@@ -31,13 +27,17 @@ public readonly partial struct JSIterable : IEnumerable<JSValue>, IEquatable<JSV
     #region IJSValue<JSIterable> implementation
 
     //TODO: (vmoroz) implement proper check using Symbol.iterator
-    public static bool CanBeConvertedFrom(JSValue value) => value.IsObject();
+    public static bool CanCreateFrom(JSValue value) => value.IsObject();
 
-    public static JSIterable CreateUnchecked(JSValue value) => new(value);
-
-    #endregion
+#if NET7_0_OR_GREATER
+    static JSIterable IJSValue<JSIterable>.CreateUnchecked(JSValue value) => new(value);
+#else
+    private static JSIterable CreateUnchecked(JSValue value) => new(value);
+#endif
 
     public JSValue AsJSValue() => _value;
+
+#endregion
 
     public Enumerator GetEnumerator() => new(_value);
 

--- a/src/NodeApi/JSIterable.cs
+++ b/src/NodeApi/JSIterable.cs
@@ -32,12 +32,14 @@ public readonly partial struct JSIterable : IJSValue<JSIterable>, IEnumerable<JS
 #if NET7_0_OR_GREATER
     static JSIterable IJSValue<JSIterable>.CreateUnchecked(JSValue value) => new(value);
 #else
+#pragma warning disable IDE0051 // It is used by the IJSValueShim<T> class through reflection.
     private static JSIterable CreateUnchecked(JSValue value) => new(value);
+#pragma warning restore IDE0051
 #endif
 
     public JSValue AsJSValue() => _value;
 
-#endregion
+    #endregion
 
     public Enumerator GetEnumerator() => new(_value);
 

--- a/src/NodeApi/JSMap.cs
+++ b/src/NodeApi/JSMap.cs
@@ -12,8 +12,29 @@ public readonly partial struct JSMap : IJSValue<JSMap>, IDictionary<JSValue, JSV
 {
     private readonly JSValue _value;
 
+    /// <summary>
+    /// Implicitly converts a <see cref="JSMap" /> to a <see cref="JSValue" />.
+    /// </summary>
+    /// <param name="value">The <see cref="JSMap" /> to convert.</param>
     public static implicit operator JSValue(JSMap value) => value.AsJSValue();
+
+    /// <summary>
+    /// Explicitly converts a <see cref="JSValue" /> to a nullable <see cref="JSMap" />.
+    /// </summary>
+    /// <param name="value">The <see cref="JSValue" /> to convert.</param>
+    /// <returns>
+    /// The <see cref="JSMap" /> if it was successfully created or `null` if it was failed.
+    /// </returns>
     public static explicit operator JSMap?(JSValue value) => value.As<JSMap>();
+
+    /// <summary>
+    /// Explicitly converts a <see cref="JSValue" /> to a <see cref="JSMap" />.
+    /// </summary>
+    /// <param name="value">The <see cref="JSValue" /> to convert.</param>
+    /// <returns><see cref="JSMap" /> struct created based on this `JSValue`.</returns>
+    /// <exception cref="InvalidCastException">
+    /// Thrown when the T struct cannot be created based on this `JSValue`.
+    /// </exception>
     public static explicit operator JSMap(JSValue value) => value.CastTo<JSMap>();
 
     public static explicit operator JSMap(JSObject obj) => (JSMap)(JSValue)obj;
@@ -43,9 +64,29 @@ public readonly partial struct JSMap : IJSValue<JSMap>, IDictionary<JSValue, JSV
 
     #region IJSValue<JSMap> implementation
 
+    /// <summary>
+    /// Determines whether a <see cref="JSMap" /> can be created from
+    /// the specified <see cref="JSValue" />.
+    /// </summary>
+    /// <param name="value">The <see cref="JSValue" /> to check.</param>
+    /// <returns>
+    /// <c>true</c> if a <see cref="JSMap" /> can be created from
+    /// the specified <see cref="JSValue" />; otherwise, <c>false</c>.
+    /// </returns>
     public static bool CanCreateFrom(JSValue value)
         => value.IsObject() && value.InstanceOf(JSValue.Global["Map"]);
 
+    /// <summary>
+    /// Creates a new instance of <see cref="JSMap" /> from
+    /// the specified <see cref="JSValue" />.
+    /// </summary>
+    /// <param name="value">
+    /// The <see cref="JSValue" /> to create a <see cref="JSMap" /> from.
+    /// </param>
+    /// <returns>
+    /// A new instance of <see cref="JSMap" /> created from
+    /// the specified <see cref="JSValue" />.
+    /// </returns>
 #if NET7_0_OR_GREATER
     static JSMap IJSValue<JSMap>.CreateUnchecked(JSValue value) => new(value);
 #else
@@ -54,6 +95,12 @@ public readonly partial struct JSMap : IJSValue<JSMap>, IDictionary<JSValue, JSV
 #pragma warning restore IDE0051
 #endif
 
+    /// <summary>
+    /// Converts the <see cref="JSMap" /> to a <see cref="JSValue" />.
+    /// </summary>
+    /// <returns>
+    /// The <see cref="JSValue" /> representation of the <see cref="JSMap" />.
+    /// </returns>
     public JSValue AsJSValue() => _value;
 
     #endregion

--- a/src/NodeApi/JSMap.cs
+++ b/src/NodeApi/JSMap.cs
@@ -9,11 +9,16 @@ using Microsoft.JavaScript.NodeApi.Interop;
 namespace Microsoft.JavaScript.NodeApi;
 
 public readonly partial struct JSMap : IDictionary<JSValue, JSValue>, IEquatable<JSValue>
+#if NET7_0_OR_GREATER
+    , IJSValue<JSMap>
+#endif
 {
     private readonly JSValue _value;
 
-    public static explicit operator JSMap(JSValue value) => new(value);
-    public static implicit operator JSValue(JSMap map) => map._value;
+    public static implicit operator JSValue(JSMap value) => value.AsJSValue();
+    public static explicit operator JSMap?(JSValue value) => value.As<JSMap>();
+    public static explicit operator JSMap(JSValue value)
+        => value.As<JSMap>() ?? throw new InvalidCastException("JSValue is not a Map.");
 
     public static explicit operator JSMap(JSObject obj) => (JSMap)(JSValue)obj;
     public static implicit operator JSObject(JSMap map) => (JSObject)map._value;
@@ -39,6 +44,17 @@ public readonly partial struct JSMap : IDictionary<JSValue, JSValue>, IEquatable
     {
         _value = JSRuntimeContext.Current.Import(null, "Map").CallAsConstructor(iterable);
     }
+
+    #region IJSValue<JSMap> implementation
+
+    // TODO: (vmoroz) Implement using instanceof
+    public static bool CanBeConvertedFrom(JSValue value) => value.IsObject();
+
+    public static JSMap CreateUnchecked(JSValue value) => new(value);
+
+    #endregion
+
+    public JSValue AsJSValue() => _value;
 
     public int Count => (int)_value["size"];
 

--- a/src/NodeApi/JSMap.cs
+++ b/src/NodeApi/JSMap.cs
@@ -8,17 +8,13 @@ using Microsoft.JavaScript.NodeApi.Interop;
 
 namespace Microsoft.JavaScript.NodeApi;
 
-public readonly partial struct JSMap : IDictionary<JSValue, JSValue>, IEquatable<JSValue>
-#if NET7_0_OR_GREATER
-    , IJSValue<JSMap>
-#endif
+public readonly partial struct JSMap : IJSValue<JSMap>, IDictionary<JSValue, JSValue>
 {
     private readonly JSValue _value;
 
     public static implicit operator JSValue(JSMap value) => value.AsJSValue();
     public static explicit operator JSMap?(JSValue value) => value.As<JSMap>();
-    public static explicit operator JSMap(JSValue value)
-        => value.As<JSMap>() ?? throw new InvalidCastException("JSValue is not a Map.");
+    public static explicit operator JSMap(JSValue value) => value.CastTo<JSMap>();
 
     public static explicit operator JSMap(JSObject obj) => (JSMap)(JSValue)obj;
     public static implicit operator JSObject(JSMap map) => (JSObject)map._value;
@@ -48,13 +44,17 @@ public readonly partial struct JSMap : IDictionary<JSValue, JSValue>, IEquatable
     #region IJSValue<JSMap> implementation
 
     // TODO: (vmoroz) Implement using instanceof
-    public static bool CanBeConvertedFrom(JSValue value) => value.IsObject();
+    public static bool CanCreateFrom(JSValue value) => value.IsObject();
 
-    public static JSMap CreateUnchecked(JSValue value) => new(value);
-
-    #endregion
+#if NET7_0_OR_GREATER
+    static JSMap IJSValue<JSMap>.CreateUnchecked(JSValue value) => new(value);
+#else
+    private static JSMap CreateUnchecked(JSValue value) => new(value);
+#endif
 
     public JSValue AsJSValue() => _value;
+
+    #endregion
 
     public int Count => (int)_value["size"];
 

--- a/src/NodeApi/JSMap.cs
+++ b/src/NodeApi/JSMap.cs
@@ -49,7 +49,9 @@ public readonly partial struct JSMap : IJSValue<JSMap>, IDictionary<JSValue, JSV
 #if NET7_0_OR_GREATER
     static JSMap IJSValue<JSMap>.CreateUnchecked(JSValue value) => new(value);
 #else
+#pragma warning disable IDE0051 // It is used by the IJSValueShim<T> class through reflection.
     private static JSMap CreateUnchecked(JSValue value) => new(value);
+#pragma warning restore IDE0051
 #endif
 
     public JSValue AsJSValue() => _value;

--- a/src/NodeApi/JSMap.cs
+++ b/src/NodeApi/JSMap.cs
@@ -65,6 +65,14 @@ public readonly partial struct JSMap : IJSValue<JSMap>, IDictionary<JSValue, JSV
     #region IJSValue<JSMap> implementation
 
     /// <summary>
+    /// Converts the <see cref="JSMap" /> to a <see cref="JSValue" />.
+    /// </summary>
+    /// <returns>
+    /// The <see cref="JSValue" /> representation of the <see cref="JSMap" />.
+    /// </returns>
+    public JSValue AsJSValue() => _value;
+
+    /// <summary>
     /// Determines whether a <see cref="JSMap" /> can be created from
     /// the specified <see cref="JSValue" />.
     /// </summary>
@@ -73,7 +81,13 @@ public readonly partial struct JSMap : IJSValue<JSMap>, IDictionary<JSValue, JSV
     /// <c>true</c> if a <see cref="JSMap" /> can be created from
     /// the specified <see cref="JSValue" />; otherwise, <c>false</c>.
     /// </returns>
-    public static bool CanCreateFrom(JSValue value)
+#if NET7_0_OR_GREATER
+    static bool IJSValue<JSMap>.CanCreateFrom(JSValue value)
+#else
+#pragma warning disable IDE0051 // It is used by the IJSValueShim<T> class through reflection.
+    private static bool CanCreateFrom(JSValue value)
+#pragma warning restore IDE0051
+#endif
         => value.IsObject() && value.InstanceOf(JSValue.Global["Map"]);
 
     /// <summary>
@@ -94,14 +108,6 @@ public readonly partial struct JSMap : IJSValue<JSMap>, IDictionary<JSValue, JSV
     private static JSMap CreateUnchecked(JSValue value) => new(value);
 #pragma warning restore IDE0051
 #endif
-
-    /// <summary>
-    /// Converts the <see cref="JSMap" /> to a <see cref="JSValue" />.
-    /// </summary>
-    /// <returns>
-    /// The <see cref="JSValue" /> representation of the <see cref="JSMap" />.
-    /// </returns>
-    public JSValue AsJSValue() => _value;
 
     #endregion
 

--- a/src/NodeApi/JSMap.cs
+++ b/src/NodeApi/JSMap.cs
@@ -43,8 +43,8 @@ public readonly partial struct JSMap : IJSValue<JSMap>, IDictionary<JSValue, JSV
 
     #region IJSValue<JSMap> implementation
 
-    // TODO: (vmoroz) Implement using instanceof
-    public static bool CanCreateFrom(JSValue value) => value.IsObject();
+    public static bool CanCreateFrom(JSValue value)
+        => value.IsObject() && value.InstanceOf(JSValue.Global["Map"]);
 
 #if NET7_0_OR_GREATER
     static JSMap IJSValue<JSMap>.CreateUnchecked(JSValue value) => new(value);

--- a/src/NodeApi/JSMap.cs
+++ b/src/NodeApi/JSMap.cs
@@ -16,7 +16,7 @@ public readonly partial struct JSMap : IJSValue<JSMap>, IDictionary<JSValue, JSV
     /// Implicitly converts a <see cref="JSMap" /> to a <see cref="JSValue" />.
     /// </summary>
     /// <param name="value">The <see cref="JSMap" /> to convert.</param>
-    public static implicit operator JSValue(JSMap value) => value.AsJSValue();
+    public static implicit operator JSValue(JSMap map) => map._value;
 
     /// <summary>
     /// Explicitly converts a <see cref="JSValue" /> to a nullable <see cref="JSMap" />.
@@ -65,12 +65,43 @@ public readonly partial struct JSMap : IJSValue<JSMap>, IDictionary<JSValue, JSV
     #region IJSValue<JSMap> implementation
 
     /// <summary>
-    /// Converts the <see cref="JSMap" /> to a <see cref="JSValue" />.
+    /// Checks if the T struct can be created from this instance`.
     /// </summary>
+    /// <typeparam name="T">A struct that implements IJSValue interface.</typeparam>
     /// <returns>
-    /// The <see cref="JSValue" /> representation of the <see cref="JSMap" />.
+    /// `true` if the T struct can be created from this instance. Otherwise it returns `false`.
     /// </returns>
-    public JSValue AsJSValue() => _value;
+    public bool Is<T>() where T : struct, IJSValue<T> => _value.Is<T>();
+
+    /// <summary>
+    /// Tries to create a T struct from this instance.
+    /// It returns `null` if the T struct cannot be created.
+    /// </summary>
+    /// <typeparam name="T">A struct that implements IJSValue interface.</typeparam>
+    /// <returns>
+    /// Nullable value that contains T struct if it was successfully created
+    /// or `null` if it was failed.
+    /// </returns>
+    public T? As<T>() where T : struct, IJSValue<T> => _value.As<T>();
+
+    /// <summary>
+    /// Creates a T struct from this instance without checking the enclosed handle type.
+    /// It must be used only when the handle type is known to be correct.
+    /// </summary>
+    /// <typeparam name="T">A struct that implements IJSValue interface.</typeparam>
+    /// <returns>T struct created based on this instance.</returns>
+    public T AsUnchecked<T>() where T : struct, IJSValue<T> => _value.AsUnchecked<T>();
+
+    /// <summary>
+    /// Creates a T struct from this instance.
+    /// It throws `InvalidCastException` in case of failure.
+    /// </summary>
+    /// <typeparam name="T">A struct that implements IJSValue interface.</typeparam>
+    /// <returns>T struct created based on this instance.</returns>
+    /// <exception cref="InvalidCastException">
+    /// Thrown when the T struct cannot be crated based on this instance.
+    /// </exception>
+    public T CastTo<T>() where T : struct, IJSValue<T> => _value.CastTo<T>();
 
     /// <summary>
     /// Determines whether a <see cref="JSMap" /> can be created from

--- a/src/NodeApi/JSObject.cs
+++ b/src/NodeApi/JSObject.cs
@@ -8,17 +8,13 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.JavaScript.NodeApi;
 
-public readonly partial struct JSObject : IDictionary<JSValue, JSValue>, IEquatable<JSValue>
-#if NET7_0_OR_GREATER
-    , IJSValue<JSObject>
-#endif
+public readonly partial struct JSObject : IJSValue<JSObject>, IDictionary<JSValue, JSValue>
 {
     private readonly JSValue _value;
 
     public static implicit operator JSValue(JSObject value) => value.AsJSValue();
     public static explicit operator JSObject?(JSValue value) => value.As<JSObject>();
-    public static explicit operator JSObject(JSValue value)
-        => value.As<JSObject>() ?? throw new InvalidCastException("JSValue is not an Object.");
+    public static explicit operator JSObject(JSValue value) => value.CastTo<JSObject>();
 
     private JSObject(JSValue value)
     {
@@ -31,13 +27,17 @@ public readonly partial struct JSObject : IDictionary<JSValue, JSValue>, IEquata
 
     #region IJSValue<JSObject> implementation
 
-    public static bool CanBeConvertedFrom(JSValue value) => value.IsObject();
+    public static bool CanCreateFrom(JSValue value) => value.IsObject();
 
-    public static JSObject CreateUnchecked(JSValue value) => new(value);
-
-    #endregion
+#if NET7_0_OR_GREATER
+    static JSObject IJSValue<JSObject>.CreateUnchecked(JSValue value) => new(value);
+#else
+    private static JSObject CreateUnchecked(JSValue value) => new(value);
+#endif
 
     public JSValue AsJSValue() => _value;
+
+#endregion
 
     public JSObject(IEnumerable<KeyValuePair<JSValue, JSValue>> properties) : this()
     {

--- a/src/NodeApi/JSObject.cs
+++ b/src/NodeApi/JSObject.cs
@@ -49,6 +49,14 @@ public readonly partial struct JSObject : IJSValue<JSObject>, IDictionary<JSValu
     #region IJSValue<JSObject> implementation
 
     /// <summary>
+    /// Converts the <see cref="JSObject" /> to a <see cref="JSValue" />.
+    /// </summary>
+    /// <returns>
+    /// The <see cref="JSValue" /> representation of the <see cref="JSObject" />.
+    /// </returns>
+    public JSValue AsJSValue() => _value;
+
+    /// <summary>
     /// Determines whether a <see cref="JSObject" /> can be created from
     /// the specified <see cref="JSValue" />.
     /// </summary>
@@ -57,7 +65,14 @@ public readonly partial struct JSObject : IJSValue<JSObject>, IDictionary<JSValu
     /// <c>true</c> if a <see cref="JSObject" /> can be created from
     /// the specified <see cref="JSValue" />; otherwise, <c>false</c>.
     /// </returns>
-    public static bool CanCreateFrom(JSValue value) => value.IsObject();
+#if NET7_0_OR_GREATER
+    static bool IJSValue<JSObject>.CanCreateFrom(JSValue value)
+#else
+#pragma warning disable IDE0051 // It is used by the IJSValueShim<T> class through reflection.
+    private static bool CanCreateFrom(JSValue value)
+#pragma warning restore IDE0051
+#endif
+        => value.IsObject();
 
     /// <summary>
     /// Creates a new instance of <see cref="JSObject" /> from
@@ -77,14 +92,6 @@ public readonly partial struct JSObject : IJSValue<JSObject>, IDictionary<JSValu
     private static JSObject CreateUnchecked(JSValue value) => new(value);
 #pragma warning restore IDE0051
 #endif
-
-    /// <summary>
-    /// Converts the <see cref="JSObject" /> to a <see cref="JSValue" />.
-    /// </summary>
-    /// <returns>
-    /// The <see cref="JSValue" /> representation of the <see cref="JSObject" />.
-    /// </returns>
-    public JSValue AsJSValue() => _value;
 
     #endregion
 

--- a/src/NodeApi/JSObject.cs
+++ b/src/NodeApi/JSObject.cs
@@ -16,7 +16,7 @@ public readonly partial struct JSObject : IJSValue<JSObject>, IDictionary<JSValu
     /// Implicitly converts a <see cref="JSObject" /> to a <see cref="JSValue" />.
     /// </summary>
     /// <param name="value">The <see cref="JSObject" /> to convert.</param>
-    public static implicit operator JSValue(JSObject value) => value.AsJSValue();
+    public static implicit operator JSValue(JSObject obj) => obj._value;
 
     /// <summary>
     /// Explicitly converts a <see cref="JSValue" /> to a nullable <see cref="JSObject" />.
@@ -49,12 +49,43 @@ public readonly partial struct JSObject : IJSValue<JSObject>, IDictionary<JSValu
     #region IJSValue<JSObject> implementation
 
     /// <summary>
-    /// Converts the <see cref="JSObject" /> to a <see cref="JSValue" />.
+    /// Checks if the T struct can be created from this instance`.
     /// </summary>
+    /// <typeparam name="T">A struct that implements IJSValue interface.</typeparam>
     /// <returns>
-    /// The <see cref="JSValue" /> representation of the <see cref="JSObject" />.
+    /// `true` if the T struct can be created from this instance. Otherwise it returns `false`.
     /// </returns>
-    public JSValue AsJSValue() => _value;
+    public bool Is<T>() where T : struct, IJSValue<T> => _value.Is<T>();
+
+    /// <summary>
+    /// Tries to create a T struct from this instance.
+    /// It returns `null` if the T struct cannot be created.
+    /// </summary>
+    /// <typeparam name="T">A struct that implements IJSValue interface.</typeparam>
+    /// <returns>
+    /// Nullable value that contains T struct if it was successfully created
+    /// or `null` if it was failed.
+    /// </returns>
+    public T? As<T>() where T : struct, IJSValue<T> => _value.As<T>();
+
+    /// <summary>
+    /// Creates a T struct from this instance without checking the enclosed handle type.
+    /// It must be used only when the handle type is known to be correct.
+    /// </summary>
+    /// <typeparam name="T">A struct that implements IJSValue interface.</typeparam>
+    /// <returns>T struct created based on this instance.</returns>
+    public T AsUnchecked<T>() where T : struct, IJSValue<T> => _value.AsUnchecked<T>();
+
+    /// <summary>
+    /// Creates a T struct from this instance.
+    /// It throws `InvalidCastException` in case of failure.
+    /// </summary>
+    /// <typeparam name="T">A struct that implements IJSValue interface.</typeparam>
+    /// <returns>T struct created based on this instance.</returns>
+    /// <exception cref="InvalidCastException">
+    /// Thrown when the T struct cannot be crated based on this instance.
+    /// </exception>
+    public T CastTo<T>() where T : struct, IJSValue<T> => _value.CastTo<T>();
 
     /// <summary>
     /// Determines whether a <see cref="JSObject" /> can be created from

--- a/src/NodeApi/JSObject.cs
+++ b/src/NodeApi/JSObject.cs
@@ -32,12 +32,14 @@ public readonly partial struct JSObject : IJSValue<JSObject>, IDictionary<JSValu
 #if NET7_0_OR_GREATER
     static JSObject IJSValue<JSObject>.CreateUnchecked(JSValue value) => new(value);
 #else
+#pragma warning disable IDE0051 // It is used by the IJSValueShim<T> class through reflection.
     private static JSObject CreateUnchecked(JSValue value) => new(value);
+#pragma warning restore IDE0051
 #endif
 
     public JSValue AsJSValue() => _value;
 
-#endregion
+    #endregion
 
     public JSObject(IEnumerable<KeyValuePair<JSValue, JSValue>> properties) : this()
     {

--- a/src/NodeApi/JSObject.cs
+++ b/src/NodeApi/JSObject.cs
@@ -12,8 +12,29 @@ public readonly partial struct JSObject : IJSValue<JSObject>, IDictionary<JSValu
 {
     private readonly JSValue _value;
 
+    /// <summary>
+    /// Implicitly converts a <see cref="JSObject" /> to a <see cref="JSValue" />.
+    /// </summary>
+    /// <param name="value">The <see cref="JSObject" /> to convert.</param>
     public static implicit operator JSValue(JSObject value) => value.AsJSValue();
+
+    /// <summary>
+    /// Explicitly converts a <see cref="JSValue" /> to a nullable <see cref="JSObject" />.
+    /// </summary>
+    /// <param name="value">The <see cref="JSValue" /> to convert.</param>
+    /// <returns>
+    /// The <see cref="JSObject" /> if it was successfully created or `null` if it was failed.
+    /// </returns>
     public static explicit operator JSObject?(JSValue value) => value.As<JSObject>();
+
+    /// <summary>
+    /// Explicitly converts a <see cref="JSValue" /> to a <see cref="JSObject" />.
+    /// </summary>
+    /// <param name="value">The <see cref="JSValue" /> to convert.</param>
+    /// <returns><see cref="JSObject" /> struct created based on this `JSValue`.</returns>
+    /// <exception cref="InvalidCastException">
+    /// Thrown when the T struct cannot be created based on this `JSValue`.
+    /// </exception>
     public static explicit operator JSObject(JSValue value) => value.CastTo<JSObject>();
 
     private JSObject(JSValue value)
@@ -27,8 +48,28 @@ public readonly partial struct JSObject : IJSValue<JSObject>, IDictionary<JSValu
 
     #region IJSValue<JSObject> implementation
 
+    /// <summary>
+    /// Determines whether a <see cref="JSObject" /> can be created from
+    /// the specified <see cref="JSValue" />.
+    /// </summary>
+    /// <param name="value">The <see cref="JSValue" /> to check.</param>
+    /// <returns>
+    /// <c>true</c> if a <see cref="JSObject" /> can be created from
+    /// the specified <see cref="JSValue" />; otherwise, <c>false</c>.
+    /// </returns>
     public static bool CanCreateFrom(JSValue value) => value.IsObject();
 
+    /// <summary>
+    /// Creates a new instance of <see cref="JSObject" /> from
+    /// the specified <see cref="JSValue" />.
+    /// </summary>
+    /// <param name="value">
+    /// The <see cref="JSValue" /> to create a <see cref="JSObject" /> from.
+    /// </param>
+    /// <returns>
+    /// A new instance of <see cref="JSObject" /> created from
+    /// the specified <see cref="JSValue" />.
+    /// </returns>
 #if NET7_0_OR_GREATER
     static JSObject IJSValue<JSObject>.CreateUnchecked(JSValue value) => new(value);
 #else
@@ -37,6 +78,12 @@ public readonly partial struct JSObject : IJSValue<JSObject>, IDictionary<JSValu
 #pragma warning restore IDE0051
 #endif
 
+    /// <summary>
+    /// Converts the <see cref="JSObject" /> to a <see cref="JSValue" />.
+    /// </summary>
+    /// <returns>
+    /// The <see cref="JSValue" /> representation of the <see cref="JSObject" />.
+    /// </returns>
     public JSValue AsJSValue() => _value;
 
     #endregion

--- a/src/NodeApi/JSPromise.cs
+++ b/src/NodeApi/JSPromise.cs
@@ -151,12 +151,14 @@ public readonly struct JSPromise : IJSValue<JSPromise>
 #if NET7_0_OR_GREATER
     static JSPromise IJSValue<JSPromise>.CreateUnchecked(JSValue value) => new(value);
 #else
+#pragma warning disable IDE0051 // It is used by the IJSValueShim<T> class through reflection.
     private static JSPromise CreateUnchecked(JSValue value) => new(value);
+#pragma warning restore IDE0051
 #endif
 
     public JSValue AsJSValue() => _value;
 
-#endregion
+    #endregion
 
     /// <summary>
     /// Registers callbacks that are invoked when a promise is fulfilled and/or rejected,

--- a/src/NodeApi/JSPromise.cs
+++ b/src/NodeApi/JSPromise.cs
@@ -14,17 +14,13 @@ namespace Microsoft.JavaScript.NodeApi;
 /// Represents a JavaScript Promise object.
 /// </summary>
 /// <seealso cref="TaskExtensions"/>
-public readonly struct JSPromise : IEquatable<JSValue>
-#if NET7_0_OR_GREATER
-    , IJSValue<JSPromise>
-#endif
+public readonly struct JSPromise : IJSValue<JSPromise>
 {
     private readonly JSValue _value;
 
     public static implicit operator JSValue(JSPromise value) => value.AsJSValue();
     public static explicit operator JSPromise?(JSValue value) => value.As<JSPromise>();
-    public static explicit operator JSPromise(JSValue value)
-        => value.As<JSPromise>() ?? throw new InvalidCastException("JSValue is not a Promise.");
+    public static explicit operator JSPromise(JSValue value) => value.CastTo<JSPromise>();
 
     public static explicit operator JSPromise(JSObject obj) => (JSPromise)(JSValue)obj;
     public static implicit operator JSObject(JSPromise promise) => (JSObject)promise._value;
@@ -150,13 +146,17 @@ public readonly struct JSPromise : IEquatable<JSValue>
 
     #region IJSValue<JSPromise> implementation
 
-    public static bool CanBeConvertedFrom(JSValue value) => value.IsPromise();
+    public static bool CanCreateFrom(JSValue value) => value.IsPromise();
 
-    public static JSPromise CreateUnchecked(JSValue value) => new(value);
-
-    #endregion
+#if NET7_0_OR_GREATER
+    static JSPromise IJSValue<JSPromise>.CreateUnchecked(JSValue value) => new(value);
+#else
+    private static JSPromise CreateUnchecked(JSValue value) => new(value);
+#endif
 
     public JSValue AsJSValue() => _value;
+
+#endregion
 
     /// <summary>
     /// Registers callbacks that are invoked when a promise is fulfilled and/or rejected,

--- a/src/NodeApi/JSPromise.cs
+++ b/src/NodeApi/JSPromise.cs
@@ -168,6 +168,14 @@ public readonly struct JSPromise : IJSValue<JSPromise>
     #region IJSValue<JSPromise> implementation
 
     /// <summary>
+    /// Converts the <see cref="JSPromise" /> to a <see cref="JSValue" />.
+    /// </summary>
+    /// <returns>
+    /// The <see cref="JSValue" /> representation of the <see cref="JSPromise" />.
+    /// </returns>
+    public JSValue AsJSValue() => _value;
+
+    /// <summary>
     /// Determines whether a <see cref="JSPromise" /> can be created from
     /// the specified <see cref="JSValue" />.
     /// </summary>
@@ -176,7 +184,14 @@ public readonly struct JSPromise : IJSValue<JSPromise>
     /// <c>true</c> if a <see cref="JSPromise" /> can be created from
     /// the specified <see cref="JSValue" />; otherwise, <c>false</c>.
     /// </returns>
-    public static bool CanCreateFrom(JSValue value) => value.IsPromise();
+#if NET7_0_OR_GREATER
+    static bool IJSValue<JSPromise>.CanCreateFrom(JSValue value)
+#else
+#pragma warning disable IDE0051 // It is used by the IJSValueShim<T> class through reflection.
+    private static bool CanCreateFrom(JSValue value)
+#pragma warning restore IDE0051
+#endif
+        => value.IsPromise();
 
     /// <summary>
     /// Creates a new instance of <see cref="JSPromise" /> from
@@ -196,14 +211,6 @@ public readonly struct JSPromise : IJSValue<JSPromise>
     private static JSPromise CreateUnchecked(JSValue value) => new(value);
 #pragma warning restore IDE0051
 #endif
-
-    /// <summary>
-    /// Converts the <see cref="JSPromise" /> to a <see cref="JSValue" />.
-    /// </summary>
-    /// <returns>
-    /// The <see cref="JSValue" /> representation of the <see cref="JSPromise" />.
-    /// </returns>
-    public JSValue AsJSValue() => _value;
 
     #endregion
 

--- a/src/NodeApi/JSPromise.cs
+++ b/src/NodeApi/JSPromise.cs
@@ -18,8 +18,29 @@ public readonly struct JSPromise : IJSValue<JSPromise>
 {
     private readonly JSValue _value;
 
+    /// <summary>
+    /// Implicitly converts a <see cref="JSPromise" /> to a <see cref="JSValue" />.
+    /// </summary>
+    /// <param name="value">The <see cref="JSPromise" /> to convert.</param>
     public static implicit operator JSValue(JSPromise value) => value.AsJSValue();
+
+    /// <summary>
+    /// Explicitly converts a <see cref="JSValue" /> to a nullable <see cref="JSPromise" />.
+    /// </summary>
+    /// <param name="value">The <see cref="JSValue" /> to convert.</param>
+    /// <returns>
+    /// The <see cref="JSPromise" /> if it was successfully created or `null` if it was failed.
+    /// </returns>
     public static explicit operator JSPromise?(JSValue value) => value.As<JSPromise>();
+
+    /// <summary>
+    /// Explicitly converts a <see cref="JSValue" /> to a <see cref="JSPromise" />.
+    /// </summary>
+    /// <param name="value">The <see cref="JSValue" /> to convert.</param>
+    /// <returns><see cref="JSPromise" /> struct created based on this `JSValue`.</returns>
+    /// <exception cref="InvalidCastException">
+    /// Thrown when the T struct cannot be created based on this `JSValue`.
+    /// </exception>
     public static explicit operator JSPromise(JSValue value) => value.CastTo<JSPromise>();
 
     public static explicit operator JSPromise(JSObject obj) => (JSPromise)(JSValue)obj;
@@ -146,8 +167,28 @@ public readonly struct JSPromise : IJSValue<JSPromise>
 
     #region IJSValue<JSPromise> implementation
 
+    /// <summary>
+    /// Determines whether a <see cref="JSPromise" /> can be created from
+    /// the specified <see cref="JSValue" />.
+    /// </summary>
+    /// <param name="value">The <see cref="JSValue" /> to check.</param>
+    /// <returns>
+    /// <c>true</c> if a <see cref="JSPromise" /> can be created from
+    /// the specified <see cref="JSValue" />; otherwise, <c>false</c>.
+    /// </returns>
     public static bool CanCreateFrom(JSValue value) => value.IsPromise();
 
+    /// <summary>
+    /// Creates a new instance of <see cref="JSPromise" /> from
+    /// the specified <see cref="JSValue" />.
+    /// </summary>
+    /// <param name="value">
+    /// The <see cref="JSValue" /> to create a <see cref="JSPromise" /> from.
+    /// </param>
+    /// <returns>
+    /// A new instance of <see cref="JSPromise" /> created from
+    /// the specified <see cref="JSValue" />.
+    /// </returns>
 #if NET7_0_OR_GREATER
     static JSPromise IJSValue<JSPromise>.CreateUnchecked(JSValue value) => new(value);
 #else
@@ -156,6 +197,12 @@ public readonly struct JSPromise : IJSValue<JSPromise>
 #pragma warning restore IDE0051
 #endif
 
+    /// <summary>
+    /// Converts the <see cref="JSPromise" /> to a <see cref="JSValue" />.
+    /// </summary>
+    /// <returns>
+    /// The <see cref="JSValue" /> representation of the <see cref="JSPromise" />.
+    /// </returns>
     public JSValue AsJSValue() => _value;
 
     #endregion

--- a/src/NodeApi/JSPromise.cs
+++ b/src/NodeApi/JSPromise.cs
@@ -22,7 +22,7 @@ public readonly struct JSPromise : IJSValue<JSPromise>
     /// Implicitly converts a <see cref="JSPromise" /> to a <see cref="JSValue" />.
     /// </summary>
     /// <param name="value">The <see cref="JSPromise" /> to convert.</param>
-    public static implicit operator JSValue(JSPromise value) => value.AsJSValue();
+    public static implicit operator JSValue(JSPromise promise) => promise._value;
 
     /// <summary>
     /// Explicitly converts a <see cref="JSValue" /> to a nullable <see cref="JSPromise" />.
@@ -168,12 +168,43 @@ public readonly struct JSPromise : IJSValue<JSPromise>
     #region IJSValue<JSPromise> implementation
 
     /// <summary>
-    /// Converts the <see cref="JSPromise" /> to a <see cref="JSValue" />.
+    /// Checks if the T struct can be created from this instance`.
     /// </summary>
+    /// <typeparam name="T">A struct that implements IJSValue interface.</typeparam>
     /// <returns>
-    /// The <see cref="JSValue" /> representation of the <see cref="JSPromise" />.
+    /// `true` if the T struct can be created from this instance. Otherwise it returns `false`.
     /// </returns>
-    public JSValue AsJSValue() => _value;
+    public bool Is<T>() where T : struct, IJSValue<T> => _value.Is<T>();
+
+    /// <summary>
+    /// Tries to create a T struct from this instance.
+    /// It returns `null` if the T struct cannot be created.
+    /// </summary>
+    /// <typeparam name="T">A struct that implements IJSValue interface.</typeparam>
+    /// <returns>
+    /// Nullable value that contains T struct if it was successfully created
+    /// or `null` if it was failed.
+    /// </returns>
+    public T? As<T>() where T : struct, IJSValue<T> => _value.As<T>();
+
+    /// <summary>
+    /// Creates a T struct from this instance without checking the enclosed handle type.
+    /// It must be used only when the handle type is known to be correct.
+    /// </summary>
+    /// <typeparam name="T">A struct that implements IJSValue interface.</typeparam>
+    /// <returns>T struct created based on this instance.</returns>
+    public T AsUnchecked<T>() where T : struct, IJSValue<T> => _value.AsUnchecked<T>();
+
+    /// <summary>
+    /// Creates a T struct from this instance.
+    /// It throws `InvalidCastException` in case of failure.
+    /// </summary>
+    /// <typeparam name="T">A struct that implements IJSValue interface.</typeparam>
+    /// <returns>T struct created based on this instance.</returns>
+    /// <exception cref="InvalidCastException">
+    /// Thrown when the T struct cannot be crated based on this instance.
+    /// </exception>
+    public T CastTo<T>() where T : struct, IJSValue<T> => _value.CastTo<T>();
 
     /// <summary>
     /// Determines whether a <see cref="JSPromise" /> can be created from

--- a/src/NodeApi/JSProxy.cs
+++ b/src/NodeApi/JSProxy.cs
@@ -17,8 +17,29 @@ public readonly partial struct JSProxy : IJSValue<JSProxy>
     private readonly JSValue _value;
     private readonly JSValue _revoke = default;
 
+    /// <summary>
+    /// Implicitly converts a <see cref="JSProxy" /> to a <see cref="JSValue" />.
+    /// </summary>
+    /// <param name="value">The <see cref="JSProxy" /> to convert.</param>
     public static implicit operator JSValue(JSProxy value) => value.AsJSValue();
+
+    /// <summary>
+    /// Explicitly converts a <see cref="JSValue" /> to a nullable <see cref="JSProxy" />.
+    /// </summary>
+    /// <param name="value">The <see cref="JSValue" /> to convert.</param>
+    /// <returns>
+    /// The <see cref="JSProxy" /> if it was successfully created or `null` if it was failed.
+    /// </returns>
     public static explicit operator JSProxy?(JSValue value) => value.As<JSProxy>();
+
+    /// <summary>
+    /// Explicitly converts a <see cref="JSValue" /> to a <see cref="JSProxy" />.
+    /// </summary>
+    /// <param name="value">The <see cref="JSValue" /> to convert.</param>
+    /// <returns><see cref="JSProxy" /> struct created based on this `JSValue`.</returns>
+    /// <exception cref="InvalidCastException">
+    /// Thrown when the T struct cannot be created based on this `JSValue`.
+    /// </exception>
     public static explicit operator JSProxy(JSValue value) => value.CastTo<JSProxy>();
 
     private JSProxy(JSValue value)
@@ -68,9 +89,33 @@ public readonly partial struct JSProxy : IJSValue<JSProxy>
 
     #region IJSValue<JSProxy> implementation
 
-    // According to JavaScript specification we cannot differentiate Proxy instance from other objects.
-    public static bool CanCreateFrom(JSValue value) => value.IsObject();
+    /// <summary>
+    /// Determines whether a <see cref="JSProxy" /> can be created from
+    /// the specified <see cref="JSValue" />.
+    /// </summary>
+    /// <param name="value">The <see cref="JSValue" /> to check.</param>
+    /// <returns>
+    /// <c>true</c> if a <see cref="JSProxy" /> can be created from
+    /// the specified <see cref="JSValue" />; otherwise, <c>false</c>.
+    /// </returns>
+    public static bool CanCreateFrom(JSValue value)
+    {
+        // According to JavaScript specification we cannot differentiate Proxy instance
+        // from other objects.
+        return value.IsObject();
+    }
 
+    /// <summary>
+    /// Creates a new instance of <see cref="JSProxy" /> from
+    /// the specified <see cref="JSValue" />.
+    /// </summary>
+    /// <param name="value">
+    /// The <see cref="JSValue" /> to create a <see cref="JSProxy" /> from.
+    /// </param>
+    /// <returns>
+    /// A new instance of <see cref="JSProxy" /> created from
+    /// the specified <see cref="JSValue" />.
+    /// </returns>
 #if NET7_0_OR_GREATER
     static JSProxy IJSValue<JSProxy>.CreateUnchecked(JSValue value) => new(value);
 #else
@@ -79,6 +124,12 @@ public readonly partial struct JSProxy : IJSValue<JSProxy>
 #pragma warning restore IDE0051
 #endif
 
+    /// <summary>
+    /// Converts the <see cref="JSProxy" /> to a <see cref="JSValue" />.
+    /// </summary>
+    /// <returns>
+    /// The <see cref="JSValue" /> representation of the <see cref="JSProxy" />.
+    /// </returns>
     public JSValue AsJSValue() => _value;
 
     #endregion

--- a/src/NodeApi/JSProxy.cs
+++ b/src/NodeApi/JSProxy.cs
@@ -68,9 +68,8 @@ public readonly partial struct JSProxy : IJSValue<JSProxy>
 
     #region IJSValue<JSProxy> implementation
 
-    // TODO: (vmoroz) Implement using instanceof
-    public static bool CanCreateFrom(JSValue value)
-        => value.IsObject() && value.InstanceOf(JSValue.Global["Proxy"]);
+    // According to JavaScript specification we cannot differentiate Proxy instance from other objects.
+    public static bool CanCreateFrom(JSValue value) => value.IsObject();
 
 #if NET7_0_OR_GREATER
     static JSProxy IJSValue<JSProxy>.CreateUnchecked(JSValue value) => new(value);

--- a/src/NodeApi/JSProxy.cs
+++ b/src/NodeApi/JSProxy.cs
@@ -69,7 +69,8 @@ public readonly partial struct JSProxy : IJSValue<JSProxy>
     #region IJSValue<JSProxy> implementation
 
     // TODO: (vmoroz) Implement using instanceof
-    public static bool CanCreateFrom(JSValue value) => value.IsObject();
+    public static bool CanCreateFrom(JSValue value)
+        => value.IsObject() && value.InstanceOf(JSValue.Global["Proxy"]);
 
 #if NET7_0_OR_GREATER
     static JSProxy IJSValue<JSProxy>.CreateUnchecked(JSValue value) => new(value);

--- a/src/NodeApi/JSProxy.cs
+++ b/src/NodeApi/JSProxy.cs
@@ -13,12 +13,17 @@ namespace Microsoft.JavaScript.NodeApi;
 /// Enables creation of JS Proxy objects with C# handler callbacks.
 /// </summary>
 public readonly partial struct JSProxy : IEquatable<JSValue>
+#if NET7_0_OR_GREATER
+    , IJSValue<JSProxy>
+#endif
 {
     private readonly JSValue _value;
     private readonly JSValue _revoke = default;
 
-    public static explicit operator JSProxy(JSValue value) => new(value);
-    public static implicit operator JSValue(JSProxy proxy) => proxy._value;
+    public static implicit operator JSValue(JSProxy value) => value.AsJSValue();
+    public static explicit operator JSProxy?(JSValue value) => value.As<JSProxy>();
+    public static explicit operator JSProxy(JSValue value)
+        => value.As<JSProxy>() ?? throw new InvalidCastException("JSValue is not a Proxy.");
 
     private JSProxy(JSValue value)
     {
@@ -64,6 +69,17 @@ public readonly partial struct JSProxy : IEquatable<JSValue>
             _value = proxyConstructor.CallAsConstructor(jsTarget, handler.JSHandler);
         }
     }
+
+    #region IJSValue<JSProxy> implementation
+
+    // TODO: (vmoroz) Implement using instanceof
+    public static bool CanBeConvertedFrom(JSValue value) => value.IsObject();
+
+    public static JSProxy CreateUnchecked(JSValue value) => new(value);
+
+    #endregion
+
+    public JSValue AsJSValue() => _value;
 
     /// <summary>
     /// Revokes the proxy, so that further access to the target is no longer trapped by

--- a/src/NodeApi/JSProxy.cs
+++ b/src/NodeApi/JSProxy.cs
@@ -90,6 +90,14 @@ public readonly partial struct JSProxy : IJSValue<JSProxy>
     #region IJSValue<JSProxy> implementation
 
     /// <summary>
+    /// Converts the <see cref="JSProxy" /> to a <see cref="JSValue" />.
+    /// </summary>
+    /// <returns>
+    /// The <see cref="JSValue" /> representation of the <see cref="JSProxy" />.
+    /// </returns>
+    public JSValue AsJSValue() => _value;
+
+    /// <summary>
     /// Determines whether a <see cref="JSProxy" /> can be created from
     /// the specified <see cref="JSValue" />.
     /// </summary>
@@ -98,7 +106,13 @@ public readonly partial struct JSProxy : IJSValue<JSProxy>
     /// <c>true</c> if a <see cref="JSProxy" /> can be created from
     /// the specified <see cref="JSValue" />; otherwise, <c>false</c>.
     /// </returns>
-    public static bool CanCreateFrom(JSValue value)
+#if NET7_0_OR_GREATER
+    static bool IJSValue<JSProxy>.CanCreateFrom(JSValue value)
+#else
+#pragma warning disable IDE0051 // It is used by the IJSValueShim<T> class through reflection.
+    private static bool CanCreateFrom(JSValue value)
+#pragma warning restore IDE0051
+#endif
     {
         // According to JavaScript specification we cannot differentiate Proxy instance
         // from other objects.
@@ -123,14 +137,6 @@ public readonly partial struct JSProxy : IJSValue<JSProxy>
     private static JSProxy CreateUnchecked(JSValue value) => new(value);
 #pragma warning restore IDE0051
 #endif
-
-    /// <summary>
-    /// Converts the <see cref="JSProxy" /> to a <see cref="JSValue" />.
-    /// </summary>
-    /// <returns>
-    /// The <see cref="JSValue" /> representation of the <see cref="JSProxy" />.
-    /// </returns>
-    public JSValue AsJSValue() => _value;
 
     #endregion
 

--- a/src/NodeApi/JSProxy.cs
+++ b/src/NodeApi/JSProxy.cs
@@ -74,7 +74,9 @@ public readonly partial struct JSProxy : IJSValue<JSProxy>
 #if NET7_0_OR_GREATER
     static JSProxy IJSValue<JSProxy>.CreateUnchecked(JSValue value) => new(value);
 #else
+#pragma warning disable IDE0051 // It is used by the IJSValueShim<T> class through reflection.
     private static JSProxy CreateUnchecked(JSValue value) => new(value);
+#pragma warning restore IDE0051
 #endif
 
     public JSValue AsJSValue() => _value;

--- a/src/NodeApi/JSProxy.cs
+++ b/src/NodeApi/JSProxy.cs
@@ -21,7 +21,7 @@ public readonly partial struct JSProxy : IJSValue<JSProxy>
     /// Implicitly converts a <see cref="JSProxy" /> to a <see cref="JSValue" />.
     /// </summary>
     /// <param name="value">The <see cref="JSProxy" /> to convert.</param>
-    public static implicit operator JSValue(JSProxy value) => value.AsJSValue();
+    public static implicit operator JSValue(JSProxy proxy) => proxy._value;
 
     /// <summary>
     /// Explicitly converts a <see cref="JSValue" /> to a nullable <see cref="JSProxy" />.
@@ -90,12 +90,43 @@ public readonly partial struct JSProxy : IJSValue<JSProxy>
     #region IJSValue<JSProxy> implementation
 
     /// <summary>
-    /// Converts the <see cref="JSProxy" /> to a <see cref="JSValue" />.
+    /// Checks if the T struct can be created from this instance`.
     /// </summary>
+    /// <typeparam name="T">A struct that implements IJSValue interface.</typeparam>
     /// <returns>
-    /// The <see cref="JSValue" /> representation of the <see cref="JSProxy" />.
+    /// `true` if the T struct can be created from this instance. Otherwise it returns `false`.
     /// </returns>
-    public JSValue AsJSValue() => _value;
+    public bool Is<T>() where T : struct, IJSValue<T> => _value.Is<T>();
+
+    /// <summary>
+    /// Tries to create a T struct from this instance.
+    /// It returns `null` if the T struct cannot be created.
+    /// </summary>
+    /// <typeparam name="T">A struct that implements IJSValue interface.</typeparam>
+    /// <returns>
+    /// Nullable value that contains T struct if it was successfully created
+    /// or `null` if it was failed.
+    /// </returns>
+    public T? As<T>() where T : struct, IJSValue<T> => _value.As<T>();
+
+    /// <summary>
+    /// Creates a T struct from this instance without checking the enclosed handle type.
+    /// It must be used only when the handle type is known to be correct.
+    /// </summary>
+    /// <typeparam name="T">A struct that implements IJSValue interface.</typeparam>
+    /// <returns>T struct created based on this instance.</returns>
+    public T AsUnchecked<T>() where T : struct, IJSValue<T> => _value.AsUnchecked<T>();
+
+    /// <summary>
+    /// Creates a T struct from this instance.
+    /// It throws `InvalidCastException` in case of failure.
+    /// </summary>
+    /// <typeparam name="T">A struct that implements IJSValue interface.</typeparam>
+    /// <returns>T struct created based on this instance.</returns>
+    /// <exception cref="InvalidCastException">
+    /// Thrown when the T struct cannot be crated based on this instance.
+    /// </exception>
+    public T CastTo<T>() where T : struct, IJSValue<T> => _value.CastTo<T>();
 
     /// <summary>
     /// Determines whether a <see cref="JSProxy" /> can be created from

--- a/src/NodeApi/JSSet.cs
+++ b/src/NodeApi/JSSet.cs
@@ -17,7 +17,7 @@ public readonly partial struct JSSet : IJSValue<JSSet>, ISet<JSValue>
     /// Implicitly converts a <see cref="JSSet" /> to a <see cref="JSValue" />.
     /// </summary>
     /// <param name="value">The <see cref="JSSet" /> to convert.</param>
-    public static implicit operator JSValue(JSSet value) => value.AsJSValue();
+    public static implicit operator JSValue(JSSet set) => set._value;
 
     /// <summary>
     /// Explicitly converts a <see cref="JSValue" /> to a nullable <see cref="JSSet" />.
@@ -69,6 +69,45 @@ public readonly partial struct JSSet : IJSValue<JSSet>, ISet<JSValue>
     #region IJSValue<JSSet> implementation
 
     /// <summary>
+    /// Checks if the T struct can be created from this instance`.
+    /// </summary>
+    /// <typeparam name="T">A struct that implements IJSValue interface.</typeparam>
+    /// <returns>
+    /// `true` if the T struct can be created from this instance. Otherwise it returns `false`.
+    /// </returns>
+    public bool Is<T>() where T : struct, IJSValue<T> => _value.Is<T>();
+
+    /// <summary>
+    /// Tries to create a T struct from this instance.
+    /// It returns `null` if the T struct cannot be created.
+    /// </summary>
+    /// <typeparam name="T">A struct that implements IJSValue interface.</typeparam>
+    /// <returns>
+    /// Nullable value that contains T struct if it was successfully created
+    /// or `null` if it was failed.
+    /// </returns>
+    public T? As<T>() where T : struct, IJSValue<T> => _value.As<T>();
+
+    /// <summary>
+    /// Creates a T struct from this instance without checking the enclosed handle type.
+    /// It must be used only when the handle type is known to be correct.
+    /// </summary>
+    /// <typeparam name="T">A struct that implements IJSValue interface.</typeparam>
+    /// <returns>T struct created based on this instance.</returns>
+    public T AsUnchecked<T>() where T : struct, IJSValue<T> => _value.AsUnchecked<T>();
+
+    /// <summary>
+    /// Creates a T struct from this instance.
+    /// It throws `InvalidCastException` in case of failure.
+    /// </summary>
+    /// <typeparam name="T">A struct that implements IJSValue interface.</typeparam>
+    /// <returns>T struct created based on this instance.</returns>
+    /// <exception cref="InvalidCastException">
+    /// Thrown when the T struct cannot be crated based on this instance.
+    /// </exception>
+    public T CastTo<T>() where T : struct, IJSValue<T> => _value.CastTo<T>();
+
+    /// <summary>
     /// Determines whether a <see cref="JSSet" /> can be created from
     /// the specified <see cref="JSValue" />.
     /// </summary>
@@ -104,14 +143,6 @@ public readonly partial struct JSSet : IJSValue<JSSet>, ISet<JSValue>
     private static JSSet CreateUnchecked(JSValue value) => new(value);
 #pragma warning restore IDE0051
 #endif
-
-    /// <summary>
-    /// Converts the <see cref="JSSet" /> to a <see cref="JSValue" />.
-    /// </summary>
-    /// <returns>
-    /// The <see cref="JSValue" /> representation of the <see cref="JSSet" />.
-    /// </returns>
-    public JSValue AsJSValue() => _value;
 
     #endregion
 

--- a/src/NodeApi/JSSet.cs
+++ b/src/NodeApi/JSSet.cs
@@ -13,8 +13,29 @@ public readonly partial struct JSSet : IJSValue<JSSet>, ISet<JSValue>
 {
     private readonly JSValue _value;
 
+    /// <summary>
+    /// Implicitly converts a <see cref="JSSet" /> to a <see cref="JSValue" />.
+    /// </summary>
+    /// <param name="value">The <see cref="JSSet" /> to convert.</param>
     public static implicit operator JSValue(JSSet value) => value.AsJSValue();
+
+    /// <summary>
+    /// Explicitly converts a <see cref="JSValue" /> to a nullable <see cref="JSSet" />.
+    /// </summary>
+    /// <param name="value">The <see cref="JSValue" /> to convert.</param>
+    /// <returns>
+    /// The <see cref="JSSet" /> if it was successfully created or `null` if it was failed.
+    /// </returns>
     public static explicit operator JSSet?(JSValue value) => value.As<JSSet>();
+
+    /// <summary>
+    /// Explicitly converts a <see cref="JSValue" /> to a <see cref="JSSet" />.
+    /// </summary>
+    /// <param name="value">The <see cref="JSValue" /> to convert.</param>
+    /// <returns><see cref="JSSet" /> struct created based on this `JSValue`.</returns>
+    /// <exception cref="InvalidCastException">
+    /// Thrown when the T struct cannot be created based on this `JSValue`.
+    /// </exception>
     public static explicit operator JSSet(JSValue value) => value.CastTo<JSSet>();
 
     public static explicit operator JSSet(JSObject obj) => (JSSet)(JSValue)obj;
@@ -47,10 +68,29 @@ public readonly partial struct JSSet : IJSValue<JSSet>, ISet<JSValue>
 
     #region IJSValue<JSSet> implementation
 
-    // TODO: (vmoroz) Implement using instanceof
+    /// <summary>
+    /// Determines whether a <see cref="JSSet" /> can be created from
+    /// the specified <see cref="JSValue" />.
+    /// </summary>
+    /// <param name="value">The <see cref="JSValue" /> to check.</param>
+    /// <returns>
+    /// <c>true</c> if a <see cref="JSSet" /> can be created from
+    /// the specified <see cref="JSValue" />; otherwise, <c>false</c>.
+    /// </returns>
     public static bool CanCreateFrom(JSValue value)
         => value.IsObject() && value.InstanceOf(JSValue.Global["Set"]);
 
+    /// <summary>
+    /// Creates a new instance of <see cref="JSSet" /> from
+    /// the specified <see cref="JSValue" />.
+    /// </summary>
+    /// <param name="value">
+    /// The <see cref="JSValue" /> to create a <see cref="JSSet" /> from.
+    /// </param>
+    /// <returns>
+    /// A new instance of <see cref="JSSet" /> created from
+    /// the specified <see cref="JSValue" />.
+    /// </returns>
 #if NET7_0_OR_GREATER
     static JSSet IJSValue<JSSet>.CreateUnchecked(JSValue value) => new(value);
 #else
@@ -59,6 +99,12 @@ public readonly partial struct JSSet : IJSValue<JSSet>, ISet<JSValue>
 #pragma warning restore IDE0051
 #endif
 
+    /// <summary>
+    /// Converts the <see cref="JSSet" /> to a <see cref="JSValue" />.
+    /// </summary>
+    /// <returns>
+    /// The <see cref="JSValue" /> representation of the <see cref="JSSet" />.
+    /// </returns>
     public JSValue AsJSValue() => _value;
 
     #endregion

--- a/src/NodeApi/JSSet.cs
+++ b/src/NodeApi/JSSet.cs
@@ -53,7 +53,9 @@ public readonly partial struct JSSet : IJSValue<JSSet>, ISet<JSValue>
 #if NET7_0_OR_GREATER
     static JSSet IJSValue<JSSet>.CreateUnchecked(JSValue value) => new(value);
 #else
+#pragma warning disable IDE0051 // It is used by the IJSValueShim<T> class through reflection.
     private static JSSet CreateUnchecked(JSValue value) => new(value);
+#pragma warning restore IDE0051
 #endif
 
     public JSValue AsJSValue() => _value;

--- a/src/NodeApi/JSSet.cs
+++ b/src/NodeApi/JSSet.cs
@@ -9,17 +9,13 @@ using Microsoft.JavaScript.NodeApi.Interop;
 
 namespace Microsoft.JavaScript.NodeApi;
 
-public readonly partial struct JSSet : ISet<JSValue>, IEquatable<JSValue>
-#if NET7_0_OR_GREATER
-    , IJSValue<JSSet>
-#endif
+public readonly partial struct JSSet : IJSValue<JSSet>, ISet<JSValue>
 {
     private readonly JSValue _value;
 
     public static implicit operator JSValue(JSSet value) => value.AsJSValue();
     public static explicit operator JSSet?(JSValue value) => value.As<JSSet>();
-    public static explicit operator JSSet(JSValue value)
-        => value.As<JSSet>() ?? throw new InvalidCastException("JSValue is not a Set.");
+    public static explicit operator JSSet(JSValue value) => value.CastTo<JSSet>();
 
     public static explicit operator JSSet(JSObject obj) => (JSSet)(JSValue)obj;
     public static implicit operator JSObject(JSSet set) => (JSObject)set._value;
@@ -52,13 +48,17 @@ public readonly partial struct JSSet : ISet<JSValue>, IEquatable<JSValue>
     #region IJSValue<JSSet> implementation
 
     // TODO: (vmoroz) Implement using instanceof
-    public static bool CanBeConvertedFrom(JSValue value) => value.IsObject();
+    public static bool CanCreateFrom(JSValue value) => value.IsObject();
 
-    public static JSSet CreateUnchecked(JSValue value) => new(value);
-
-    #endregion
+#if NET7_0_OR_GREATER
+    static JSSet IJSValue<JSSet>.CreateUnchecked(JSValue value) => new(value);
+#else
+    private static JSSet CreateUnchecked(JSValue value) => new(value);
+#endif
 
     public JSValue AsJSValue() => _value;
+
+    #endregion
 
     public int Count => (int)_value["size"];
 

--- a/src/NodeApi/JSSet.cs
+++ b/src/NodeApi/JSSet.cs
@@ -10,11 +10,16 @@ using Microsoft.JavaScript.NodeApi.Interop;
 namespace Microsoft.JavaScript.NodeApi;
 
 public readonly partial struct JSSet : ISet<JSValue>, IEquatable<JSValue>
+#if NET7_0_OR_GREATER
+    , IJSValue<JSSet>
+#endif
 {
     private readonly JSValue _value;
 
-    public static explicit operator JSSet(JSValue value) => new(value);
-    public static implicit operator JSValue(JSSet set) => set._value;
+    public static implicit operator JSValue(JSSet value) => value.AsJSValue();
+    public static explicit operator JSSet?(JSValue value) => value.As<JSSet>();
+    public static explicit operator JSSet(JSValue value)
+        => value.As<JSSet>() ?? throw new InvalidCastException("JSValue is not a Set.");
 
     public static explicit operator JSSet(JSObject obj) => (JSSet)(JSValue)obj;
     public static implicit operator JSObject(JSSet set) => (JSObject)set._value;
@@ -43,6 +48,17 @@ public readonly partial struct JSSet : ISet<JSValue>, IEquatable<JSValue>
     {
         _value = JSRuntimeContext.Current.Import(null, "Set").CallAsConstructor(iterable);
     }
+
+    #region IJSValue<JSSet> implementation
+
+    // TODO: (vmoroz) Implement using instanceof
+    public static bool CanBeConvertedFrom(JSValue value) => value.IsObject();
+
+    public static JSSet CreateUnchecked(JSValue value) => new(value);
+
+    #endregion
+
+    public JSValue AsJSValue() => _value;
 
     public int Count => (int)_value["size"];
 

--- a/src/NodeApi/JSSet.cs
+++ b/src/NodeApi/JSSet.cs
@@ -77,7 +77,13 @@ public readonly partial struct JSSet : IJSValue<JSSet>, ISet<JSValue>
     /// <c>true</c> if a <see cref="JSSet" /> can be created from
     /// the specified <see cref="JSValue" />; otherwise, <c>false</c>.
     /// </returns>
-    public static bool CanCreateFrom(JSValue value)
+#if NET7_0_OR_GREATER
+    static bool IJSValue<JSSet>.CanCreateFrom(JSValue value)
+#else
+#pragma warning disable IDE0051 // It is used by the IJSValueShim<T> class through reflection.
+    private static bool CanCreateFrom(JSValue value)
+#pragma warning restore IDE0051
+#endif
         => value.IsObject() && value.InstanceOf(JSValue.Global["Set"]);
 
     /// <summary>

--- a/src/NodeApi/JSSet.cs
+++ b/src/NodeApi/JSSet.cs
@@ -48,7 +48,8 @@ public readonly partial struct JSSet : IJSValue<JSSet>, ISet<JSValue>
     #region IJSValue<JSSet> implementation
 
     // TODO: (vmoroz) Implement using instanceof
-    public static bool CanCreateFrom(JSValue value) => value.IsObject();
+    public static bool CanCreateFrom(JSValue value)
+        => value.IsObject() && value.InstanceOf(JSValue.Global["Set"]);
 
 #if NET7_0_OR_GREATER
     static JSSet IJSValue<JSSet>.CreateUnchecked(JSValue value) => new(value);

--- a/src/NodeApi/JSSymbol.cs
+++ b/src/NodeApi/JSSymbol.cs
@@ -54,6 +54,14 @@ public readonly struct JSSymbol : IJSValue<JSSymbol>
     #region IJSValue<JSSymbol> implementation
 
     /// <summary>
+    /// Converts the <see cref="JSSymbol" /> to a <see cref="JSValue" />.
+    /// </summary>
+    /// <returns>
+    /// The <see cref="JSValue" /> representation of the <see cref="JSSymbol" />.
+    /// </returns>
+    public JSValue AsJSValue() => _value;
+
+    /// <summary>
     /// Determines whether a <see cref="JSSymbol" /> can be created from
     /// the specified <see cref="JSValue" />.
     /// </summary>
@@ -62,7 +70,14 @@ public readonly struct JSSymbol : IJSValue<JSSymbol>
     /// <c>true</c> if a <see cref="JSSymbol" /> can be created from
     /// the specified <see cref="JSValue" />; otherwise, <c>false</c>.
     /// </returns>
-    public static bool CanCreateFrom(JSValue value) => value.IsSymbol();
+#if NET7_0_OR_GREATER
+    static bool IJSValue<JSSymbol>.CanCreateFrom(JSValue value)
+#else
+#pragma warning disable IDE0051 // It is used by the IJSValueShim<T> class through reflection.
+    private static bool CanCreateFrom(JSValue value)
+#pragma warning restore IDE0051
+#endif
+        => value.IsSymbol();
 
     /// <summary>
     /// Creates a new instance of <see cref="JSSymbol" /> from
@@ -82,14 +97,6 @@ public readonly struct JSSymbol : IJSValue<JSSymbol>
     private static JSSymbol CreateUnchecked(JSValue value) => new(value);
 #pragma warning restore IDE0051
 #endif
-
-    /// <summary>
-    /// Converts the <see cref="JSSymbol" /> to a <see cref="JSValue" />.
-    /// </summary>
-    /// <returns>
-    /// The <see cref="JSValue" /> representation of the <see cref="JSSymbol" />.
-    /// </returns>
-    public JSValue AsJSValue() => _value;
 
     #endregion
 

--- a/src/NodeApi/JSSymbol.cs
+++ b/src/NodeApi/JSSymbol.cs
@@ -20,7 +20,7 @@ public readonly struct JSSymbol : IJSValue<JSSymbol>
     /// Implicitly converts a <see cref="JSSymbol" /> to a <see cref="JSValue" />.
     /// </summary>
     /// <param name="value">The <see cref="JSSymbol" /> to convert.</param>
-    public static implicit operator JSValue(JSSymbol value) => value.AsJSValue();
+    public static implicit operator JSValue(JSSymbol symbol) => symbol._value;
 
     /// <summary>
     /// Explicitly converts a <see cref="JSValue" /> to a nullable <see cref="JSSymbol" />.
@@ -54,12 +54,43 @@ public readonly struct JSSymbol : IJSValue<JSSymbol>
     #region IJSValue<JSSymbol> implementation
 
     /// <summary>
-    /// Converts the <see cref="JSSymbol" /> to a <see cref="JSValue" />.
+    /// Checks if the T struct can be created from this instance`.
     /// </summary>
+    /// <typeparam name="T">A struct that implements IJSValue interface.</typeparam>
     /// <returns>
-    /// The <see cref="JSValue" /> representation of the <see cref="JSSymbol" />.
+    /// `true` if the T struct can be created from this instance. Otherwise it returns `false`.
     /// </returns>
-    public JSValue AsJSValue() => _value;
+    public bool Is<T>() where T : struct, IJSValue<T> => _value.Is<T>();
+
+    /// <summary>
+    /// Tries to create a T struct from this instance.
+    /// It returns `null` if the T struct cannot be created.
+    /// </summary>
+    /// <typeparam name="T">A struct that implements IJSValue interface.</typeparam>
+    /// <returns>
+    /// Nullable value that contains T struct if it was successfully created
+    /// or `null` if it was failed.
+    /// </returns>
+    public T? As<T>() where T : struct, IJSValue<T> => _value.As<T>();
+
+    /// <summary>
+    /// Creates a T struct from this instance without checking the enclosed handle type.
+    /// It must be used only when the handle type is known to be correct.
+    /// </summary>
+    /// <typeparam name="T">A struct that implements IJSValue interface.</typeparam>
+    /// <returns>T struct created based on this instance.</returns>
+    public T AsUnchecked<T>() where T : struct, IJSValue<T> => _value.AsUnchecked<T>();
+
+    /// <summary>
+    /// Creates a T struct from this instance.
+    /// It throws `InvalidCastException` in case of failure.
+    /// </summary>
+    /// <typeparam name="T">A struct that implements IJSValue interface.</typeparam>
+    /// <returns>T struct created based on this instance.</returns>
+    /// <exception cref="InvalidCastException">
+    /// Thrown when the T struct cannot be crated based on this instance.
+    /// </exception>
+    public T CastTo<T>() where T : struct, IJSValue<T> => _value.CastTo<T>();
 
     /// <summary>
     /// Determines whether a <see cref="JSSymbol" /> can be created from

--- a/src/NodeApi/JSSymbol.cs
+++ b/src/NodeApi/JSSymbol.cs
@@ -37,12 +37,14 @@ public readonly struct JSSymbol : IJSValue<JSSymbol>
 #if NET7_0_OR_GREATER
     static JSSymbol IJSValue<JSSymbol>.CreateUnchecked(JSValue value) => new(value);
 #else
+#pragma warning disable IDE0051 // It is used by the IJSValueShim<T> class through reflection.
     private static JSSymbol CreateUnchecked(JSValue value) => new(value);
+#pragma warning restore IDE0051
 #endif
 
     public JSValue AsJSValue() => _value;
 
-#endregion
+    #endregion
 
     /// <summary>
     /// Gets the symbol's description, or null if it does not have one.

--- a/src/NodeApi/JSSymbol.cs
+++ b/src/NodeApi/JSSymbol.cs
@@ -6,10 +6,7 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.JavaScript.NodeApi;
 
-public readonly struct JSSymbol : IEquatable<JSValue>
-#if NET7_0_OR_GREATER
-    , IJSValue<JSSymbol>
-#endif
+public readonly struct JSSymbol : IJSValue<JSSymbol>
 {
     private readonly JSValue _value;
 
@@ -21,8 +18,7 @@ public readonly struct JSSymbol : IEquatable<JSValue>
 
     public static implicit operator JSValue(JSSymbol value) => value.AsJSValue();
     public static explicit operator JSSymbol?(JSValue value) => value.As<JSSymbol>();
-    public static explicit operator JSSymbol(JSValue value)
-        => value.As<JSSymbol>() ?? throw new InvalidCastException("JSValue is not a Symbol.");
+    public static explicit operator JSSymbol(JSValue value) => value.CastTo<JSSymbol>();
 
     private JSSymbol(JSValue value)
     {
@@ -36,13 +32,17 @@ public readonly struct JSSymbol : IEquatable<JSValue>
 
     #region IJSValue<JSSymbol> implementation
 
-    public static bool CanBeConvertedFrom(JSValue value) => value.IsSymbol();
+    public static bool CanCreateFrom(JSValue value) => value.IsSymbol();
 
-    public static JSSymbol CreateUnchecked(JSValue value) => new(value);
-
-    #endregion
+#if NET7_0_OR_GREATER
+    static JSSymbol IJSValue<JSSymbol>.CreateUnchecked(JSValue value) => new(value);
+#else
+    private static JSSymbol CreateUnchecked(JSValue value) => new(value);
+#endif
 
     public JSValue AsJSValue() => _value;
+
+#endregion
 
     /// <summary>
     /// Gets the symbol's description, or null if it does not have one.

--- a/src/NodeApi/JSSymbol.cs
+++ b/src/NodeApi/JSSymbol.cs
@@ -16,8 +16,29 @@ public readonly struct JSSymbol : IJSValue<JSSymbol>
     private static readonly Lazy<JSReference> s_asyncIteratorSymbol =
         new(() => new JSReference(JSValue.Global["Symbol"]["asyncIterator"]));
 
+    /// <summary>
+    /// Implicitly converts a <see cref="JSSymbol" /> to a <see cref="JSValue" />.
+    /// </summary>
+    /// <param name="value">The <see cref="JSSymbol" /> to convert.</param>
     public static implicit operator JSValue(JSSymbol value) => value.AsJSValue();
+
+    /// <summary>
+    /// Explicitly converts a <see cref="JSValue" /> to a nullable <see cref="JSSymbol" />.
+    /// </summary>
+    /// <param name="value">The <see cref="JSValue" /> to convert.</param>
+    /// <returns>
+    /// The <see cref="JSSymbol" /> if it was successfully created or `null` if it was failed.
+    /// </returns>
     public static explicit operator JSSymbol?(JSValue value) => value.As<JSSymbol>();
+
+    /// <summary>
+    /// Explicitly converts a <see cref="JSValue" /> to a <see cref="JSSymbol" />.
+    /// </summary>
+    /// <param name="value">The <see cref="JSValue" /> to convert.</param>
+    /// <returns><see cref="JSSymbol" /> struct created based on this `JSValue`.</returns>
+    /// <exception cref="InvalidCastException">
+    /// Thrown when the T struct cannot be created based on this `JSValue`.
+    /// </exception>
     public static explicit operator JSSymbol(JSValue value) => value.CastTo<JSSymbol>();
 
     private JSSymbol(JSValue value)
@@ -32,8 +53,28 @@ public readonly struct JSSymbol : IJSValue<JSSymbol>
 
     #region IJSValue<JSSymbol> implementation
 
+    /// <summary>
+    /// Determines whether a <see cref="JSSymbol" /> can be created from
+    /// the specified <see cref="JSValue" />.
+    /// </summary>
+    /// <param name="value">The <see cref="JSValue" /> to check.</param>
+    /// <returns>
+    /// <c>true</c> if a <see cref="JSSymbol" /> can be created from
+    /// the specified <see cref="JSValue" />; otherwise, <c>false</c>.
+    /// </returns>
     public static bool CanCreateFrom(JSValue value) => value.IsSymbol();
 
+    /// <summary>
+    /// Creates a new instance of <see cref="JSSymbol" /> from
+    /// the specified <see cref="JSValue" />.
+    /// </summary>
+    /// <param name="value">
+    /// The <see cref="JSValue" /> to create a <see cref="JSSymbol" /> from.
+    /// </param>
+    /// <returns>
+    /// A new instance of <see cref="JSSymbol" /> created from
+    /// the specified <see cref="JSValue" />.
+    /// </returns>
 #if NET7_0_OR_GREATER
     static JSSymbol IJSValue<JSSymbol>.CreateUnchecked(JSValue value) => new(value);
 #else
@@ -42,6 +83,12 @@ public readonly struct JSSymbol : IJSValue<JSSymbol>
 #pragma warning restore IDE0051
 #endif
 
+    /// <summary>
+    /// Converts the <see cref="JSSymbol" /> to a <see cref="JSValue" />.
+    /// </summary>
+    /// <returns>
+    /// The <see cref="JSValue" /> representation of the <see cref="JSSymbol" />.
+    /// </returns>
     public JSValue AsJSValue() => _value;
 
     #endregion

--- a/src/NodeApi/JSTypedArray.cs
+++ b/src/NodeApi/JSTypedArray.cs
@@ -146,6 +146,14 @@ public readonly struct JSTypedArray<T> : IJSValue<JSTypedArray<T>>
     #region IJSValue<JSTypedArray<T>> implementation
 
     /// <summary>
+    /// Converts the <see cref="JSTypedArray&lt;T&gt;" /> to a <see cref="JSValue" />.
+    /// </summary>
+    /// <returns>
+    /// The <see cref="JSValue" /> representation of the <see cref="JSTypedArray&lt;T&gt;" />.
+    /// </returns>
+    public JSValue AsJSValue() => _value;
+
+    /// <summary>
     /// Determines whether a <see cref="JSTypedArray&lt;T&gt;" /> can be created from
     /// the specified <see cref="JSValue" />.
     /// </summary>
@@ -154,7 +162,13 @@ public readonly struct JSTypedArray<T> : IJSValue<JSTypedArray<T>>
     /// <c>true</c> if a <see cref="JSTypedArray&lt;T&gt;" /> can be created from
     /// the specified <see cref="JSValue" />; otherwise, <c>false</c>.
     /// </returns>
-    public static bool CanCreateFrom(JSValue value)
+#if NET7_0_OR_GREATER
+    static bool IJSValue<JSTypedArray<T>>.CanCreateFrom(JSValue value)
+#else
+#pragma warning disable IDE0051 // It is used by the IJSValueShim<T> class through reflection.
+    private static bool CanCreateFrom(JSValue value)
+#pragma warning restore IDE0051
+#endif
         => value.IsObject() && value.InstanceOf(JSValue.Global[JSTypeName]);
 
     /// <summary>
@@ -175,14 +189,6 @@ public readonly struct JSTypedArray<T> : IJSValue<JSTypedArray<T>>
     private static JSTypedArray<T> CreateUnchecked(JSValue value) => new(value);
 #pragma warning restore IDE0051
 #endif
-
-    /// <summary>
-    /// Converts the <see cref="JSTypedArray&lt;T&gt;" /> to a <see cref="JSValue" />.
-    /// </summary>
-    /// <returns>
-    /// The <see cref="JSValue" /> representation of the <see cref="JSTypedArray&lt;T&gt;" />.
-    /// </returns>
-    public JSValue AsJSValue() => _value;
 
     #endregion
 

--- a/src/NodeApi/JSTypedArray.cs
+++ b/src/NodeApi/JSTypedArray.cs
@@ -19,7 +19,7 @@ public readonly struct JSTypedArray<T> : IJSValue<JSTypedArray<T>>
     /// Implicitly converts a <see cref="JSTypedArray&lt;T&gt;" /> to a <see cref="JSValue" />.
     /// </summary>
     /// <param name="value">The <see cref="JSTypedArray&lt;T&gt;" /> to convert.</param>
-    public static implicit operator JSValue(JSTypedArray<T> value) => value.AsJSValue();
+    public static implicit operator JSValue(JSTypedArray<T> array) => array._value;
 
     /// <summary>
     /// Explicitly converts a <see cref="JSValue" /> to a
@@ -146,12 +146,47 @@ public readonly struct JSTypedArray<T> : IJSValue<JSTypedArray<T>>
     #region IJSValue<JSTypedArray<T>> implementation
 
     /// <summary>
-    /// Converts the <see cref="JSTypedArray&lt;T&gt;" /> to a <see cref="JSValue" />.
+    /// Checks if the T struct can be created from this instance`.
     /// </summary>
+    /// <typeparam name="TOther">A struct that implements IJSValue interface.</typeparam>
     /// <returns>
-    /// The <see cref="JSValue" /> representation of the <see cref="JSTypedArray&lt;T&gt;" />.
+    /// `true` if the T struct can be created from this instance. Otherwise it returns `false`.
     /// </returns>
-    public JSValue AsJSValue() => _value;
+    public bool Is<TOther>() where TOther : struct, IJSValue<TOther>
+        => _value.Is<TOther>();
+
+    /// <summary>
+    /// Tries to create a T struct from this instance.
+    /// It returns `null` if the T struct cannot be created.
+    /// </summary>
+    /// <typeparam name="TOther">A struct that implements IJSValue interface.</typeparam>
+    /// <returns>
+    /// Nullable value that contains T struct if it was successfully created
+    /// or `null` if it was failed.
+    /// </returns>
+    public TOther? As<TOther>() where TOther : struct, IJSValue<TOther>
+        => _value.As<TOther>();
+
+    /// <summary>
+    /// Creates a T struct from this instance without checking the enclosed handle type.
+    /// It must be used only when the handle type is known to be correct.
+    /// </summary>
+    /// <typeparam name="TOther">A struct that implements IJSValue interface.</typeparam>
+    /// <returns>T struct created based on this instance.</returns>
+    public TOther AsUnchecked<TOther>() where TOther : struct, IJSValue<TOther>
+        => _value.AsUnchecked<TOther>();
+
+    /// <summary>
+    /// Creates a T struct from this instance.
+    /// It throws `InvalidCastException` in case of failure.
+    /// </summary>
+    /// <typeparam name="TOther">A struct that implements IJSValue interface.</typeparam>
+    /// <returns>T struct created based on this instance.</returns>
+    /// <exception cref="InvalidCastException">
+    /// Thrown when the T struct cannot be crated based on this instance.
+    /// </exception>
+    public TOther CastTo<TOther>() where TOther : struct, IJSValue<TOther>
+        => _value.CastTo<TOther>();
 
     /// <summary>
     /// Determines whether a <see cref="JSTypedArray&lt;T&gt;" /> can be created from

--- a/src/NodeApi/JSTypedArray.cs
+++ b/src/NodeApi/JSTypedArray.cs
@@ -15,8 +15,31 @@ public readonly struct JSTypedArray<T> : IJSValue<JSTypedArray<T>>
 {
     private readonly JSValue _value;
 
+    /// <summary>
+    /// Implicitly converts a <see cref="JSTypedArray&lt;T&gt;" /> to a <see cref="JSValue" />.
+    /// </summary>
+    /// <param name="value">The <see cref="JSTypedArray&lt;T&gt;" /> to convert.</param>
     public static implicit operator JSValue(JSTypedArray<T> value) => value.AsJSValue();
+
+    /// <summary>
+    /// Explicitly converts a <see cref="JSValue" /> to a
+    /// nullable <see cref="JSTypedArray&lt;T&gt;" />.
+    /// </summary>
+    /// <param name="value">The <see cref="JSValue" /> to convert.</param>
+    /// <returns>
+    /// The <see cref="JSTypedArray&lt;T&gt;" /> if it was successfully created or
+    /// `null` if it was failed.
+    /// </returns>
     public static explicit operator JSTypedArray<T>?(JSValue value) => value.As<JSTypedArray<T>>();
+
+    /// <summary>
+    /// Explicitly converts a <see cref="JSValue" /> to a <see cref="JSTypedArray&lt;T&gt;" />.
+    /// </summary>
+    /// <param name="value">The <see cref="JSValue" /> to convert.</param>
+    /// <returns><see cref="JSTypedArray&lt;T&gt;" /> struct created based on this `JSValue`.</returns>
+    /// <exception cref="InvalidCastException">
+    /// Thrown when the T struct cannot be created based on this `JSValue`.
+    /// </exception>
     public static explicit operator JSTypedArray<T>(JSValue value)
         => value.CastTo<JSTypedArray<T>>();
 
@@ -122,9 +145,29 @@ public readonly struct JSTypedArray<T> : IJSValue<JSTypedArray<T>>
 
     #region IJSValue<JSTypedArray<T>> implementation
 
+    /// <summary>
+    /// Determines whether a <see cref="JSTypedArray&lt;T&gt;" /> can be created from
+    /// the specified <see cref="JSValue" />.
+    /// </summary>
+    /// <param name="value">The <see cref="JSValue" /> to check.</param>
+    /// <returns>
+    /// <c>true</c> if a <see cref="JSTypedArray&lt;T&gt;" /> can be created from
+    /// the specified <see cref="JSValue" />; otherwise, <c>false</c>.
+    /// </returns>
     public static bool CanCreateFrom(JSValue value)
         => value.IsObject() && value.InstanceOf(JSValue.Global[JSTypeName]);
 
+    /// <summary>
+    /// Creates a new instance of <see cref="JSTypedArray&lt;T&gt;" /> from
+    /// the specified <see cref="JSValue" />.
+    /// </summary>
+    /// <param name="value">
+    /// The <see cref="JSValue" /> to create a <see cref="JSTypedArray&lt;T&gt;" /> from.
+    /// </param>
+    /// <returns>
+    /// A new instance of <see cref="JSTypedArray&lt;T&gt;" /> created from
+    /// the specified <see cref="JSValue" />.
+    /// </returns>
 #if NET7_0_OR_GREATER
     static JSTypedArray<T> IJSValue<JSTypedArray<T>>.CreateUnchecked(JSValue value) => new(value);
 #else
@@ -133,6 +176,12 @@ public readonly struct JSTypedArray<T> : IJSValue<JSTypedArray<T>>
 #pragma warning restore IDE0051
 #endif
 
+    /// <summary>
+    /// Converts the <see cref="JSTypedArray&lt;T&gt;" /> to a <see cref="JSValue" />.
+    /// </summary>
+    /// <returns>
+    /// The <see cref="JSValue" /> representation of the <see cref="JSTypedArray&lt;T&gt;" />.
+    /// </returns>
     public JSValue AsJSValue() => _value;
 
     #endregion

--- a/src/NodeApi/JSTypedArray.cs
+++ b/src/NodeApi/JSTypedArray.cs
@@ -9,6 +9,7 @@ using System.Runtime.InteropServices;
 
 namespace Microsoft.JavaScript.NodeApi;
 
+//TODO: Add support for Uint8ClampedArray
 public readonly struct JSTypedArray<T> : IJSValue<JSTypedArray<T>>
     where T : struct
 {
@@ -46,6 +47,21 @@ public readonly struct JSTypedArray<T> : IJSValue<JSTypedArray<T>>
         ulong => JSTypedArrayType.BigUInt64,
         float => JSTypedArrayType.Float32,
         double => JSTypedArrayType.Float64,
+        _ => throw new InvalidCastException("Invalid typed-array type: " + typeof(T)),
+    };
+
+    private static string JSTypeName { get; } = default(T) switch
+    {
+        sbyte => "Int8Array",
+        byte => "Uint8Array",
+        short => "Int16Array",
+        ushort => "Uint16Array",
+        int => "Int32Array",
+        uint => "Uint32Array",
+        long => "BigInt64Array",
+        ulong => "BigUint64Array",
+        float => "Float32Array",
+        double => "Float64Array",
         _ => throw new InvalidCastException("Invalid typed-array type: " + typeof(T)),
     };
 
@@ -106,8 +122,8 @@ public readonly struct JSTypedArray<T> : IJSValue<JSTypedArray<T>>
 
     #region IJSValue<JSTypedArray<T>> implementation
 
-    //TODO: (vmoroz) Implement correctly
-    public static bool CanCreateFrom(JSValue value) => value.IsObject();
+    public static bool CanCreateFrom(JSValue value)
+        => value.IsObject() && value.InstanceOf(JSValue.Global[JSTypeName]);
 
 #if NET7_0_OR_GREATER
     static JSTypedArray<T> IJSValue<JSTypedArray<T>>.CreateUnchecked(JSValue value) => new(value);

--- a/src/NodeApi/JSTypedArray.cs
+++ b/src/NodeApi/JSTypedArray.cs
@@ -112,7 +112,9 @@ public readonly struct JSTypedArray<T> : IJSValue<JSTypedArray<T>>
 #if NET7_0_OR_GREATER
     static JSTypedArray<T> IJSValue<JSTypedArray<T>>.CreateUnchecked(JSValue value) => new(value);
 #else
+#pragma warning disable IDE0051 // It is used by the IJSValueShim<T> class through reflection.
     private static JSTypedArray<T> CreateUnchecked(JSValue value) => new(value);
+#pragma warning restore IDE0051
 #endif
 
     public JSValue AsJSValue() => _value;

--- a/src/NodeApi/JSValue.cs
+++ b/src/NodeApi/JSValue.cs
@@ -391,6 +391,29 @@ public readonly struct JSValue : IEquatable<JSValue>
 
     public bool IsBigInt() => TypeOf() == JSValueType.BigInt;
 
+    public bool Is<TValue>() where TValue : struct
+#if NET7_0_OR_GREATER
+        , IJSValue<TValue> => TValue.CanBeConvertedFrom(this);
+#else
+        => IJSValueShim<TValue>.CanBeConvertedFrom(this);
+#endif
+
+    public TValue? As<TValue>() where TValue : struct
+#if NET7_0_OR_GREATER
+        , IJSValue<TValue>
+        => TValue.CanBeConvertedFrom(this) ? TValue.CreateUnchecked(this) : default;
+#else
+        => IJSValueShim<TValue>.CanBeConvertedFrom(this)
+            ? IJSValueShim<TValue>.CreateUnchecked(this) : default;
+#endif
+
+    public TValue AsUnchecked<TValue>() where TValue : struct
+#if NET7_0_OR_GREATER
+        , IJSValue<TValue> => TValue.CreateUnchecked(this);
+#else
+        => IJSValueShim<TValue>.CreateUnchecked(this);
+#endif
+
     public double GetValueDouble() => GetRuntime(out napi_env env, out napi_value handle)
         .GetValueDouble(env, handle, out double result).ThrowIfFailed(result);
 

--- a/src/NodeApi/JSValue.cs
+++ b/src/NodeApi/JSValue.cs
@@ -15,7 +15,7 @@ using static Microsoft.JavaScript.NodeApi.Runtime.JSRuntime;
 
 namespace Microsoft.JavaScript.NodeApi;
 
-public readonly struct JSValue : IEquatable<JSValue>
+public readonly struct JSValue : IJSValue<JSValue>
 {
     private readonly napi_value _handle = default;
     private readonly JSValueScope? _scope = null;
@@ -391,6 +391,8 @@ public readonly struct JSValue : IEquatable<JSValue>
 
     public bool IsBigInt() => TypeOf() == JSValueType.BigInt;
 
+    #region IJSValue<JSValue> implementation
+
     /// <summary>
     /// Checks if the T struct can be created from this `JSValue`.
     /// </summary>
@@ -442,6 +444,25 @@ public readonly struct JSValue : IEquatable<JSValue>
     public T CastTo<T>() where T : struct, IJSValue<T>
         => As<T>()
         ?? throw new InvalidCastException("JSValue cannot be casted to target type.");
+
+#if NET7_0_OR_GREATER
+    static bool IJSValue<JSValue>.CanCreateFrom(JSValue _)
+#else
+#pragma warning disable IDE0051 // It is used by the IJSValueShim<T> class through reflection.
+    private static bool CanCreateFrom(JSValue _)
+#pragma warning restore IDE0051
+#endif
+        => true;
+
+#if NET7_0_OR_GREATER
+    static JSValue IJSValue<JSValue>.CreateUnchecked(JSValue value) => value;
+#else
+#pragma warning disable IDE0051 // It is used by the IJSValueShim<T> class through reflection.
+    private static JSValue CreateUnchecked(JSValue value) => value;
+#pragma warning restore IDE0051
+#endif
+
+    #endregion
 
     public double GetValueDouble() => GetRuntime(out napi_env env, out napi_value handle)
         .GetValueDouble(env, handle, out double result).ThrowIfFailed(result);

--- a/src/NodeApi/JSValue.cs
+++ b/src/NodeApi/JSValue.cs
@@ -443,7 +443,8 @@ public readonly struct JSValue : IJSValue<JSValue>
     /// </exception>
     public T CastTo<T>() where T : struct, IJSValue<T>
         => As<T>()
-        ?? throw new InvalidCastException("JSValue cannot be casted to target type.");
+        ?? throw new InvalidCastException(
+            $"JSValue cannot be casted to target type {typeof(T).Name}.");
 
 #if NET7_0_OR_GREATER
     static bool IJSValue<JSValue>.CanCreateFrom(JSValue _)

--- a/src/NodeApi/JSValue.cs
+++ b/src/NodeApi/JSValue.cs
@@ -400,10 +400,10 @@ public readonly struct JSValue : IEquatable<JSValue>
 
     public TValue? As<TValue>() where TValue : struct, IJSValue<TValue>
 #if NET7_0_OR_GREATER
-        => TValue.CanCreateFrom(this) ? TValue.CreateUnchecked(this) : default;
+        => TValue.CanCreateFrom(this) ? TValue.CreateUnchecked(this) : default(TValue?);
 #else
         => IJSValueShim<TValue>.CanCreateFrom(this)
-            ? IJSValueShim<TValue>.CreateUnchecked(this) : default;
+            ? IJSValueShim<TValue>.CreateUnchecked(this) : default(TValue?);
 #endif
 
     public TValue AsUnchecked<TValue>() where TValue : struct, IJSValue<TValue>

--- a/src/node-api-dotnet/pack.js
+++ b/src/node-api-dotnet/pack.js
@@ -70,6 +70,7 @@ function packMainPackage() {
     `NodeApi/${assemblyName}.runtimeconfig.json`,
     `NodeApi/${assemblyName}.dll`,
     `NodeApi.DotNetHost/${assemblyName}.DotNetHost.dll`,
+    `NodeApi/Microsoft.Bcl.AsyncInterfaces.dll`,
     `NodeApi/System.Memory.dll`,
     `NodeApi/System.Runtime.CompilerServices.Unsafe.dll`,
     `NodeApi/System.Threading.Tasks.Extensions.dll`,
@@ -170,6 +171,12 @@ function copyFrameworkSpecificBinaries(targetFrameworks, packageStageDir, ...bin
         tfm.includes('.') &&
         binFileName.startsWith('System.') &&
         !binFileName.includes('MetadataLoadContext')
+      ) return;
+      
+      // Exclude Microsoft.Bcl.AsyncInterfaces from new platforms
+      if (
+        tfm.includes('.') &&
+        binFileName.startsWith('Microsoft.Bcl.AsyncInterfaces')
       ) return;
 
       const binPath = path.join(outBinDir, projectName, tfm, rids[0], binFileName);

--- a/test/TestCases/napi-dotnet/JSValueCast.cs
+++ b/test/TestCases/napi-dotnet/JSValueCast.cs
@@ -67,9 +67,6 @@ public static class JSValueCast
 
     #region JSAsyncIterable
 
-    public static JSValue GetAsyncIterator(JSValue value)
-        => JSValue.Global["Symbol"]["asyncIterator"];
-
     public static string ValueAsAsyncIterable(JSValue value)
         => (JSAsyncIterable?)value is not null ? "ok" : "failed";
 
@@ -153,6 +150,414 @@ public static class JSValueCast
         try
         {
             JSFunction signal = (JSFunction)value;
+            JSValue value2 = signal;
+            return value.Handle == value2.Handle ? "ok" : "failed roundrip";
+        }
+        catch (InvalidCastException)
+        {
+            return "failed";
+        }
+    }
+
+    #endregion
+
+    #region JSIterable
+
+    public static string ValueAsIterable(JSValue value)
+        => (JSIterable?)value is not null ? "ok" : "failed";
+
+    public static string ValueIsIterable(JSValue value)
+        => value.Is<JSIterable>() ? "ok" : "failed";
+
+    public static string ValueCastToIterable(JSValue value)
+    {
+        try
+        {
+            JSIterable signal = (JSIterable)value;
+            JSValue value2 = signal;
+            return value.Handle == value2.Handle ? "ok" : "failed roundrip";
+        }
+        catch (InvalidCastException)
+        {
+            return "failed";
+        }
+    }
+
+    #endregion
+
+    #region JSMap
+
+    public static string ValueAsMap(JSValue value)
+        => (JSMap?)value is not null ? "ok" : "failed";
+
+    public static string ValueIsMap(JSValue value)
+        => value.Is<JSMap>() ? "ok" : "failed";
+
+    public static string ValueCastToMap(JSValue value)
+    {
+        try
+        {
+            JSMap signal = (JSMap)value;
+            JSValue value2 = signal;
+            return value.Handle == value2.Handle ? "ok" : "failed roundrip";
+        }
+        catch (InvalidCastException)
+        {
+            return "failed";
+        }
+    }
+
+    #endregion
+
+    #region JSObject
+
+    public static string ValueAsObject(JSValue value)
+        => (JSObject?)value is not null ? "ok" : "failed";
+
+    public static string ValueIsObject(JSValue value)
+        => value.Is<JSObject>() ? "ok" : "failed";
+
+    public static string ValueCastToObject(JSValue value)
+    {
+        try
+        {
+            JSObject signal = (JSObject)value;
+            JSValue value2 = signal;
+            return value.Handle == value2.Handle ? "ok" : "failed roundrip";
+        }
+        catch (InvalidCastException)
+        {
+            return "failed";
+        }
+    }
+
+    #endregion
+
+    #region JSPromise
+
+    public static string ValueAsPromise(JSValue value)
+        => (JSPromise?)value is not null ? "ok" : "failed";
+
+    public static string ValueIsPromise(JSValue value)
+        => value.Is<JSPromise>() ? "ok" : "failed";
+
+    public static string ValueCastToPromise(JSValue value)
+    {
+        try
+        {
+            JSPromise signal = (JSPromise)value;
+            JSValue value2 = signal;
+            return value.Handle == value2.Handle ? "ok" : "failed roundrip";
+        }
+        catch (InvalidCastException)
+        {
+            return "failed";
+        }
+    }
+
+    #endregion
+
+    #region JSProxy
+
+    public static string ValueAsProxy(JSValue value)
+        => (JSProxy?)value is not null ? "ok" : "failed";
+
+    public static string ValueIsProxy(JSValue value)
+        => value.Is<JSProxy>() ? "ok" : "failed";
+
+    public static string ValueCastToProxy(JSValue value)
+    {
+        try
+        {
+            JSProxy signal = (JSProxy)value;
+            JSValue value2 = signal;
+            return value.Handle == value2.Handle ? "ok" : "failed roundrip";
+        }
+        catch (InvalidCastException)
+        {
+            return "failed";
+        }
+    }
+
+    #endregion
+
+    #region JSSet
+
+    public static string ValueAsSet(JSValue value)
+        => (JSSet?)value is not null ? "ok" : "failed";
+
+    public static string ValueIsSet(JSValue value)
+        => value.Is<JSSet>() ? "ok" : "failed";
+
+    public static string ValueCastToSet(JSValue value)
+    {
+        try
+        {
+            JSSet signal = (JSSet)value;
+            JSValue value2 = signal;
+            return value.Handle == value2.Handle ? "ok" : "failed roundrip";
+        }
+        catch (InvalidCastException)
+        {
+            return "failed";
+        }
+    }
+
+    #endregion
+
+    #region JSSymbol
+
+    public static string ValueAsSymbol(JSValue value)
+        => (JSSymbol?)value is not null ? "ok" : "failed";
+
+    public static string ValueIsSymbol(JSValue value)
+        => value.Is<JSSymbol>() ? "ok" : "failed";
+
+    public static string ValueCastToSymbol(JSValue value)
+    {
+        try
+        {
+            JSSymbol signal = (JSSymbol)value;
+            JSValue value2 = signal;
+            return value.Handle == value2.Handle ? "ok" : "failed roundrip";
+        }
+        catch (InvalidCastException)
+        {
+            return "failed";
+        }
+    }
+
+    #endregion
+
+    #region JSTypedArray<sbyte>
+
+    public static string ValueAsTypedArrayInt8(JSValue value)
+        => (JSTypedArray<sbyte>?)value is not null ? "ok" : "failed";
+
+    public static string ValueIsTypedArrayInt8(JSValue value)
+        => value.Is<JSTypedArray<sbyte>>() ? "ok" : "failed";
+
+    public static string ValueCastToTypedArrayInt8(JSValue value)
+    {
+        try
+        {
+            JSTypedArray<sbyte> signal = (JSTypedArray<sbyte>)value;
+            JSValue value2 = signal;
+            return value.Handle == value2.Handle ? "ok" : "failed roundrip";
+        }
+        catch (InvalidCastException)
+        {
+            return "failed";
+        }
+    }
+
+    #endregion
+
+    #region JSTypedArray<byte>
+
+    public static string ValueAsTypedArrayUint8(JSValue value)
+        => (JSTypedArray<byte>?)value is not null ? "ok" : "failed";
+
+    public static string ValueIsTypedArrayUint8(JSValue value)
+        => value.Is<JSTypedArray<byte>>() ? "ok" : "failed";
+
+    public static string ValueCastToTypedArrayUint8(JSValue value)
+    {
+        try
+        {
+            JSTypedArray<byte> signal = (JSTypedArray<byte>)value;
+            JSValue value2 = signal;
+            return value.Handle == value2.Handle ? "ok" : "failed roundrip";
+        }
+        catch (InvalidCastException)
+        {
+            return "failed";
+        }
+    }
+
+    #endregion
+
+    #region JSTypedArray<short>
+
+    public static string ValueAsTypedArrayInt16(JSValue value)
+        => (JSTypedArray<short>?)value is not null ? "ok" : "failed";
+
+    public static string ValueIsTypedArrayInt16(JSValue value)
+        => value.Is<JSTypedArray<short>>() ? "ok" : "failed";
+
+    public static string ValueCastToTypedArrayInt16(JSValue value)
+    {
+        try
+        {
+            JSTypedArray<short> signal = (JSTypedArray<short>)value;
+            JSValue value2 = signal;
+            return value.Handle == value2.Handle ? "ok" : "failed roundrip";
+        }
+        catch (InvalidCastException)
+        {
+            return "failed";
+        }
+    }
+
+    #endregion
+
+    #region JSTypedArray<ushort>
+
+    public static string ValueAsTypedArrayUint16(JSValue value)
+        => (JSTypedArray<ushort>?)value is not null ? "ok" : "failed";
+
+    public static string ValueIsTypedArrayUint16(JSValue value)
+        => value.Is<JSTypedArray<ushort>>() ? "ok" : "failed";
+
+    public static string ValueCastToTypedArrayUint16(JSValue value)
+    {
+        try
+        {
+            JSTypedArray<ushort> signal = (JSTypedArray<ushort>)value;
+            JSValue value2 = signal;
+            return value.Handle == value2.Handle ? "ok" : "failed roundrip";
+        }
+        catch (InvalidCastException)
+        {
+            return "failed";
+        }
+    }
+
+    #endregion
+
+    #region JSTypedArray<int>
+
+    public static string ValueAsTypedArrayInt32(JSValue value)
+        => (JSTypedArray<int>?)value is not null ? "ok" : "failed";
+
+    public static string ValueIsTypedArrayInt32(JSValue value)
+        => value.Is<JSTypedArray<int>>() ? "ok" : "failed";
+
+    public static string ValueCastToTypedArrayInt32(JSValue value)
+    {
+        try
+        {
+            JSTypedArray<int> signal = (JSTypedArray<int>)value;
+            JSValue value2 = signal;
+            return value.Handle == value2.Handle ? "ok" : "failed roundrip";
+        }
+        catch (InvalidCastException)
+        {
+            return "failed";
+        }
+    }
+
+    #endregion
+
+    #region JSTypedArray<uint>
+
+    public static string ValueAsTypedArrayUint32(JSValue value)
+        => (JSTypedArray<uint>?)value is not null ? "ok" : "failed";
+
+    public static string ValueIsTypedArrayUint32(JSValue value)
+        => value.Is<JSTypedArray<uint>>() ? "ok" : "failed";
+
+    public static string ValueCastToTypedArrayUint32(JSValue value)
+    {
+        try
+        {
+            JSTypedArray<uint> signal = (JSTypedArray<uint>)value;
+            JSValue value2 = signal;
+            return value.Handle == value2.Handle ? "ok" : "failed roundrip";
+        }
+        catch (InvalidCastException)
+        {
+            return "failed";
+        }
+    }
+
+    #endregion
+
+    #region JSTypedArray<long>
+
+    public static string ValueAsTypedArrayBigInt64(JSValue value)
+        => (JSTypedArray<long>?)value is not null ? "ok" : "failed";
+
+    public static string ValueIsTypedArrayBigInt64(JSValue value)
+        => value.Is<JSTypedArray<long>>() ? "ok" : "failed";
+
+    public static string ValueCastToTypedArrayBigInt64(JSValue value)
+    {
+        try
+        {
+            JSTypedArray<long> signal = (JSTypedArray<long>)value;
+            JSValue value2 = signal;
+            return value.Handle == value2.Handle ? "ok" : "failed roundrip";
+        }
+        catch (InvalidCastException)
+        {
+            return "failed";
+        }
+    }
+
+    #endregion
+
+    #region JSTypedArray<ulong>
+
+    public static string ValueAsTypedArrayBigUint64(JSValue value)
+        => (JSTypedArray<ulong>?)value is not null ? "ok" : "failed";
+
+    public static string ValueIsTypedArrayBigUint64(JSValue value)
+        => value.Is<JSTypedArray<ulong>>() ? "ok" : "failed";
+
+    public static string ValueCastToTypedArrayBigUint64(JSValue value)
+    {
+        try
+        {
+            JSTypedArray<ulong> signal = (JSTypedArray<ulong>)value;
+            JSValue value2 = signal;
+            return value.Handle == value2.Handle ? "ok" : "failed roundrip";
+        }
+        catch (InvalidCastException)
+        {
+            return "failed";
+        }
+    }
+
+    #endregion
+
+    #region JSTypedArray<float>
+
+    public static string ValueAsTypedArrayFloat32(JSValue value)
+        => (JSTypedArray<float>?)value is not null ? "ok" : "failed";
+
+    public static string ValueIsTypedArrayFloat32(JSValue value)
+        => value.Is<JSTypedArray<float>>() ? "ok" : "failed";
+
+    public static string ValueCastToTypedArrayFloat32(JSValue value)
+    {
+        try
+        {
+            JSTypedArray<float> signal = (JSTypedArray<float>)value;
+            JSValue value2 = signal;
+            return value.Handle == value2.Handle ? "ok" : "failed roundrip";
+        }
+        catch (InvalidCastException)
+        {
+            return "failed";
+        }
+    }
+
+    #endregion
+
+    #region JSTypedArray<double>
+
+    public static string ValueAsTypedArrayFloat64(JSValue value)
+        => (JSTypedArray<double>?)value is not null ? "ok" : "failed";
+
+    public static string ValueIsTypedArrayFloat64(JSValue value)
+        => value.Is<JSTypedArray<double>>() ? "ok" : "failed";
+
+    public static string ValueCastToTypedArrayFloat64(JSValue value)
+    {
+        try
+        {
+            JSTypedArray<double> signal = (JSTypedArray<double>)value;
             JSValue value2 = signal;
             return value.Handle == value2.Handle ? "ok" : "failed roundrip";
         }

--- a/test/TestCases/napi-dotnet/JSValueCast.cs
+++ b/test/TestCases/napi-dotnet/JSValueCast.cs
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma warning disable IDE0060 // Unused parameters
+#pragma warning disable IDE0301 // Collection initialization can be simplified
+
+using System;
+using System.Collections.Generic;
+using System.Numerics;
+using Interop = Microsoft.JavaScript.NodeApi.Interop;
+
+namespace Microsoft.JavaScript.NodeApi.TestCases;
+
+/// <summary>
+/// Tests type casting between JSValue and IJSValue derived types.
+/// </summary>
+[JSExport]
+public static class JSValueCast
+{
+    [JSExport("testAbortSignalAs")]
+    public static string TestAbortSignalAs(JSValue value)
+    {
+        return (Interop.JSAbortSignal?)value is not null ? "ok" : "fail";
+    }
+
+    [JSExport("testAbortSignalIs")]
+    public static string TestAbortSignalIs(JSValue value)
+    {
+        return value.Is<Interop.JSAbortSignal>() ? "ok" : "fail";
+    }
+
+    [JSExport("testAbortSignalCast")]
+    public static string TestAbortSignalCast(JSValue value)
+    {
+        try
+        {
+            Interop.JSAbortSignal signal = (Interop.JSAbortSignal)value;
+            JSValue value2 = signal;
+            return value.Handle == value2.Handle ? "ok" : "fail roundrip";
+        }
+        catch (InvalidCastException)
+        {
+            return "fail";
+        }
+    }
+}

--- a/test/TestCases/napi-dotnet/JSValueCast.cs
+++ b/test/TestCases/napi-dotnet/JSValueCast.cs
@@ -17,30 +17,150 @@ namespace Microsoft.JavaScript.NodeApi.TestCases;
 [JSExport]
 public static class JSValueCast
 {
-    [JSExport("testAbortSignalAs")]
-    public static string TestAbortSignalAs(JSValue value)
-    {
-        return (Interop.JSAbortSignal?)value is not null ? "ok" : "fail";
-    }
+    #region JSAbortSignal
 
-    [JSExport("testAbortSignalIs")]
-    public static string TestAbortSignalIs(JSValue value)
-    {
-        return value.Is<Interop.JSAbortSignal>() ? "ok" : "fail";
-    }
+    public static string ValueAsAbortSignal(JSValue value)
+        => (Interop.JSAbortSignal?)value is not null ? "ok" : "failed";
 
-    [JSExport("testAbortSignalCast")]
-    public static string TestAbortSignalCast(JSValue value)
+    public static string ValueIsAbortSignal(JSValue value)
+        => value.Is<Interop.JSAbortSignal>() ? "ok" : "failed";
+
+    public static string ValueCastToAbortSignal(JSValue value)
     {
         try
         {
             Interop.JSAbortSignal signal = (Interop.JSAbortSignal)value;
             JSValue value2 = signal;
-            return value.Handle == value2.Handle ? "ok" : "fail roundrip";
+            return value.Handle == value2.Handle ? "ok" : "failed roundrip";
         }
         catch (InvalidCastException)
         {
-            return "fail";
+            return "failed";
         }
     }
+
+    #endregion
+
+    #region JSArray
+
+    public static string ValueAsArray(JSValue value)
+        => (JSArray?)value is not null ? "ok" : "failed";
+
+    public static string ValueIsArray(JSValue value)
+        => value.Is<JSArray>() ? "ok" : "failed";
+
+    public static string ValueCastToArray(JSValue value)
+    {
+        try
+        {
+            JSArray signal = (JSArray)value;
+            JSValue value2 = signal;
+            return value.Handle == value2.Handle ? "ok" : "failed roundrip";
+        }
+        catch (InvalidCastException)
+        {
+            return "failed";
+        }
+    }
+
+    #endregion
+
+    #region JSAsyncIterable
+
+    public static JSValue GetAsyncIterator(JSValue value)
+        => JSValue.Global["Symbol"]["asyncIterator"];
+
+    public static string ValueAsAsyncIterable(JSValue value)
+        => (JSAsyncIterable?)value is not null ? "ok" : "failed";
+
+    public static string ValueIsAsyncIterable(JSValue value)
+        => value.Is<JSAsyncIterable>() ? "ok" : "failed";
+
+    public static string ValueCastToAsyncIterable(JSValue value)
+    {
+        try
+        {
+            JSAsyncIterable signal = (JSAsyncIterable)value;
+            JSValue value2 = signal;
+            return value.Handle == value2.Handle ? "ok" : "failed roundrip";
+        }
+        catch (InvalidCastException)
+        {
+            return "failed";
+        }
+    }
+
+    #endregion
+
+    #region JSBigInt
+
+    public static string ValueAsBigInt(JSValue value)
+        => (JSBigInt?)value is not null ? "ok" : "failed";
+
+    public static string ValueIsBigInt(JSValue value)
+        => value.Is<JSBigInt>() ? "ok" : "failed";
+
+    public static string ValueCastToBigInt(JSValue value)
+    {
+        try
+        {
+            JSBigInt signal = (JSBigInt)value;
+            JSValue value2 = signal;
+            return value.Handle == value2.Handle ? "ok" : "failed roundrip";
+        }
+        catch (InvalidCastException)
+        {
+            return "failed";
+        }
+    }
+
+    #endregion
+
+    #region JSDate
+
+    public static string ValueAsDate(JSValue value)
+        => (JSDate?)value is not null ? "ok" : "failed";
+
+    public static string ValueIsDate(JSValue value)
+        => value.Is<JSDate>() ? "ok" : "failed";
+
+    public static string ValueCastToDate(JSValue value)
+    {
+        try
+        {
+            JSDate signal = (JSDate)value;
+            JSValue value2 = signal;
+            return value.Handle == value2.Handle ? "ok" : "failed roundrip";
+        }
+        catch (InvalidCastException)
+        {
+            return "failed";
+        }
+    }
+
+    #endregion
+
+    #region JSFunction
+
+    public static string ValueAsFunction(JSValue value)
+        => (JSFunction?)value is not null ? "ok" : "failed";
+
+    public static string ValueIsFunction(JSValue value)
+        => value.Is<JSFunction>() ? "ok" : "failed";
+
+    public static string ValueCastToFunction(JSValue value)
+    {
+        try
+        {
+            JSFunction signal = (JSFunction)value;
+            JSValue value2 = signal;
+            return value.Handle == value2.Handle ? "ok" : "failed roundrip";
+        }
+        catch (InvalidCastException)
+        {
+            return "failed";
+        }
+    }
+
+    #endregion
 }

--- a/test/TestCases/napi-dotnet/jsvalue_cast.js
+++ b/test/TestCases/napi-dotnet/jsvalue_cast.js
@@ -78,3 +78,83 @@ assert.strictEqual(JSValueCast.valueIsFunction(() => { }), "ok");
 assert.strictEqual(JSValueCast.valueIsFunction({}), "failed");
 assert.strictEqual(JSValueCast.valueCastToFunction(() => { }), "ok");
 assert.strictEqual(JSValueCast.valueCastToFunction({}), "failed");
+
+assert.strictEqual(typeof JSValueCast.valueAsIterable, 'function');
+assert.strictEqual(typeof JSValueCast.valueIsIterable, 'function');
+assert.strictEqual(typeof JSValueCast.valueCastToIterable, 'function');
+assert.strictEqual(JSValueCast.valueAsIterable([]), "ok");
+assert.strictEqual(JSValueCast.valueAsIterable({}), "failed");
+assert.strictEqual(JSValueCast.valueIsIterable([]), "ok");
+assert.strictEqual(JSValueCast.valueIsIterable({}), "failed");
+assert.strictEqual(JSValueCast.valueCastToIterable([]), "ok");
+assert.strictEqual(JSValueCast.valueCastToIterable({}), "failed");
+
+assert.strictEqual(typeof JSValueCast.valueAsMap, 'function');
+assert.strictEqual(typeof JSValueCast.valueIsMap, 'function');
+assert.strictEqual(typeof JSValueCast.valueCastToMap, 'function');
+assert.strictEqual(JSValueCast.valueAsMap(new Map()), "ok");
+assert.strictEqual(JSValueCast.valueAsMap({}), "failed");
+assert.strictEqual(JSValueCast.valueIsMap(new Map()), "ok");
+assert.strictEqual(JSValueCast.valueIsMap({}), "failed");
+assert.strictEqual(JSValueCast.valueCastToMap(new Map()), "ok");
+assert.strictEqual(JSValueCast.valueCastToMap({}), "failed");
+
+assert.strictEqual(typeof JSValueCast.valueAsObject, 'function');
+assert.strictEqual(typeof JSValueCast.valueIsObject, 'function');
+assert.strictEqual(typeof JSValueCast.valueCastToObject, 'function');
+assert.strictEqual(JSValueCast.valueAsObject({}), "ok");
+assert.strictEqual(JSValueCast.valueAsObject(""), "failed");
+assert.strictEqual(JSValueCast.valueIsObject({}), "ok");
+assert.strictEqual(JSValueCast.valueIsObject(""), "failed");
+assert.strictEqual(JSValueCast.valueCastToObject({}), "ok");
+assert.strictEqual(JSValueCast.valueCastToObject(""), "failed");
+
+assert.strictEqual(typeof JSValueCast.valueAsPromise, 'function');
+assert.strictEqual(typeof JSValueCast.valueIsPromise, 'function');
+assert.strictEqual(typeof JSValueCast.valueCastToPromise, 'function');
+assert.strictEqual(JSValueCast.valueAsPromise(Promise.resolve(123)), "ok");
+assert.strictEqual(JSValueCast.valueAsPromise({}), "failed");
+assert.strictEqual(JSValueCast.valueIsPromise(Promise.resolve(123)), "ok");
+assert.strictEqual(JSValueCast.valueIsPromise({}), "failed");
+assert.strictEqual(JSValueCast.valueCastToPromise(Promise.resolve(123)), "ok");
+assert.strictEqual(JSValueCast.valueCastToPromise({}), "failed");
+
+assert.strictEqual(typeof JSValueCast.valueAsProxy, 'function');
+assert.strictEqual(typeof JSValueCast.valueIsProxy, 'function');
+assert.strictEqual(typeof JSValueCast.valueCastToProxy, 'function');
+assert.strictEqual(JSValueCast.valueAsProxy(new Proxy({}, {})), "ok");
+assert.strictEqual(JSValueCast.valueAsProxy("1"), "failed");
+assert.strictEqual(JSValueCast.valueIsProxy(new Proxy({}, {})), "ok");
+assert.strictEqual(JSValueCast.valueIsProxy("1"), "failed");
+assert.strictEqual(JSValueCast.valueCastToProxy(new Proxy({}, {})), "ok");
+assert.strictEqual(JSValueCast.valueCastToProxy("1"), "failed");
+
+assert.strictEqual(typeof JSValueCast.valueAsSet, 'function');
+assert.strictEqual(typeof JSValueCast.valueIsSet, 'function');
+assert.strictEqual(typeof JSValueCast.valueCastToSet, 'function');
+assert.strictEqual(JSValueCast.valueAsSet(new Set()), "ok");
+assert.strictEqual(JSValueCast.valueAsSet({}), "failed");
+assert.strictEqual(JSValueCast.valueIsSet(new Set()), "ok");
+assert.strictEqual(JSValueCast.valueIsSet({}), "failed");
+assert.strictEqual(JSValueCast.valueCastToSet(new Set()), "ok");
+assert.strictEqual(JSValueCast.valueCastToSet({}), "failed");
+
+assert.strictEqual(typeof JSValueCast.valueAsSymbol, 'function');
+assert.strictEqual(typeof JSValueCast.valueIsSymbol, 'function');
+assert.strictEqual(typeof JSValueCast.valueCastToSymbol, 'function');
+assert.strictEqual(JSValueCast.valueAsSymbol(Symbol.iterator), "ok");
+assert.strictEqual(JSValueCast.valueAsSymbol({}), "failed");
+assert.strictEqual(JSValueCast.valueIsSymbol(Symbol.iterator), "ok");
+assert.strictEqual(JSValueCast.valueIsSymbol({}), "failed");
+assert.strictEqual(JSValueCast.valueCastToSymbol(Symbol.iterator), "ok");
+assert.strictEqual(JSValueCast.valueCastToSymbol({}), "failed");
+
+assert.strictEqual(typeof JSValueCast.valueAsTypedArrayInt8, 'function');
+assert.strictEqual(typeof JSValueCast.valueIsTypedArrayInt8, 'function');
+assert.strictEqual(typeof JSValueCast.valueCastToTypedArrayInt8, 'function');
+assert.strictEqual(JSValueCast.valueAsTypedArrayInt8(new Int8Array(8)), "ok");
+assert.strictEqual(JSValueCast.valueAsTypedArrayInt8({}), "failed");
+assert.strictEqual(JSValueCast.valueIsTypedArrayInt8(new Int8Array(8)), "ok");
+assert.strictEqual(JSValueCast.valueIsTypedArrayInt8({}), "failed");
+assert.strictEqual(JSValueCast.valueCastToTypedArrayInt8(new Int8Array(8)), "ok");
+assert.strictEqual(JSValueCast.valueCastToTypedArrayInt8({}), "failed");

--- a/test/TestCases/napi-dotnet/jsvalue_cast.js
+++ b/test/TestCases/napi-dotnet/jsvalue_cast.js
@@ -9,12 +9,72 @@ const binding = require('../common').binding;
 const JSValueCast = binding.JSValueCast;
 assert.strictEqual(typeof JSValueCast, 'object');
 
-assert.strictEqual(typeof JSValueCast.testAbortSignalAs, 'function');
-assert.strictEqual(typeof JSValueCast.testAbortSignalIs, 'function');
-assert.strictEqual(typeof JSValueCast.testAbortSignalCast, 'function');
-assert.strictEqual(JSValueCast.testAbortSignalAs(AbortSignal.abort()), "ok");
-assert.strictEqual(JSValueCast.testAbortSignalAs({}), "fail");
-assert.strictEqual(JSValueCast.testAbortSignalIs(AbortSignal.abort()), "ok");
-assert.strictEqual(JSValueCast.testAbortSignalIs({}), "fail");
-assert.strictEqual(JSValueCast.testAbortSignalCast(AbortSignal.abort()), "ok");
-assert.strictEqual(JSValueCast.testAbortSignalCast({}), "fail");
+assert.strictEqual(typeof JSValueCast.valueAsAbortSignal, 'function');
+assert.strictEqual(typeof JSValueCast.valueIsAbortSignal, 'function');
+assert.strictEqual(typeof JSValueCast.valueCastToAbortSignal, 'function');
+assert.strictEqual(JSValueCast.valueAsAbortSignal(AbortSignal.abort()), "ok");
+assert.strictEqual(JSValueCast.valueAsAbortSignal({}), "failed");
+assert.strictEqual(JSValueCast.valueIsAbortSignal(AbortSignal.abort()), "ok");
+assert.strictEqual(JSValueCast.valueIsAbortSignal({}), "failed");
+assert.strictEqual(JSValueCast.valueCastToAbortSignal(AbortSignal.abort()), "ok");
+assert.strictEqual(JSValueCast.valueCastToAbortSignal({}), "failed");
+
+assert.strictEqual(typeof JSValueCast.valueAsArray, 'function');
+assert.strictEqual(typeof JSValueCast.valueIsArray, 'function');
+assert.strictEqual(typeof JSValueCast.valueCastToArray, 'function');
+assert.strictEqual(JSValueCast.valueAsArray(["foo"]), "ok");
+assert.strictEqual(JSValueCast.valueAsArray({}), "failed");
+assert.strictEqual(JSValueCast.valueIsArray(["foo"]), "ok");
+assert.strictEqual(JSValueCast.valueIsArray({}), "failed");
+assert.strictEqual(JSValueCast.valueCastToArray(["foo"]), "ok");
+assert.strictEqual(JSValueCast.valueCastToArray({}), "failed");
+
+const asyncIterable = {
+  async *[Symbol.asyncIterator]() {
+    yield await Promise.resolve("a");
+  },
+};
+const asyncIterable2 = Object.create(asyncIterable);
+
+assert.strictEqual(typeof JSValueCast.valueAsAsyncIterable, 'function');
+assert.strictEqual(typeof JSValueCast.valueIsAsyncIterable, 'function');
+assert.strictEqual(typeof JSValueCast.valueCastToAsyncIterable, 'function');
+assert.strictEqual(JSValueCast.valueAsAsyncIterable(asyncIterable), "ok");
+assert.strictEqual(JSValueCast.valueAsAsyncIterable(asyncIterable2), "ok");
+assert.strictEqual(JSValueCast.valueAsAsyncIterable({}), "failed");
+assert.strictEqual(JSValueCast.valueIsAsyncIterable(asyncIterable), "ok");
+assert.strictEqual(JSValueCast.valueIsAsyncIterable(asyncIterable2), "ok");
+assert.strictEqual(JSValueCast.valueIsAsyncIterable({}), "failed");
+assert.strictEqual(JSValueCast.valueCastToAsyncIterable(asyncIterable), "ok");
+assert.strictEqual(JSValueCast.valueCastToAsyncIterable(asyncIterable2), "ok");
+assert.strictEqual(JSValueCast.valueCastToAsyncIterable({}), "failed");
+
+assert.strictEqual(typeof JSValueCast.valueAsBigInt, 'function');
+assert.strictEqual(typeof JSValueCast.valueIsBigInt, 'function');
+assert.strictEqual(typeof JSValueCast.valueCastToBigInt, 'function');
+assert.strictEqual(JSValueCast.valueAsBigInt(42n), "ok");
+assert.strictEqual(JSValueCast.valueAsBigInt({}), "failed");
+assert.strictEqual(JSValueCast.valueIsBigInt(42n), "ok");
+assert.strictEqual(JSValueCast.valueIsBigInt({}), "failed");
+assert.strictEqual(JSValueCast.valueCastToBigInt(42n), "ok");
+assert.strictEqual(JSValueCast.valueCastToBigInt({}), "failed");
+
+assert.strictEqual(typeof JSValueCast.valueAsDate, 'function');
+assert.strictEqual(typeof JSValueCast.valueIsDate, 'function');
+assert.strictEqual(typeof JSValueCast.valueCastToDate, 'function');
+assert.strictEqual(JSValueCast.valueAsDate(new Date()), "ok");
+assert.strictEqual(JSValueCast.valueAsDate({}), "failed");
+assert.strictEqual(JSValueCast.valueIsDate(new Date()), "ok");
+assert.strictEqual(JSValueCast.valueIsDate({}), "failed");
+assert.strictEqual(JSValueCast.valueCastToDate(new Date()), "ok");
+assert.strictEqual(JSValueCast.valueCastToDate({}), "failed");
+
+assert.strictEqual(typeof JSValueCast.valueAsFunction, 'function');
+assert.strictEqual(typeof JSValueCast.valueIsFunction, 'function');
+assert.strictEqual(typeof JSValueCast.valueCastToFunction, 'function');
+assert.strictEqual(JSValueCast.valueAsFunction(() => { }), "ok");
+assert.strictEqual(JSValueCast.valueAsFunction({}), "failed");
+assert.strictEqual(JSValueCast.valueIsFunction(() => { }), "ok");
+assert.strictEqual(JSValueCast.valueIsFunction({}), "failed");
+assert.strictEqual(JSValueCast.valueCastToFunction(() => { }), "ok");
+assert.strictEqual(JSValueCast.valueCastToFunction({}), "failed");

--- a/test/TestCases/napi-dotnet/jsvalue_cast.js
+++ b/test/TestCases/napi-dotnet/jsvalue_cast.js
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+const assert = require('assert');
+
+/** @type {import('./napi-dotnet')} */
+const binding = require('../common').binding;
+
+const JSValueCast = binding.JSValueCast;
+assert.strictEqual(typeof JSValueCast, 'object');
+
+assert.strictEqual(typeof JSValueCast.testAbortSignalAs, 'function');
+assert.strictEqual(typeof JSValueCast.testAbortSignalIs, 'function');
+assert.strictEqual(typeof JSValueCast.testAbortSignalCast, 'function');
+assert.strictEqual(JSValueCast.testAbortSignalAs(AbortSignal.abort()), "ok");
+assert.strictEqual(JSValueCast.testAbortSignalAs({}), "fail");
+assert.strictEqual(JSValueCast.testAbortSignalIs(AbortSignal.abort()), "ok");
+assert.strictEqual(JSValueCast.testAbortSignalIs({}), "fail");
+assert.strictEqual(JSValueCast.testAbortSignalCast(AbortSignal.abort()), "ok");
+assert.strictEqual(JSValueCast.testAbortSignalCast({}), "fail");


### PR DESCRIPTION
This PR implements checked and unchecked casting from/to `JSValue` to other types that wrap `JSValue`.
- `JSValue` has new generic methods: `Is<T>`, `As<T>`, `AsUnchecked<T>`, and `CastTo<T>`.
- These methods are implemented by using the new interface `IJSValue` that has static methods `CanCreateFrom` and `CreateUnchecked`. In case if we targeted .Net version is below version 7.0, it uses `IJSValueShim` helper class that binds to static methods using reflection.
- The types that wrap up the `JSValue` implement these static methods.
- Explicit casting operators are changed to use the new `JSValue.As<T>` method.
- New unit tests are added to test the new casting operations.

Please note that I could not find a good way to differentiate `Proxy` from `Object` and currently any `JSValue` that is an object can be casted to `JSProxy`.