### PR TITLE
Fix generator bug with derived reference in base class

### DIFF
--- a/test/TestCases/napi-dotnet/ComplexTypes.cs
+++ b/test/TestCases/napi-dotnet/ComplexTypes.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#pragma warning disable IDE0060 // Unused parameters
 #pragma warning disable IDE0301 // Collection initialization can be simplified
 
 using System;
@@ -183,7 +184,7 @@ public enum TestEnum
 // Ensure module generation handles circular references between a base class and derived class.
 public class BaseClass
 {
-    protected BaseClass(int x) {}
+    protected BaseClass(int x) { }
 
     public DerivedClass? Derived { get; set; }
 }
@@ -191,5 +192,5 @@ public class BaseClass
 [JSExport]
 public class DerivedClass : BaseClass
 {
-    public DerivedClass(int x) : base(x) {}
+    public DerivedClass(int x) : base(x) { }
 }

--- a/test/TestCases/napi-dotnet/ComplexTypes.cs
+++ b/test/TestCases/napi-dotnet/ComplexTypes.cs
@@ -179,3 +179,17 @@ public enum TestEnum
     One,
     Two,
 }
+
+// Ensure module generation handles circular references between a base class and derived class.
+public class BaseClass
+{
+    protected BaseClass(int x) {}
+
+    public DerivedClass? Derived { get; set; }
+}
+
+[JSExport]
+public class DerivedClass : BaseClass
+{
+    public DerivedClass(int x) : base(x) {}
+}


### PR DESCRIPTION
Fixes: #233

This fixes a bug in `SymbolExtensions` while converting symbolic types to runtime types. In the case of a base class that referenced a derived class (and had a nontrivial constructor), the type would not be built even when the `buildType=true` parameter was specified. It caused a build error:

> NotSupportedException: The invoked member is not supported before the type is created.

I suggest hiding whitespace differences when reviewing, since most changed lines are just indentation.
