### PR TITLE
Fix typedefs bug with interface circular references

### DIFF
--- a/src/NodeApi.Generator/SymbolExtensions.cs
+++ b/src/NodeApi.Generator/SymbolExtensions.cs
@@ -341,7 +341,8 @@ internal static class SymbolExtensions
         TypeBuilder typeBuilder,
         Type[]? genericTypeParameters)
     {
-        foreach (Type interfaceType in typeSymbol.Interfaces.Select(AsType))
+        foreach (Type interfaceType in typeSymbol.Interfaces.Select(
+            (i) => i.AsType(genericTypeParameters)))
         {
             typeBuilder.AddInterfaceImplementation(interfaceType);
         }


### PR DESCRIPTION
Fixes #195 

Internal calls to `SymbolExtensions.AsType()` should pass the generic type parameters (as all other locations in this file do). That overload also defaults to `buildType: false`, which allows for circular references among types.