### PR TITLE
Use macos-13-arm64 image for osx-arm64

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -27,12 +27,11 @@ parameters:
       VMImage: windows-latest
       TargetRuntime: win-arm64
     - Name: osx_x64
-      VMImage: macos-latest
+      VMImage: macos-13
       TargetRuntime: osx-x64
     - Name: osx_arm64
-      VMImage: macos-latest
+      VMImage: macos-13-arm64
       TargetRuntime: osx-arm64
-      UseGlobalJson: true
     - Name: linux_x64
       VMImage: ubuntu-latest
       TargetRuntime: linux-x64


### PR DESCRIPTION
This PR uses macos-13 image instead of macos-latest which is the macos-12.
For ARM64 we use the macos-13-arm64.