### PR TITLE
Fix generator bug handling generic parameter

### DIFF
--- a/src/NodeApi.Generator/SymbolExtensions.cs
+++ b/src/NodeApi.Generator/SymbolExtensions.cs
@@ -108,7 +108,8 @@ internal static class SymbolExtensions
                 throw new NotSupportedException("Multi-dimensional arrays are not supported.");
             }
 
-            return arrayTypeSymbol.ElementType.AsType(genericTypeParameters).MakeArrayType();
+            return arrayTypeSymbol.ElementType.AsType(genericTypeParameters, buildType)
+                .MakeArrayType();
         }
 
         if (typeSymbol is ITypeParameterSymbol typeParameterSymbol)
@@ -143,8 +144,9 @@ internal static class SymbolExtensions
         {
             if (genericArguments.Length > 0)
             {
-                systemType = systemType.MakeGenericType(
-                    genericArguments.Select((t) => t.AsType(genericTypeParameters)).ToArray());
+                systemType = systemType.MakeGenericType(genericArguments
+                    .Select((t) => t.AsType(genericTypeParameters, buildType))
+                    .ToArray());
             }
 
             return systemType;
@@ -158,8 +160,9 @@ internal static class SymbolExtensions
         {
             if (genericArguments.Length > 0)
             {
-                symbolicType = symbolicType.MakeGenericType(
-                    genericArguments.Select((t) => t.AsType(genericTypeParameters)).ToArray());
+                symbolicType = symbolicType.MakeGenericType(genericArguments
+                    .Select((t) => t.AsType(genericTypeParameters, buildType))
+                    .ToArray());
             }
 
             if (buildType && symbolicType is TypeBuilder typeBuilder)
@@ -190,8 +193,9 @@ internal static class SymbolExtensions
 
         if (genericArguments.Length > 0)
         {
-            symbolicType = symbolicType.MakeGenericType(
-                genericArguments.Select((t) => t.AsType(genericTypeParameters)).ToArray());
+            symbolicType = symbolicType.MakeGenericType(genericArguments
+                .Select((t) => t.AsType(genericTypeParameters, buildType))
+                .ToArray());
         }
 
         return symbolicType;

--- a/test/TestCases/napi-dotnet/ComplexTypes.cs
+++ b/test/TestCases/napi-dotnet/ComplexTypes.cs
@@ -160,6 +160,11 @@ public class ClassObject : ITestInterface
     {
         obj.AppendGenericValue<int>(value);
     }
+
+    public static void WithGenericList(IList<StructObject> list)
+    {
+        // This just ensures the TS generator can handle generic parameter types.
+    }
 #endif
 
     public class NestedClass


### PR DESCRIPTION
The module-generator or typedefs-generator tool could fail when handling a method with a parameter that had another type in the same assembly as a generic type argument. The fix ensures the generic type argument is "built" (if requested) before being used in the method parameter.