### PR TITLE
Fix marshalling of classes that override Equals

### DIFF
--- a/test/TestCases/napi-dotnet/ComplexTypes.cs
+++ b/test/TestCases/napi-dotnet/ComplexTypes.cs
@@ -91,6 +91,16 @@ public struct StructObject
 {
     public string? Value { get; set; }
 
+    public override bool Equals(object? obj)
+    {
+        return obj is StructObject structObject && Value == structObject.Value;
+    }
+
+    public override int GetHashCode()
+    {
+        return Value?.GetHashCode() ?? 0;
+    }
+
     public static string? StaticValue { get; set; }
 
     public readonly StructObject ThisObject() => this;
@@ -120,6 +130,16 @@ public interface ITestInterface
 public class ClassObject : ITestInterface
 {
     public string? Value { get; set; }
+
+    public override bool Equals(object? obj)
+    {
+        return obj is ClassObject classObject && Value == classObject.Value;
+    }
+
+    public override int GetHashCode()
+    {
+        return Value?.GetHashCode() ?? 0;
+    }
 
     public string AppendValue(string append)
     {

--- a/test/TestCases/napi-dotnet/complex_types.js
+++ b/test/TestCases/napi-dotnet/complex_types.js
@@ -284,3 +284,34 @@ assert.strictEqual(
 // It should still be possible to get an instance that was constructed some other way.
 const instanceWithPrivateConstructor = ClassWithPrivateConstructor.createInstance('test');
 assert.strictEqual(instanceWithPrivateConstructor.value, 'test');
+
+// Check that class and struct instances can be round-tripped and are not mixed up by equality.
+const classInstanceA = new ClassObject('test');
+const classInstanceB = new ClassObject('test');
+assert(classInstanceA !== classInstanceB); // Reference inequality.
+assert(classInstanceA.equals(classInstanceB)); // Value equality (C#).
+assert.deepStrictEqual(classInstanceA, classInstanceB); // Value equality (JS).
+// Classes are marshalled by reference so they maintain both value and reference equality.
+ComplexTypes.classObject = classInstanceA;
+assert(ComplexTypes.classObject.equals(classInstanceA));
+assert(ComplexTypes.classObject.equals(classInstanceB));
+assert.deepStrictEqual(ComplexTypes.classObject, classInstanceA);
+assert.deepStrictEqual(ComplexTypes.classObject, classInstanceB);
+assert(ComplexTypes.classObject === classInstanceA);
+assert(ComplexTypes.classObject !== classInstanceB);
+ComplexTypes.classObject = classInstanceB;
+assert(ComplexTypes.classObject.equals(classInstanceA));
+assert(ComplexTypes.classObject.equals(classInstanceB));
+assert(ComplexTypes.classObject !== classInstanceA);
+assert(ComplexTypes.classObject === classInstanceB);
+
+const structInstanceA = new StructObject();
+structInstanceA.value = 'test';
+const structInstanceB = new StructObject();
+structInstanceB.value = 'test';
+assert(structInstanceA !== structInstanceB); // Reference inequality.
+assert.deepStrictEqual(structInstanceA, structInstanceB); // Value equality.
+ComplexTypes.structObject = structInstanceA;
+// Structs are marshalled by value so they maintain value equality but not reference equality.
+assert.deepStrictEqual(ComplexTypes.structObject, structInstanceA);
+assert.deepStrictEqual(ComplexTypes.structObject, structInstanceB);

--- a/test/TestCases/napi-dotnet/dynamic_invoke.js
+++ b/test/TestCases/napi-dotnet/dynamic_invoke.js
@@ -16,7 +16,7 @@ assert.strictEqual(version.ToString(), '1.2.3');
 assert.strictEqual(version + '.4', '1.2.3.4'); // Implicit call to .NET ToString()
 
 const parsedVersion = Version.TryParse('1.2.3'); // Try* pattern returns result or undefined.
-assert.strictEqual(version, parsedVersion);
+assert.deepStrictEqual(version, parsedVersion);
 assert.strictEqual(undefined, Version.TryParse('invalid'));
 
 // Load the test module using dynamic binding `load()` instead of static binding `require()`.


### PR DESCRIPTION
Updates/supersedes PR #156 

Class objects are marshalled by reference and therefore must use reference equality in the object map. Previously, a class overrides `Equals()` to implement value quality semantics would get confused by the marshaller (object map) with other instances that were value-equal.

Structs are marshalled by value, not tracked in the object map, and are not guaranteed to maintain reference equality after marshalling.