### PR TITLE
Use AnyCPU target to support ARM64 and x64 CPUs

### DIFF
--- a/src/NodeApi.DotNetHost/NodeApi.DotNetHost.csproj
+++ b/src/NodeApi.DotNetHost/NodeApi.DotNetHost.csproj
@@ -5,6 +5,7 @@
     <RootNamespace>Microsoft.JavaScript.NodeApi.DotNetHost</RootNamespace>
     <IsPackable>true</IsPackable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NodeApi.Generator/NodeApi.Generator.csproj
+++ b/src/NodeApi.Generator/NodeApi.Generator.csproj
@@ -48,6 +48,7 @@
 
   <PropertyGroup>
     <GetTargetPathDependsOn>$(GetTargetPathDependsOn);GetDependencyTargetPaths</GetTargetPathDependsOn>
+    <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
 
   <Target Name="GetDependencyTargetPaths">

--- a/src/NodeApi/NodeApi.csproj
+++ b/src/NodeApi/NodeApi.csproj
@@ -7,6 +7,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <SelfContained>false</SelfContained>
+    <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(PublishAot)' == 'true' ">


### PR DESCRIPTION
Our .Net assemblies were created CPU-specific.
Thus, when we install an NPM package for Mac or Windows ARM64 we had a crash because assemblies were targeting x64.
In this PR we change the settings to target `AnyCPU`.
In my manual tests I saw it was working on x64 and ARM64 machines (Windows and Mac).

Fixes #179
Fixes #211