### PR TITLE
JSExport method overload support

### DIFF
--- a/src/NodeApi.Generator/SymbolExtensions.cs
+++ b/src/NodeApi.Generator/SymbolExtensions.cs
@@ -414,7 +414,8 @@ internal static class SymbolExtensions
         IReadOnlyList<IParameterSymbol> parameters = constructorSymbol.Parameters;
         for (int i = 0; i < parameters.Count; i++)
         {
-            constructorBuilder.DefineParameter(i, ParameterAttributes.None, parameters[i].Name);
+            // The parameter index is offset by 1.
+            constructorBuilder.DefineParameter(i + 1, ParameterAttributes.None, parameters[i].Name);
         }
 
         if (isDelegateConstructor)
@@ -556,8 +557,10 @@ internal static class SymbolExtensions
             parameter.Type.AsType(type.GenericTypeArguments, buildType: true);
         }
 
-        ConstructorInfo? constructorInfo = type.GetConstructor(
-            methodSymbol.Parameters.Select((p) => p.Type.AsType()).ToArray());
+        BindingFlags bindingFlags = BindingFlags.Public | BindingFlags.Instance;
+        ConstructorInfo? constructorInfo = type.GetConstructors(bindingFlags)
+            .FirstOrDefault((c) => c.GetParameters().Select((p) => p.Name).SequenceEqual(
+                methodSymbol.Parameters.Select((p) => p.Name)));
         return constructorInfo ?? throw new InvalidOperationException(
                 $"Constructor not found for type: {type.Name}");
     }

--- a/src/NodeApi/Interop/JSPropertyDescriptorListOfT.cs
+++ b/src/NodeApi/Interop/JSPropertyDescriptorListOfT.cs
@@ -215,4 +215,14 @@ public abstract class JSPropertyDescriptorList<TDerived, TObject>
           attributes,
           data);
     }
+
+    public TDerived AddMethod(
+        string name,
+        JSCallbackDescriptor callbackDescriptor,
+        JSPropertyAttributes attributes = JSPropertyAttributes.DefaultMethod)
+    {
+        Properties.Add(JSPropertyDescriptor.Function(
+            name, callbackDescriptor.Callback, attributes, callbackDescriptor.Data));
+        return (TDerived)(object)this;
+    }
 }

--- a/test/TestCases/napi-dotnet/Overloads.cs
+++ b/test/TestCases/napi-dotnet/Overloads.cs
@@ -26,6 +26,11 @@ public class Overloads
         StringValue = stringValue;
     }
 
+    public Overloads(ITestInterface obj)
+    {
+        StringValue = obj.Value;
+    }
+
     public int? IntValue { get; private set; }
 
     public string? StringValue { get; private set; }
@@ -44,6 +49,11 @@ public class Overloads
     {
         IntValue = intValue;
         StringValue = stringValue;
+    }
+
+    public void SetValue(ITestInterface obj)
+    {
+        StringValue = obj.Value;
     }
 
     // Method with overloaded name in C# is given a non-overloaded export name.

--- a/test/TestCases/napi-dotnet/Overloads.cs
+++ b/test/TestCases/napi-dotnet/Overloads.cs
@@ -1,0 +1,55 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.JavaScript.NodeApi.TestCases;
+
+[JSExport]
+public class Overloads
+{
+    public Overloads()
+    {
+    }
+
+    public Overloads(int intValue)
+    {
+        IntValue = intValue;
+    }
+
+    public Overloads(string stringValue)
+    {
+        StringValue = stringValue;
+    }
+
+    public Overloads(int intValue, string stringValue)
+    {
+        IntValue = intValue;
+        StringValue = stringValue;
+    }
+
+    public int? IntValue { get; private set; }
+
+    public string? StringValue { get; private set; }
+
+    public void SetValue(int intValue)
+    {
+        IntValue = intValue;
+    }
+
+    public void SetValue(string stringValue)
+    {
+        StringValue = stringValue;
+    }
+
+    public void SetValue(int intValue, string stringValue)
+    {
+        IntValue = intValue;
+        StringValue = stringValue;
+    }
+
+    // Method with overloaded name in C# is given a non-overloaded export name.
+    [JSExport("setDoubleValue")]
+    public void SetValue(double doubleValue)
+    {
+        IntValue = (int)doubleValue;
+    }
+}

--- a/test/TestCases/napi-dotnet/overloads.js
+++ b/test/TestCases/napi-dotnet/overloads.js
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+const assert = require('assert');
+
+/** @type {import('./napi-dotnet')} */
+const binding = require('../common').binding;
+
+const Overloads = binding.Overloads;
+
+// Overloaded constructor
+const emptyObj = new Overloads();
+assert.strictEqual(emptyObj.intValue, undefined);
+assert.strictEqual(emptyObj.stringValue, undefined);
+
+const intObj = new Overloads(1);
+assert.strictEqual(intObj.intValue, 1);
+assert.strictEqual(intObj.stringValue, undefined);
+
+const stringObj = new Overloads('two');
+assert.strictEqual(stringObj.intValue, undefined);
+assert.strictEqual(stringObj.stringValue, 'two');
+
+const comboObj = new Overloads(3, 'three');
+assert.strictEqual(comboObj.intValue, 3);
+assert.strictEqual(comboObj.stringValue, 'three');
+
+// Overloaded method
+const obj1 = new Overloads();
+obj1.setValue(1);
+assert.strictEqual(obj1.intValue, 1);
+assert.strictEqual(obj1.stringValue, undefined);
+
+const obj2 = new Overloads();
+obj2.setValue('two');
+assert.strictEqual(obj2.intValue, undefined);
+assert.strictEqual(obj2.stringValue, 'two');
+
+const obj3 = new Overloads();
+obj3.setValue(3, 'three');
+assert.strictEqual(obj3.intValue, 3);
+assert.strictEqual(obj3.stringValue, 'three');
+
+const obj4 = new Overloads();
+obj4.setDoubleValue(4.0);
+assert.strictEqual(obj4.intValue, 4);

--- a/test/TestCases/napi-dotnet/overloads.js
+++ b/test/TestCases/napi-dotnet/overloads.js
@@ -7,6 +7,7 @@ const assert = require('assert');
 const binding = require('../common').binding;
 
 const Overloads = binding.Overloads;
+const ClassObject = binding.ClassObject;
 
 // Overloaded constructor
 const emptyObj = new Overloads();
@@ -25,6 +26,11 @@ const comboObj = new Overloads(3, 'three');
 assert.strictEqual(comboObj.intValue, 3);
 assert.strictEqual(comboObj.stringValue, 'three');
 
+const objValue = new ClassObject();
+objValue.value = 'test';
+const objFromClass = new Overloads(objValue);
+assert.strictEqual(objFromClass.stringValue, 'test');
+
 // Overloaded method
 const obj1 = new Overloads();
 obj1.setValue(1);
@@ -42,5 +48,10 @@ assert.strictEqual(obj3.intValue, 3);
 assert.strictEqual(obj3.stringValue, 'three');
 
 const obj4 = new Overloads();
-obj4.setDoubleValue(4.0);
-assert.strictEqual(obj4.intValue, 4);
+obj4.setValue(objValue);
+assert.strictEqual(obj4.stringValue, 'test');
+
+const obj5 = new Overloads();
+obj5.setDoubleValue(5.0);
+assert.strictEqual(obj5.intValue, 5);
+


### PR DESCRIPTION
Fixes: #199
Fixes: #201

This change adds support for exporting multiple methods with the same name using `[JSExport]`, when defining a Node API module in C#. Overloaded constructors were mostly implemented already, but had a bug (#201). Now they are fixed and tested too. Overload resolution is supported in Native AOT modules since it does not depend on reflection. (Advanced overload resolution planned in #134 might require reflection though.)
