### PR TITLE
Fix symbolic type generation bugs

### DIFF
--- a/src/NodeApi.Generator/ModuleGenerator.cs
+++ b/src/NodeApi.Generator/ModuleGenerator.cs
@@ -749,7 +749,8 @@ public class ModuleGenerator : SourceGenerator, ISourceGenerator
         }
 
         if (constructors.Length == 0 || constructors.Any((c) => c.Parameters.Length == 0 ||
-            (c.Parameters.Length == 1 && c.Parameters[0].Type.AsType() == typeof(JSCallbackArgs))))
+            (c.Parameters.Length == 1 &&
+                GetFullName(c.Parameters[0].Type) == typeof(JSCallbackArgs).FullName)))
         {
             return false;
         }
@@ -767,10 +768,10 @@ public class ModuleGenerator : SourceGenerator, ISourceGenerator
         if (method.IsStatic &&
             (method.Parameters.Length == 0 ||
             (method.Parameters.Length == 1 &&
-            method.Parameters[0].Type.AsType() == typeof(JSCallbackArgs))) &&
+            GetFullName(method.Parameters[0].Type) == typeof(JSCallbackArgs).FullName)) &&
             method.Parameters.All((p) => p.RefKind == RefKind.None) &&
             (method.ReturnsVoid ||
-            method.ReturnType.AsType() == typeof(JSValue)))
+            GetFullName(method.ReturnType) == typeof(JSValue).FullName))
         {
             return false;
         }


### PR DESCRIPTION
Fixes: #225

Certain kinds of circular references among type symbols processed by the source-generator could cause exceptions similar to the following:

```
CSC : error NAPI1001: TypeLoadException : Could not load type 'SkiaSharp.ISKSkipObjectRegistration' from assembly 'Microsoft.JavaScript.NodeApi.Generator.SymbolExtensions_1, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.
   at System. Reflection.Emit.RuntimeTypeBuilder.CreateTypeNoLock()
   at System.Reflection.Emit.RuntimeTypeBuilder.CreateTypeInfoImpl()
   at Microsoft.JavaScript.NodeApi.Generator.SymbolExtensions.AsType(ITypeSymbol typeSymbol, Type[] genericTypeParameters , Boolean buildType)
   at Microsoft.JavaScript.NodeApi.Generator.SymbolExtensions.AsType(ITypeSymbol typeSymbol, Type[] g enericTypeParameters, Boolean buildType)
   at Microsoft.JavaScript.NodeApi.Generator.SymbolExtensions.BuildSymbolicMethod (TypeBuilder typeBuilder, IMethodSymbol methodSymbol, Type[] genericTypeParameters)
   at Microsoft.JavaScript.NodeApi.Gen erator.SymbolExtensions.BuildSymbolicTypeMembers(ITypeSymbol typeSymbol, TypeBuilder typeBuilder, Type[] genericTypeParam eters)
   at Microsoft.JavaScript.NodeApi.Generator.SymbolExtensions.BuildSymbolicObjectType(INamedTypeSymbol typeSymbol,  String typeFullName, Type[] genericTypeParameters, Boolean buildType)
   at Microsoft.JavaScript.NodeApi.Generator.SymbolE xtensions.AsType(ITypeSymbol typeSymbol, Type[] genericTypeParameters, Boolean buildType)
   at Microsoft.JavaScript.NodeA pi.Generator.SymbolExtensions.BuildSymbolicMethod(TypeBuilder typeBuilder, IMethodSymbol methodSymbol, Type[] genericType Parameters)
   at Microsoft.JavaScript.NodeApi.Generator.SymbolExtensions.BuildSymbolicTypeMembers(ITypeSymbol typeSymbol,  TypeBuilder typeBuilder, Type[] genericTypeParameters) 
```
The fix for the this kind of exception is to ensure base types and interfaces are built before building another type.

```
CSC : error NAPI1001: InvalidOperationException : Unable to change after type has been created.
   at System.Reflection.Emit.RuntimeTypeBuilder.ThrowIfCreated()
   at System.Reflection.Emit.RuntimeMethodBuilder.DefineParameterCore(Int32 position, ParameterAttributes attributes, String strParamName)
   at Microsoft.JavaScript.NodeApi.Generator.SymbolExtensions.BuildSymbolicParameters(MethodBuilder methodBuilder, IReadOnlyList`1 parameters)
   at Microsoft.JavaScript.NodeApi.Generator.SymbolExtensions.BuildSymbolicMethod(TypeBuilder typeBuilder, IMethodSymbol methodSymbol, Type[] genericTypeParameters)
   at Microsoft.JavaScript.NodeApi.Generator.SymbolExtensions.BuildSymbolicTypeMembers(ITypeSymbol typeSymbol, TypeBuilder typeBuilder, Type[] genericTypeParameters)
   at Microsoft.JavaScript.NodeApi.Generator.SymbolExtensions.BuildSymbolicObjectType(INamedTypeSymbol typeSymbol, String typeFullName, Type[] genericTypeParameters, Boolean buildType)
   at Microsoft.JavaScript.NodeApi.Generator.SymbolExtensions.AsType(ITypeSymbol typeSymbol, Type[] genericTypeParameters, Boolean buildType)
   at Microsoft.JavaScript.NodeApi.Generator.SymbolExtensions.BuildSymbolicMethod(TypeBuilder typeBuilder, IMethodSymbol methodSymbol, Type[] genericTypeParameters)
   at Microsoft.JavaScript.NodeApi.Generator.SymbolExtensions.BuildSymbolicTypeMembers(ITypeSymbol typeSymbol, TypeBuilder typeBuilder, Type[] genericTypeParameters)
   at Microsoft.JavaScript.NodeApi.Generator.SymbolExtensions.BuildSymbolicObjectType(INamedTypeSymbol typeSymbol, String typeFullName, Type[] genericTypeParameters, Boolean buildType)
```

The fix for this is mostly to avoid building the type too soon while constructing the type graph.