### PR TITLE
Eliminate .NET version .js suffix in module import

### DIFF
--- a/Docs/dynamic-invoke.md
+++ b/Docs/dynamic-invoke.md
@@ -57,9 +57,8 @@ For examples of this scenario, see
     ```
 
    To load a specific version of .NET, append the target framework moniker to the module name.
-   A `.js` suffix is required when using ES modules, optional with CommonJS.
    ```JavaScript
-   import dotnet from 'node-api-dotnet/net6.0.js'
+   import dotnet from 'node-api-dotnet/net6.0'
    ```
    Currently the supported target frameworks are `net472`, `net6.0`, and `net8.0`.
 

--- a/Docs/node-module.md
+++ b/Docs/node-module.md
@@ -76,9 +76,8 @@ For a minimal example of this scenario, see
     ```
 
    To load a specific version of .NET, append the target framework moniker to the module name.
-   A `.js` suffix is required when using ES modules, optional with CommonJS.
    ```JavaScript
-   import dotnet from 'node-api-dotnet/net6.0.js'
+   import dotnet from 'node-api-dotnet/net6.0'
    ```
    Currently the supported target frameworks are `net472`, `net6.0`, and `net8.0`.
 

--- a/src/node-api-dotnet/package.json
+++ b/src/node-api-dotnet/package.json
@@ -2,10 +2,13 @@
   "name": "node-api-dotnet",
   "version": "0.1.0",
   "description": "Node-API bindings for .Net",
-  "main": "index.js",
   "license": "MIT",
   "author": "Microsoft",
   "scripts": {
+  },
+  "type": "commonjs",
+  "exports": {
+    ".": "./index.js"
   },
   "types": "./index.d.ts",
   "keywords": [

--- a/test/TestCases/napi-dotnet/ComplexTypes.cs
+++ b/test/TestCases/napi-dotnet/ComplexTypes.cs
@@ -255,6 +255,6 @@ public class CollectionOfClassObjects : IEnumerable<ClassObject>
 public class Equatable : IEquatable<Equatable>
 {
     public bool Equals(Equatable? other) => other != null;
-    public override bool Equals(object obj) => obj is Equatable;
+    public override bool Equals(object? obj) => obj is Equatable;
     public override int GetHashCode() => 1;
 }

--- a/test/TestCases/projects/js-esm/net472.js
+++ b/test/TestCases/projects/js-esm/net472.js
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import assert from 'assert';
-import dotnet from 'node-api-dotnet/net472.js';
+import dotnet from 'node-api-dotnet/net472';
 
 import './bin/mscorlib.js';
 

--- a/test/TestCases/projects/js-esm/net6.0.js
+++ b/test/TestCases/projects/js-esm/net6.0.js
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import assert from 'assert';
-import dotnet from 'node-api-dotnet/net6.0.js';
+import dotnet from 'node-api-dotnet/net6.0';
 
 import './bin/System.Runtime.js';
 import './bin/System.Console.js';

--- a/test/TestCases/projects/js-esm/net8.0.js
+++ b/test/TestCases/projects/js-esm/net8.0.js
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import assert from 'assert';
-import dotnet from 'node-api-dotnet/net8.0.js';
+import dotnet from 'node-api-dotnet/net8.0';
 
 import './bin/System.Runtime.js';
 import './bin/System.Console.js';

--- a/test/TestCases/projects/ts-esm/net472.ts
+++ b/test/TestCases/projects/ts-esm/net472.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import * as assert from 'assert';
-import dotnet from 'node-api-dotnet/net472.js';
+import dotnet from 'node-api-dotnet/net472';
 
 import './bin/mscorlib.js';
 

--- a/test/TestCases/projects/ts-esm/net6.0.ts
+++ b/test/TestCases/projects/ts-esm/net6.0.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import * as assert from 'assert';
-import dotnet from 'node-api-dotnet/net6.0.js';
+import dotnet from 'node-api-dotnet/net6.0';
 
 import './bin/System.Runtime.js';
 import './bin/System.Console.js';

--- a/test/TestCases/projects/ts-esm/net8.0.ts
+++ b/test/TestCases/projects/ts-esm/net8.0.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import * as assert from 'assert';
-import dotnet from 'node-api-dotnet/net8.0.js';
+import dotnet from 'node-api-dotnet/net8.0';
 
 import './bin/System.Runtime.js';
 import './bin/System.Console.js';


### PR DESCRIPTION
This fixes a small usability issue that has been bugging me while writing docs...

When loading a specific version of .NET using ES `import`, the `.js` suffix was required after the target framework moniker:

```JavaScript
import dotnet from 'node-api-dotnet/net6.0.js'
```

While the `.js` suffix is normal for importing ES module files, the versions are not really meant to be modules but alternative entry-points. Anyway this uses the `exports` property in `package.json` to declare those entry-points without a `.js` suffix:

```JavaScript
import dotnet from 'node-api-dotnet/net6.0'
```

(Package entry-points can be conditional and work with CommonJS also. I might use them in some other ways in the future.)