### PR TITLE
Marshalling TimeSpan, Guid, BigInt

### DIFF
--- a/src/NodeApi.DotNetHost/JSMarshaller.cs
+++ b/src/NodeApi.DotNetHost/JSMarshaller.cs
@@ -2353,7 +2353,7 @@ public class JSMarshaller
             else if (fromType == typeof(TimeSpan))
             {
                 MethodInfo toString = typeof(TimeSpan).GetInstanceMethod(
-                    nameof(TimeSpan.ToString), Array.Empty<Type>());
+                    nameof(TimeSpan.ToString), []);
                 MethodInfo asJSValue = typeof(JSValue).GetImplicitConversion(
                     typeof(string), typeof(JSValue));
                 statements = new[]
@@ -2364,7 +2364,7 @@ public class JSMarshaller
             else if (fromType == typeof(Guid))
             {
                 MethodInfo toString = typeof(Guid).GetInstanceMethod(
-                    nameof(Guid.ToString), Array.Empty<Type>());
+                    nameof(Guid.ToString), []);
                 MethodInfo asJSValue = typeof(JSValue).GetImplicitConversion(
                     typeof(string), typeof(JSValue));
                 statements = new[]

--- a/src/NodeApi.Generator/SymbolExtensions.cs
+++ b/src/NodeApi.Generator/SymbolExtensions.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Numerics;
 using System.Reflection;
 using System.Reflection.Emit;
 using System.Threading;
@@ -135,7 +136,8 @@ internal static class SymbolExtensions
         string typeFullName = GetTypeSymbolFullName(namedTypeSymbol);
         ITypeSymbol[] genericArguments = namedTypeSymbol.TypeArguments.ToArray();
         Type? systemType = typeof(object).Assembly.GetType(typeFullName) ??
-            typeof(JSValue).Assembly.GetType(typeFullName);
+            typeof(JSValue).Assembly.GetType(typeFullName) ??
+            typeof(BigInteger).Assembly.GetType(typeFullName);
 
         if (systemType != null)
         {

--- a/src/NodeApi.Generator/TypeDefinitionsGenerator.cs
+++ b/src/NodeApi.Generator/TypeDefinitionsGenerator.cs
@@ -1285,6 +1285,9 @@ import { Duplex } from 'stream';
             "System.Double" => "number",
             "System.String" => "string",
             "System.DateTime" => "Date",
+            "System.TimeSpan" => "string",
+            "System.Guid" => "string",
+            "System.Numerics.BigInteger" => "bigint",
             _ => null,
         };
 

--- a/test/TestCases/napi-dotnet/ComplexTypes.cs
+++ b/test/TestCases/napi-dotnet/ComplexTypes.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Numerics;
 
 namespace Microsoft.JavaScript.NodeApi.TestCases;
 
@@ -60,6 +61,8 @@ public static class ComplexTypes
 
     public static DateTime Date { get; set; } = new DateTime(2023, 2, 1, 0, 0, 0, DateTimeKind.Utc);
 
+    public static TimeSpan Time { get; set; } = new TimeSpan(1, 12, 30, 45);
+
     public static KeyValuePair<string, int> Pair { get; set; }
         = new KeyValuePair<string, int>("pair", 1);
 
@@ -67,6 +70,10 @@ public static class ComplexTypes
         = new Tuple<string, int>("tuple", 2);
 
     public static (string Key, int Value) ValueTuple { get; set; } = (Key: "valueTuple", Value: 3);
+
+    public static Guid Guid { get; set; } = Guid.Parse("01234567-89AB-CDEF-FEDC-BA9876543210");
+
+    public static BigInteger BigInt { get; set; } = BigInteger.Parse("1234567890123456789012345");
 }
 
 /// <summary>

--- a/test/TestCases/napi-dotnet/complex_types.js
+++ b/test/TestCases/napi-dotnet/complex_types.js
@@ -166,12 +166,19 @@ assert.strictEqual(ComplexTypes.testEnum, enumType.Zero);
 ComplexTypes.testEnum = enumType.Two;
 assert.strictEqual(ComplexTypes.testEnum, enumType.Two);
 
-// Date
+// DateTime
 const dateValue = ComplexTypes.date;
 assert(dateValue instanceof Date);
 assert.deepStrictEqual(dateValue, new Date("2023-02-01"));
 ComplexTypes.date = new Date("2024-03-02T11:00");
 assert.deepStrictEqual(ComplexTypes.date, new Date("2024-03-02T11:00"));
+
+// TimeSpan
+const timeValue = ComplexTypes.time;
+assert.strictEqual(typeof timeValue, 'string');
+assert.strictEqual(timeValue, '1.12:30:45');
+ComplexTypes.time = '2.23:34:45';
+assert.strictEqual(ComplexTypes.time, '2.23:34:45');
 
 // Tuples
 const pairValue = ComplexTypes.pair;
@@ -189,6 +196,21 @@ assert(Array.isArray(valueTupleValue));
 assert.deepStrictEqual(valueTupleValue, ['valueTuple', 3]);
 ComplexTypes.valueTuple = ['valueTuple', -3];
 assert.deepStrictEqual(ComplexTypes.valueTuple, ['valueTuple', -3]);
+
+// Guid
+assert.strictEqual(ComplexTypes.guid, '01234567-89ab-cdef-fedc-ba9876543210');
+ComplexTypes.guid = 'fedcba98-7654-3210-0123-456789abcdef';
+assert.strictEqual(ComplexTypes.guid, 'fedcba98-7654-3210-0123-456789abcdef');
+
+// BigInteger
+assert.strictEqual(typeof ComplexTypes.bigInt, 'bigint');
+assert.strictEqual(ComplexTypes.bigInt, 1234567890123456789012345n);
+ComplexTypes.bigInt = 987654321098765432109876n;
+assert.strictEqual(ComplexTypes.bigInt, 987654321098765432109876n);
+ComplexTypes.bigInt = -1234567890123456789012345n;
+assert.strictEqual(ComplexTypes.bigInt, -1234567890123456789012345n);
+ComplexTypes.bigInt = 0n;
+assert.strictEqual(ComplexTypes.bigInt, 0n);
 
 // Ref / out parameters
 const results = classInstance.appendAndGetPreviousValue('!');


### PR DESCRIPTION
Fixes: #66 
Fixes: #106

- Marshal .NET `Guid` and `TimeSpan` to/from JS `string`.
  - The `Guid` string format is compatible with the popular JS `uuid` package, but there is no dependency on that package, and it mostly operates on `string` values anyway.
  - A runtime exception with descriptive error message is thrown if the string cannot be parsed when marshalling from JS `string` to a .NET value.
- Marshal .NET `BigInteger` to/from JS `bigint`.
- Update the type-definitions generator accordingly.