### PR TITLE
Fix typedefs module export

### DIFF
--- a/src/NodeApi.Generator/TypeDefinitionsGenerator.cs
+++ b/src/NodeApi.Generator/TypeDefinitionsGenerator.cs
@@ -373,6 +373,11 @@ dotnet.load(assemblyName);
         s += "export * from 'node-api-dotnet';";
         s += "}";
 
+        // Re-export this module's types directly from the module index.
+        // This supports a direct import of the module file.
+        s++;
+        s += "export * from 'node-api-dotnet';";
+
         return s;
     }
 


### PR DESCRIPTION
This fixes a regression that prevented the type definitions from resolving correctly in some scenarios. I'm not sure exactly when this regressed, but type definitions have been broken for some of the example projects for at least a couple weeks. With this fix, I've checked all the test projects and example projects to verify that type definitions are resolved.