### PR TITLE
Fix build errors due to indexers

### DIFF
--- a/src/NodeApi.Generator/ExpressionExtensions.cs
+++ b/src/NodeApi.Generator/ExpressionExtensions.cs
@@ -120,6 +120,13 @@ internal static class ExpressionExtensions
                 "[" + ToCS(index.Arguments[0], path, variables) + "]",
 
             MethodCallExpression { Method.IsSpecialName: true } call =>
+                call.Method.Name == "get_Item" && call.Arguments.Count >= 1 ?
+                    WithParentheses(call.Object!, path, variables) +
+                        FormatArgs(call.Arguments, path, variables, "[]") :
+                call.Method.Name == "set_Item" && call.Arguments.Count >= 2 ?
+                    WithParentheses(call.Object!, path, variables) + FormatArgs(
+                        call.Arguments.Take(call.Arguments.Count - 1), path, variables, "[]") +
+                        " = " + ToCS(call.Arguments.Last(), path, variables) :
 #if NETFRAMEWORK
                 call.Method.Name.StartsWith("get_") ?
                     (call.Method.IsStatic ?
@@ -390,6 +397,11 @@ internal static class ExpressionExtensions
     private static string FormatArgs(
         IEnumerable<Expression> arguments,
         string path,
-        HashSet<string>? variables)
-        => "(" + string.Join(", ", arguments.Select((a) => ToCS(a, path, variables))) + ")";
+        HashSet<string>? variables,
+        string brackets = "()")
+    {
+        char start = brackets[0];
+        char end = brackets[1];
+        return start + string.Join(", ", arguments.Select((a) => ToCS(a, path, variables))) + end;
+    }
 }

--- a/src/NodeApi.Generator/ModuleGenerator.cs
+++ b/src/NodeApi.Generator/ModuleGenerator.cs
@@ -567,7 +567,17 @@ public class ModuleGenerator : SourceGenerator, ISourceGenerator
         {
             if (member is IPropertySymbol property)
             {
-                ExportProperty(ref s, property, GetExportName(member));
+                if (property.Parameters.Any())
+                {
+                    ReportWarning(
+                        DiagnosticId.UnsupportedIndexer,
+                        property,
+                        $"Exporting indexers is not supported.");
+                }
+                else
+                {
+                    ExportProperty(ref s, property, GetExportName(member));
+                }
             }
             else if (type.TypeKind == TypeKind.Enum && member is IFieldSymbol field)
             {

--- a/src/NodeApi.Generator/SourceGenerator.cs
+++ b/src/NodeApi.Generator/SourceGenerator.cs
@@ -41,6 +41,7 @@ public abstract class SourceGenerator
         UnsupportedMethodParameterType,
         UnsupportedMethodReturnType,
         UnsupportedOverloads,
+        UnsupportedIndexer,
         ReferenedTypeNotExported,
         ESModulePropertiesAreConst,
     }

--- a/src/NodeApi.Generator/SymbolExtensions.cs
+++ b/src/NodeApi.Generator/SymbolExtensions.cs
@@ -643,12 +643,19 @@ internal static class SymbolExtensions
     {
         Type type = propertySymbol.ContainingType.AsType();
 
-        // Ensure the property type is built.
-        propertySymbol.Type.AsType(type.GenericTypeArguments, buildType: true);
+        Type propertyType = propertySymbol.Type.AsType(type.GenericTypeArguments, buildType: true);
+        Type[] parameterTypes = propertySymbol.Parameters.Select(
+            (p) => p.Type.AsType(type.GenericTypeArguments, buildType: true)).ToArray();
 
         BindingFlags bindingFlags = BindingFlags.Public |
             (propertySymbol.IsStatic ? BindingFlags.Static : BindingFlags.Instance);
-        PropertyInfo? propertyInfo = type.GetProperty(propertySymbol.Name, bindingFlags);
+        PropertyInfo? propertyInfo = type.GetProperty(
+            propertySymbol.Name,
+            bindingFlags,
+            null,
+            propertyType,
+            parameterTypes,
+            null);
         return propertyInfo ?? throw new InvalidOperationException(
                 $"Property not found: {type.Name}.{propertySymbol.Name}");
     }


### PR DESCRIPTION
Fixes: #270 
Fixes: #271 

 - Exclude indexers from module exports for now, with a warning.
 - Fix a couple things which are not really needed as long as indexers aren't exported by the module generator, but might be helpful in the future:
    - Handle indexer properties when converting expression trees to C# code.
    - Handle multiple indexers on one class when converting type symbols to types.

JavaScript doesn't support C# style indexers. (Technically it could with proxies, but I don't think we want to make every .NET object a proxy.) We could do something else like generate get/set methods for the indexer, but that would be more work. For now it's a good improvement that at least indexers won't break the build.