### PR TITLE
Fix memory leak from marshalling objects

### DIFF
--- a/src/NodeApi/Interop/JSCallbackDescriptor.cs
+++ b/src/NodeApi/Interop/JSCallbackDescriptor.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Diagnostics;
 
 namespace Microsoft.JavaScript.NodeApi.Interop;
 
@@ -10,6 +11,7 @@ namespace Microsoft.JavaScript.NodeApi.Interop;
 /// callback or standalone function callback. Enables passing a data object via the callback
 /// args data.
 /// </summary>
+[DebuggerDisplay("{Name,nq}()")]
 public readonly struct JSCallbackDescriptor
 {
     /// <summary>

--- a/src/NodeApi/Interop/JSRuntimeContext.cs
+++ b/src/NodeApi/Interop/JSRuntimeContext.cs
@@ -358,7 +358,14 @@ public sealed class JSRuntimeContext : IDisposable
         {
             // No wrapper was found in the map for the object. Create a new one.
             wrapperReference = CreateWrapper(obj);
+
+            // Use AddOrUpdate() in case the constructor just added the object.
+#if NETFRAMEWORK
+            _objectMap.Remove(obj);
             _objectMap.Add(obj, wrapperReference);
+#else
+            _objectMap.AddOrUpdate(obj, wrapperReference);
+#endif
         }
         else
         {

--- a/src/NodeApi/JSPropertyDescriptor.cs
+++ b/src/NodeApi/JSPropertyDescriptor.cs
@@ -2,10 +2,12 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Diagnostics;
 using Microsoft.JavaScript.NodeApi.Interop;
 
 namespace Microsoft.JavaScript.NodeApi;
 
+[DebuggerDisplay("{Name,nq}")]
 public readonly struct JSPropertyDescriptor
 {
     /// <summary>

--- a/src/NodeApi/Runtime/NodejsEnvironment.cs
+++ b/src/NodeApi/Runtime/NodejsEnvironment.cs
@@ -57,16 +57,11 @@ public sealed class NodejsEnvironment : IDisposable
             scope = new JSValueScope(JSValueScopeType.Root, env, platform.Runtime);
             syncContext = scope.RuntimeContext.SynchronizationContext;
 
-            if (string.IsNullOrEmpty(baseDir))
-            {
-                baseDir = ".";
-            }
-            else
+            if (!string.IsNullOrEmpty(baseDir))
             {
                 JSValue.Global.SetProperty("__dirname", baseDir!);
+                InitializeModuleImportFunctions(scope.RuntimeContext, baseDir!);
             }
-
-            InitializeModuleImportFunctions(scope.RuntimeContext, baseDir!);
 
             loadedEvent.Set();
 

--- a/src/NodeApi/Runtime/NodejsPlatform.cs
+++ b/src/NodeApi/Runtime/NodejsPlatform.cs
@@ -78,7 +78,7 @@ public sealed class NodejsPlatform : IDisposable
     /// </summary>
     /// <param name="baseDir">Optional directory that is used as the base directory when resolving
     /// imported modules, and also as the value of the global `__dirname` property. If unspecified,
-    /// modules are resolved relative to the process CWD and `__dirname` is undefined.</param>
+    /// importing modules is not enabled and `__dirname` is undefined.</param>
     /// <param name="mainScript">Optional script to run in the environment. (Literal script content,
     /// not a path to a script file.)</param>
     /// <returns>A new <see cref="NodejsEnvironment" /> instance.</returns>


### PR DESCRIPTION
Fixes #250 

The primary change is to use `ConditionalWeakTable<object, JSReference>` so that the (.NET object) keys are weakly-referenced. The JS object value references were already weak.