### PR TITLE
Update for Node.js embedding API changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,7 +87,8 @@ jobs:
       continue-on-error: true
 
     - name: Upload test logs
-      uses: actions/upload-artifact@v4
+      # upload-artifact@v4 breaks the test reporter: https://github.com/dorny/test-reporter/issues/343
+      uses: actions/upload-artifact@v3
       with:
         name: test-logs-${{ matrix.os }}-${{matrix.dotnet-version}}-node${{matrix.node-version}}-${{matrix.configuration}}
         path: |

--- a/bench/Benchmarks.cs
+++ b/bench/Benchmarks.cs
@@ -88,7 +88,8 @@ public abstract class Benchmarks
 
         // This setup avoids using NodejsEnvironment so benchmarks can run on the same thread.
         // NodejsEnvironment creates a separate thread that would slow down the micro-benchmarks.
-        platform.Runtime.CreateEnvironment(platform, Console.WriteLine, null, out _env)
+        platform.Runtime.CreateEnvironment(
+            platform, Console.WriteLine, null, NodejsEnvironment.NodeApiVersion, out _env)
             .ThrowIfFailed();
 
         // The new scope instance saves itself as the thread-local JSValueScope.Current.

--- a/src/NodeApi/Runtime/JSRuntime.cs
+++ b/src/NodeApi/Runtime/JSRuntime.cs
@@ -521,7 +521,6 @@ public abstract partial class JSRuntime
 
     public virtual napi_status CreatePlatform(
         string[]? args,
-        string[]? execArgs,
         Action<string>? errorHandler,
         out napi_platform result) => throw NS();
     public virtual napi_status DestroyPlatform(napi_platform platform) => throw NS();
@@ -529,6 +528,7 @@ public abstract partial class JSRuntime
         napi_platform platform,
         Action<string>? errorHandler,
         string? mainScript,
+        int apiVersion,
         out napi_env result) => throw NS();
     public virtual napi_status DestroyEnvironment(napi_env env, out int exitCode) => throw NS();
     public virtual napi_status RunEnvironment(napi_env env) => throw NS();

--- a/src/NodeApi/Runtime/NodejsEnvironment.cs
+++ b/src/NodeApi/Runtime/NodejsEnvironment.cs
@@ -23,6 +23,11 @@ using static JSRuntime;
 /// </remarks>
 public sealed class NodejsEnvironment : IDisposable
 {
+    /// <summary>
+    /// Corresponds to NAPI_VERSION from js_native_api.h.
+    /// </summary>
+    public const int NodeApiVersion = 8;
+
     private readonly JSValueScope _scope;
     private readonly Thread _thread;
     private readonly TaskCompletionSource<bool> _completion = new();
@@ -44,6 +49,7 @@ public sealed class NodejsEnvironment : IDisposable
                 (napi_platform)platform,
                 (error) => Console.WriteLine(error),
                 mainScript,
+                NodeApiVersion,
                 out napi_env env).ThrowIfFailed();
 
             // The new scope instance saves itself as the thread-local JSValueScope.Current.

--- a/src/NodeApi/Runtime/NodejsPlatform.cs
+++ b/src/NodeApi/Runtime/NodejsPlatform.cs
@@ -26,14 +26,12 @@ public sealed class NodejsPlatform : IDisposable
     /// Initializes the Node.js platform.
     /// </summary>
     /// <param name="libnodePath">Path to the `libnode` shared library, including extension.</param>
-    /// <param name="args">Optional application arguments.</param>
-    /// <param name="execArgs">Optional platform options.</param>
+    /// <param name="args">Optional platform arguments.</param>
     /// <exception cref="InvalidOperationException">A Node.js platform instance has already been
     /// loaded in the current process.</exception>
     public NodejsPlatform(
         string libnodePath,
-        string[]? args = null,
-        string[]? execArgs = null)
+        string[]? args = null)
     {
         if (string.IsNullOrEmpty(libnodePath)) throw new ArgumentNullException(nameof(libnodePath));
 
@@ -46,7 +44,7 @@ public sealed class NodejsPlatform : IDisposable
         nint libnodeHandle = NativeLibrary.Load(libnodePath);
         Runtime = new NodejsRuntime(libnodeHandle);
 
-        Runtime.CreatePlatform(args, execArgs, (error) => Console.WriteLine(error), out _platform)
+        Runtime.CreatePlatform(args, (error) => Console.WriteLine(error), out _platform)
             .ThrowIfFailed();
         Current = this;
     }

--- a/src/NodeApi/Runtime/TracingJSRuntime.cs
+++ b/src/NodeApi/Runtime/TracingJSRuntime.cs
@@ -2648,15 +2648,14 @@ public class TracingJSRuntime : JSRuntime
     #region Embedding
 
     public override napi_status CreatePlatform(
-        string[]? args, string[]? execArgs, Action<string>? errorHandler, out napi_platform result)
+        string[]? args, Action<string>? errorHandler, out napi_platform result)
     {
         napi_platform resultValue = default;
         napi_status status = TraceCall(
             [
                 $"[{string.Join(", ", args ?? [])}]",
-                $"[{string.Join(", ", execArgs ?? [])}]",
             ],
-            () => (_runtime.CreatePlatform(args, execArgs, errorHandler, out resultValue),
+            () => (_runtime.CreatePlatform(args, errorHandler, out resultValue),
                 Format(resultValue)));
         result = resultValue;
         return status;
@@ -2673,12 +2672,14 @@ public class TracingJSRuntime : JSRuntime
         napi_platform platform,
         Action<string>? errorHandler,
         string? mainScript,
+        int apiVersion,
         out napi_env result)
     {
         napi_env resultValue = default;
         napi_status status = TraceCall(
             [Format(platform), Format(mainScript)],
-            () => (_runtime.CreateEnvironment(platform, errorHandler, mainScript, out resultValue),
+            () => (_runtime.CreateEnvironment(
+                platform, errorHandler, mainScript, apiVersion, out resultValue),
                 Format(resultValue)));
         result = resultValue;
         return status;

--- a/test/NodejsEmbeddingTests.cs
+++ b/test/NodejsEmbeddingTests.cs
@@ -47,6 +47,14 @@ public class NodejsEmbeddingTests
     }
 
     [SkippableFact]
+    public void NodejsRestart()
+    {
+        // Create and destory a Node.js environment twice, using the same platform instance.
+        NodejsStart();
+        NodejsStart();
+    }
+
+    [SkippableFact]
     public void NodejsCallFunction()
     {
         using NodejsEnvironment nodejs = CreateNodejsEnvironment();


### PR DESCRIPTION
Fixes: #218

There's currently a failing test: the `NodejsRestart` test fails because an attempt to initialize a second environment instance (after destroying the first) crashes the process.

The embedding tests do not currently run in the online builds, because the `libnode` binary is not published, so the test failure is not reported there.