### PR TITLE
Make the source-generator target .NET Standard 2.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
-    <TargetFrameworks Condition=" '$(TargetFrameworks)' == '' and ! $([MSBuild]::IsOsPlatform('Windows')) ">net8.0;net6.0</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(TargetFrameworks)' == '' and $([MSBuild]::IsOsPlatform('Windows')) ">net8.0;net6.0;net472</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(TargetFrameworks)' == '' and ! $([MSBuild]::IsOsPlatform('Windows')) ">net8.0;net6.0;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(TargetFrameworks)' == '' and $([MSBuild]::IsOsPlatform('Windows')) ">net8.0;net6.0;netstandard2.0;net472</TargetFrameworks>
     <TargetFrameworks Condition=" '$(PublishAot)' == 'true' ">net8.0</TargetFrameworks>
     <LangVersion>12</LangVersion>
     <Nullable>enable</Nullable>
@@ -50,6 +50,21 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' != 'net472' ">
     <NetFramework>false</NetFramework>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <DefineConstants>$(DefineConstants);NETSTANDARD</DefineConstants>
+    <NetStandard>true</NetStandard>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(TargetFramework)' != 'netstandard2.0' ">
+    <NetStandard>false</NetStandard>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" !$(NetFramework) AND !$(NetStandard) ">
+    <!-- A few runtime features are unavailable in .NET Framework and require conditional compilation. -->
+    <DefineConstants>$(DefineConstants);UNMANAGED_DELEGATES</DefineConstants>
+    <DefineConstants>$(DefineConstants);STRING_AS_SPAN</DefineConstants>
+    <DefineConstants>$(DefineConstants);STREAM_MEMORY</DefineConstants>
+    <DefineConstants>$(DefineConstants);READONLY_SET</DefineConstants>
   </PropertyGroup>
 
   <Import Project="./rid.props" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,12 +5,13 @@
   <ItemGroup>
     <PackageVersion Include="BenchmarkDotNet" Version="0.13.5" />
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.3.0" /><!-- 4.3.0 is compatible with .NET 6 -->
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.1.0" /><!-- 4.1.0 is compatible with .NET Standard -->
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageVersion Include="Nerdbank.GitVersioning" Version="3.6.133" />
     <PackageVersion Include="Nullability.Source" Version="2.1.0" />
     <PackageVersion Include="System.Memory" Version="4.5.5" />
+    <PackageVersion Include="System.Reflection.Emit" Version="4.7.0" />
     <PackageVersion Include="System.Reflection.MetadataLoadContext" Version="6.0.0" />
     <PackageVersion Include="xunit" Version="2.4.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.5" />

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
-    <Import Project="../Directory.Build.props" />
+  <Import Project="../Directory.Build.props" />
 
   <ItemGroup>
     <PackageReference Include="Nerdbank.GitVersioning" PrivateAssets="all" />

--- a/src/NodeApi.DotNetHost/JSInterfaceMarshaller.cs
+++ b/src/NodeApi.DotNetHost/JSInterfaceMarshaller.cs
@@ -129,7 +129,7 @@ internal class JSInterfaceMarshaller
             BuildEventImplementation(typeBuilder, eventInfo);
         }
 
-        implementationType = typeBuilder.CreateType()!;
+        implementationType = typeBuilder.CreateTypeInfo()!;
         _interfaceTypes.TryUpdate(interfaceType, implementationType, typeBuilder);
 
         // Build and assign the implementation delegates after building the type.

--- a/src/NodeApi.DotNetHost/JSMarshaller.cs
+++ b/src/NodeApi.DotNetHost/JSMarshaller.cs
@@ -169,8 +169,10 @@ public class JSMarshaller
             type == typeof(ICollection<>) ||
             type == typeof(IReadOnlyCollection<>) ||
             type == typeof(ISet<>) ||
-#if !NETFRAMEWORK
+#if READONLY_SET
             type == typeof(IReadOnlySet<>) ||
+#else
+            // TODO: Support IReadOnlySet on .NET Framework / .NET Standard 2.0.
 #endif
             type == typeof(IList<>) ||
             type == typeof(IReadOnlyList<>) ||
@@ -2771,8 +2773,10 @@ public class JSMarshaller
 
         if (typeDefinition == typeof(IList<>) ||
             typeDefinition == typeof(ICollection<>) ||
-#if !NETFRAMEWORK
+#if READONLY_SET
             typeDefinition == typeof(IReadOnlySet<>) ||
+#else
+            // TODO: Support IReadOnlySet on .NET Framework / .NET Standard 2.0.
 #endif
             typeDefinition == typeof(ISet<>))
         {
@@ -2785,7 +2789,7 @@ public class JSMarshaller
             Type jsCollectionType = typeDefinition.Name.Contains("Set") ?
                 typeof(JSSet) : typeof(JSArray);
             MethodInfo asCollectionMethod = typeof(JSCollectionExtensions).GetStaticMethod(
-#if NETFRAMEWORK
+#if !STRING_AS_SPAN
                 "As" + typeDefinition.Name.Substring(1, typeDefinition.Name.IndexOf('`') - 1),
 #else
                 string.Concat("As",
@@ -2816,7 +2820,7 @@ public class JSMarshaller
                 typeof(JSIterable) : typeDefinition == typeof(IAsyncEnumerable<>) ?
                 typeof(JSAsyncIterable) : typeof(JSArray);
             MethodInfo asCollectionMethod = typeof(JSCollectionExtensions).GetStaticMethod(
-#if NETFRAMEWORK
+#if !STRING_AS_SPAN
                 "As" + typeDefinition.Name.Substring(1, typeDefinition.Name.IndexOf('`') - 1),
 #else
                 string.Concat("As",
@@ -2905,8 +2909,10 @@ public class JSMarshaller
 
         if (typeDefinition == typeof(IList<>) ||
             typeDefinition == typeof(ICollection<>) ||
-#if !NETFRAMEWORK
+#if READONLY_SET
             typeDefinition == typeof(IReadOnlySet<>) ||
+#else
+    // TODO: Support IReadOnlySet on .NET Framework / .NET Standard 2.0.
 #endif
             typeDefinition == typeof(ISet<>))
         {
@@ -3110,7 +3116,7 @@ public class JSMarshaller
             if (nameEnd >= 0)
             {
                 string typeArgs = string.Join("_", type.GenericTypeArguments.Select(FullTypeName));
-#if NETFRAMEWORK
+#if !STRING_AS_SPAN
                 name = name.Substring(0, nameEnd) + "_of_" + typeArgs;
 #else
                 name = string.Concat(name.AsSpan(0, nameEnd), "_of_", typeArgs);
@@ -3290,7 +3296,7 @@ public class JSMarshaller
     {
         string assemblyName = forType.FullName + "_" + Environment.CurrentManagedThreadId;
 
-#if NETFRAMEWORK
+#if NETFRAMEWORK || NETSTANDARD
         bool collectible = false;
 #else
         // Make the dynamic assembly collectible if in a collectible load context.

--- a/src/NodeApi.DotNetHost/NodeApi.DotNetHost.csproj
+++ b/src/NodeApi.DotNetHost/NodeApi.DotNetHost.csproj
@@ -9,6 +9,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.Reflection.Emit" Condition="$(NetStandard)" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\NodeApi\NodeApi.csproj" GeneratePathProperty="true" PrivateAssets="all" />
   </ItemGroup>
   

--- a/src/NodeApi.DotNetHost/TypeExtensions.cs
+++ b/src/NodeApi.DotNetHost/TypeExtensions.cs
@@ -22,7 +22,7 @@ internal static class TypeExtensions
     private const BindingFlags PublicStatic = ExactPublic | BindingFlags.Static;
     private const BindingFlags PublicInstance = ExactPublic | BindingFlags.Instance;
 
-#if !NETFRAMEWORK
+#if !(NETFRAMEWORK || NETSTANDARD)
     private static readonly Type[] s_oneGenericMethodParam = new Type[]
     {
         Type.MakeGenericMethodParameter(0),
@@ -97,7 +97,22 @@ internal static class TypeExtensions
                 $"Implicit conversion method for {fromType.Name}->{toType.Name} " +
                 $"not found on type {declaringType.Name}.");
 
-#if NETFRAMEWORK
+#if NETFRAMEWORK || NETSTANDARD
+
+    //https://github.com/dotnet/runtime/issues/23493
+    public static bool IsGenericTypeParameter(this Type target)
+    {
+        return target.IsGenericParameter &&
+               target.DeclaringType != null &&
+               target.DeclaringMethod == null;
+    }
+
+    //https://github.com/dotnet/runtime/issues/23493
+    public static bool IsGenericMethodParameter(this Type target)
+    {
+        return target.IsGenericParameter &&
+               target.DeclaringMethod != null;
+    }
 
     public static MethodInfo GetStaticMethod(
         this Type type, string name, Type[] types, Type genericArg)
@@ -182,7 +197,7 @@ internal static class TypeExtensions
         return true;
     }
 
-#else // !NETFRAMEWORK
+#else
 
     public static MethodInfo GetStaticMethod(
         this Type type, string name, Type[] types, Type genericArg)
@@ -242,5 +257,5 @@ internal static class TypeExtensions
             .ToArray();
     }
 
-#endif // !NETFRAMEWORK
+#endif
 }

--- a/src/NodeApi.DotNetHost/TypeProxy.cs
+++ b/src/NodeApi.DotNetHost/TypeProxy.cs
@@ -47,7 +47,7 @@ internal class TypeProxy
         if (type.IsGenericType && type.Name.IndexOf('`') > 0)
         {
             return prefix +
-#if NETFRAMEWORK
+#if !STRING_AS_SPAN
                 type.Name.Substring(0, type.Name.IndexOf('`')) + '$';
 #else
                 string.Concat(type.Name.AsSpan(0, type.Name.IndexOf('`')), "$");

--- a/src/NodeApi.Generator/ExpressionExtensions.cs
+++ b/src/NodeApi.Generator/ExpressionExtensions.cs
@@ -59,8 +59,9 @@ internal static class ExpressionExtensions
                 (variables is null ? FormatType(lambda.ReturnType) + " " + lambda.Name + "(" +
                   string.Join(", ", lambda.Parameters.Select((p) => p.ToCS())) + ")\n" :
                 "(" + string.Join(", ", lambda.Parameters.Select((p) => p.ToCS())) + ") =>\n") +
-                ToCS(lambda.Body, path, (variables ?? Enumerable.Empty<string>())
-                    .Union(lambda.Parameters.Select((p) => p.Name!)).ToHashSet()),
+                ToCS(lambda.Body, path, new HashSet<string>(
+                    (variables ?? Enumerable.Empty<string>()).Union(
+                        lambda.Parameters.Select((p) => p.Name!)))),
 
             ParameterExpression parameter =>
                 (parameter.IsByRef && parameter.Name?.StartsWith(OutParameterPrefix) == true) ?
@@ -127,7 +128,7 @@ internal static class ExpressionExtensions
                     WithParentheses(call.Object!, path, variables) + FormatArgs(
                         call.Arguments.Take(call.Arguments.Count - 1), path, variables, "[]") +
                         " = " + ToCS(call.Arguments.Last(), path, variables) :
-#if NETFRAMEWORK
+#if !STRING_AS_SPAN
                 call.Method.Name.StartsWith("get_") ?
                     (call.Method.IsStatic ?
                         FormatType(call.Method.DeclaringType!) +
@@ -139,8 +140,8 @@ internal static class ExpressionExtensions
                         FormatType(call.Method.DeclaringType!) +
                             "." + call.Method.Name.Substring(4) :
                         WithParentheses(call.Object!, path, variables) +
-                            "." + call.Method.Name.Substring(4) +
-                    " = " + ToCS(call.Arguments.Single(), path, variables)) :
+                            "." + call.Method.Name.Substring(4)) +
+                    " = " + ToCS(call.Arguments.Single(), path, variables) :
 #else
                 call.Method.Name.StartsWith("get_") ?
                     (call.Method.IsStatic ?

--- a/src/NodeApi.Generator/NodeApi.Generator.csproj
+++ b/src/NodeApi.Generator/NodeApi.Generator.csproj
@@ -6,6 +6,7 @@
     <OutputType>Exe</OutputType>
     <IsPackable>true</IsPackable>
     <NoWarn>$(NoWarn);SYSLIB1045</NoWarn><!-- Use GeneratedRegexAttribute -->
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <SelfContained>false</SelfContained>
@@ -17,24 +18,67 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!-- Package the generator and dependencies in the analyzer directory of the nuget package -->
-    <!-- Use the .NET 6 targeted assembly as the analyzer for broader compatibility. (There's no difference in functionality.) -->
-    <None Pack="true" Visible="false" PackagePath="analyzers/dotnet/cs" Include="$(OutputPath)\net6.0\$(RuntimeIdentifier)\$(AssemblyName).dll" />
-    <None Pack="true" Visible="false" PackagePath="analyzers/dotnet/cs" Include="$(OutputPath)\net6.0\$(RuntimeIdentifier)\$(AssemblyName).runtimeconfig.json" />
-    <None Pack="true" Visible="false" PackagePath="analyzers/dotnet/cs" Include="$(OutputPath)\net6.0\$(RuntimeIdentifier)\Microsoft.JavaScript.NodeApi.dll" />
-    <None Pack="true" Visible="false" PackagePath="analyzers/dotnet/cs" Include="$(OutputPath)\net6.0\$(RuntimeIdentifier)\Microsoft.JavaScript.NodeApi.DotNetHost.dll" />
-    <None Pack="true" Visible="false" PackagePath="analyzers/dotnet/cs" Include="$(OutputPath)\net6.0\$(RuntimeIdentifier)\Microsoft.CodeAnalysis.dll" />
-    <None Pack="true" Visible="false" PackagePath="analyzers/dotnet/cs" Include="$(OutputPath)\net6.0\$(RuntimeIdentifier)\System.Reflection.MetadataLoadContext.dll" />
+    <None Pack="true" PackagePath="\" Include="..\..\README.md" />
+
+    <!--
+      Pack netstandard2.0, net472, and net6.0 versions of the generator and dependencies. The MSBuild targets will pick the right one.
+
+        - netstandard2.0 is used for source-generation in a .NET Framework 4.x based MSBuild / CSC process (building in Visual Studio).
+          net472 cannot be used for source-generation because the compiler does not allow analyzers to reference .NET Framework assemblies.
+
+        - net472 is used for typedefs generation for projects that target .NET Framework 4.x.
+          netstandard2.0 cannot be used for typedefs generation case because it cannot be launched as a command-line executable.
+
+        - net6.0 is used for source-generation in a .NET 6+ based MSBuild / CSC process (building via dotnet CLI),
+          and for typedefs generation for projects that target .NET 6+.
+    -->
+
+    <None Pack="true" Visible="false" PackagePath="lib/netstandard2.0" Include="$(OutputPath)\netstandard2.0\$(RuntimeIdentifier)\Microsoft.Bcl.AsyncInterfaces.dll" />
+    <None Pack="true" Visible="false" PackagePath="lib/netstandard2.0" Include="$(OutputPath)\netstandard2.0\$(RuntimeIdentifier)\Microsoft.CodeAnalysis.dll" />
+    <None Pack="true" Visible="false" PackagePath="lib/netstandard2.0" Include="$(OutputPath)\netstandard2.0\$(RuntimeIdentifier)\Microsoft.JavaScript.NodeApi.dll" />
+    <None Pack="true" Visible="false" PackagePath="lib/netstandard2.0" Include="$(OutputPath)\netstandard2.0\$(RuntimeIdentifier)\Microsoft.JavaScript.NodeApi.DotNetHost.dll" />
+    <None Pack="true" Visible="false" PackagePath="lib/netstandard2.0" Include="$(OutputPath)\netstandard2.0\$(RuntimeIdentifier)\System.Collections.Immutable.dll" />
+    <None Pack="true" Visible="false" PackagePath="lib/netstandard2.0" Include="$(OutputPath)\netstandard2.0\$(RuntimeIdentifier)\System.Memory.dll" />
+    <None Pack="true" Visible="false" PackagePath="lib/netstandard2.0" Include="$(OutputPath)\netstandard2.0\$(RuntimeIdentifier)\System.Numerics.Vectors.dll" />
+    <None Pack="true" Visible="false" PackagePath="lib/netstandard2.0" Include="$(OutputPath)\netstandard2.0\$(RuntimeIdentifier)\System.Reflection.Metadata.dll" />
+    <None Pack="true" Visible="false" PackagePath="lib/netstandard2.0" Include="$(OutputPath)\netstandard2.0\$(RuntimeIdentifier)\System.Reflection.MetadataLoadContext.dll" />
+    <None Pack="true" Visible="false" PackagePath="lib/netstandard2.0" Include="$(OutputPath)\netstandard2.0\$(RuntimeIdentifier)\System.Runtime.CompilerServices.Unsafe.dll" />
+    <None Pack="true" Visible="false" PackagePath="lib/netstandard2.0" Include="$(OutputPath)\netstandard2.0\$(RuntimeIdentifier)\System.Threading.Tasks.Extensions.dll" />
+
+    <None Pack="true" Visible="false" PackagePath="lib/net472" Include="$(OutputPath)\net472\$(RuntimeIdentifier)\$(AssemblyName).exe.config" />
+    <None Pack="true" Visible="false" PackagePath="lib/net472" Include="$(OutputPath)\net472\$(RuntimeIdentifier)\Microsoft.Bcl.AsyncInterfaces.dll" />
+    <None Pack="true" Visible="false" PackagePath="lib/net472" Include="$(OutputPath)\net472\$(RuntimeIdentifier)\Microsoft.CodeAnalysis.dll" />
+    <None Pack="true" Visible="false" PackagePath="lib/net472" Include="$(OutputPath)\net472\$(RuntimeIdentifier)\Microsoft.JavaScript.NodeApi.dll" />
+    <None Pack="true" Visible="false" PackagePath="lib/net472" Include="$(OutputPath)\net472\$(RuntimeIdentifier)\Microsoft.JavaScript.NodeApi.DotNetHost.dll" />
+    <None Pack="true" Visible="false" PackagePath="lib/net472" Include="$(OutputPath)\net472\$(RuntimeIdentifier)\System.Collections.Immutable.dll" />
+    <None Pack="true" Visible="false" PackagePath="lib/net472" Include="$(OutputPath)\net472\$(RuntimeIdentifier)\System.Memory.dll" />
+    <None Pack="true" Visible="false" PackagePath="lib/net472" Include="$(OutputPath)\net472\$(RuntimeIdentifier)\System.Numerics.Vectors.dll" />
+    <None Pack="true" Visible="false" PackagePath="lib/net472" Include="$(OutputPath)\net472\$(RuntimeIdentifier)\System.Reflection.Metadata.dll" />
+    <None Pack="true" Visible="false" PackagePath="lib/net472" Include="$(OutputPath)\net472\$(RuntimeIdentifier)\System.Reflection.MetadataLoadContext.dll" />
+    <None Pack="true" Visible="false" PackagePath="lib/net472" Include="$(OutputPath)\net472\$(RuntimeIdentifier)\System.Runtime.CompilerServices.Unsafe.dll" />
+    <None Pack="true" Visible="false" PackagePath="lib/net472" Include="$(OutputPath)\net472\$(RuntimeIdentifier)\System.Threading.Tasks.Extensions.dll" />
+
+    <None Pack="true" Visible="false" PackagePath="lib/net6.0" Include="$(OutputPath)\net6.0\$(RuntimeIdentifier)\System.Reflection.MetadataLoadContext.dll" />
+    <None Pack="true" Visible="false" PackagePath="lib/net6.0" Include="$(OutputPath)\net6.0\$(RuntimeIdentifier)\Microsoft.CodeAnalysis.dll" />
+    <None Pack="true" Visible="false" PackagePath="lib/net6.0" Include="$(OutputPath)\net6.0\$(RuntimeIdentifier)\Microsoft.JavaScript.NodeApi.dll" />
+    <None Pack="true" Visible="false" PackagePath="lib/net6.0" Include="$(OutputPath)\net6.0\$(RuntimeIdentifier)\Microsoft.JavaScript.NodeApi.DotNetHost.dll" />
+
+    <!-- Pack MSBuild props and targets files that configure and invoke the generator. -->
     <None Pack="true" PackagePath="build\$(AssemblyName).props" Include="NodeApi.Generator.props" />
     <None Pack="true" PackagePath="build\$(AssemblyName).targets" Include="NodeApi.Generator.targets" />
-    <None Pack="true" PackagePath="\" Include="..\..\README.md" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" />
-    <PackageReference Include="Nullability.Source" Condition=" '$(NetFramework)' == 'true' " />
     <PackageReference Include="System.Reflection.MetadataLoadContext" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" $(NetFramework) OR $(NetStandard) ">
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
+    <PackageReference Include="Nullability.Source" />
+    <PackageReference Include="System.Reflection.Emit" />
+    <PackageReference Include="System.Memory" />
   </ItemGroup>
 
   <!--

--- a/src/NodeApi.Generator/NodeApi.Generator.csproj
+++ b/src/NodeApi.Generator/NodeApi.Generator.csproj
@@ -20,19 +20,24 @@
   <ItemGroup>
     <None Pack="true" PackagePath="\" Include="..\..\README.md" />
 
-    <!--
-      Pack netstandard2.0, net472, and net6.0 versions of the generator and dependencies. The MSBuild targets will pick the right one.
+    <!-- Pack MSBuild props and targets files that configure and invoke the generator. -->
+    <None Pack="true" PackagePath="build\$(AssemblyName).props" Include="NodeApi.Generator.props" />
+    <None Pack="true" PackagePath="build\$(AssemblyName).targets" Include="NodeApi.Generator.targets" />
+  </ItemGroup>
 
-        - netstandard2.0 is used for source-generation in a .NET Framework 4.x based MSBuild / CSC process (building in Visual Studio).
-          net472 cannot be used for source-generation because the compiler does not allow analyzers to reference .NET Framework assemblies.
+  <!--
+    Pack netstandard2.0, net472, and net6.0 versions of the generator and dependencies. The MSBuild targets will pick the right one.
 
-        - net472 is used for typedefs generation for projects that target .NET Framework 4.x.
-          netstandard2.0 cannot be used for typedefs generation case because it cannot be launched as a command-line executable.
+      - netstandard2.0 is used for source-generation in a .NET Framework 4.x based MSBuild / CSC process (building in Visual Studio).
+        net472 cannot be used for source-generation because the compiler does not allow analyzers to reference .NET Framework assemblies.
 
-        - net6.0 is used for source-generation in a .NET 6+ based MSBuild / CSC process (building via dotnet CLI),
-          and for typedefs generation for projects that target .NET 6+.
-    -->
+      - net472 is used for typedefs generation for projects that target .NET Framework 4.x.
+        netstandard2.0 cannot be used for typedefs generation case because it cannot be launched as a command-line executable.
 
+      - net6.0 is used for source-generation in a .NET 6+ based MSBuild / CSC process (building via dotnet CLI),
+        and for typedefs generation for projects that target .NET 6+.
+  -->
+  <ItemGroup>
     <None Pack="true" Visible="false" PackagePath="lib/netstandard2.0" Include="$(OutputPath)\netstandard2.0\$(RuntimeIdentifier)\Microsoft.Bcl.AsyncInterfaces.dll" />
     <None Pack="true" Visible="false" PackagePath="lib/netstandard2.0" Include="$(OutputPath)\netstandard2.0\$(RuntimeIdentifier)\Microsoft.CodeAnalysis.dll" />
     <None Pack="true" Visible="false" PackagePath="lib/netstandard2.0" Include="$(OutputPath)\netstandard2.0\$(RuntimeIdentifier)\Microsoft.JavaScript.NodeApi.dll" />
@@ -44,7 +49,8 @@
     <None Pack="true" Visible="false" PackagePath="lib/netstandard2.0" Include="$(OutputPath)\netstandard2.0\$(RuntimeIdentifier)\System.Reflection.MetadataLoadContext.dll" />
     <None Pack="true" Visible="false" PackagePath="lib/netstandard2.0" Include="$(OutputPath)\netstandard2.0\$(RuntimeIdentifier)\System.Runtime.CompilerServices.Unsafe.dll" />
     <None Pack="true" Visible="false" PackagePath="lib/netstandard2.0" Include="$(OutputPath)\netstandard2.0\$(RuntimeIdentifier)\System.Threading.Tasks.Extensions.dll" />
-
+  </ItemGroup>
+  <ItemGroup Condition="$([MSBuild]::IsOsPlatform('Windows'))">
     <None Pack="true" Visible="false" PackagePath="lib/net472" Include="$(OutputPath)\net472\$(RuntimeIdentifier)\$(AssemblyName).exe.config" />
     <None Pack="true" Visible="false" PackagePath="lib/net472" Include="$(OutputPath)\net472\$(RuntimeIdentifier)\Microsoft.Bcl.AsyncInterfaces.dll" />
     <None Pack="true" Visible="false" PackagePath="lib/net472" Include="$(OutputPath)\net472\$(RuntimeIdentifier)\Microsoft.CodeAnalysis.dll" />
@@ -57,15 +63,12 @@
     <None Pack="true" Visible="false" PackagePath="lib/net472" Include="$(OutputPath)\net472\$(RuntimeIdentifier)\System.Reflection.MetadataLoadContext.dll" />
     <None Pack="true" Visible="false" PackagePath="lib/net472" Include="$(OutputPath)\net472\$(RuntimeIdentifier)\System.Runtime.CompilerServices.Unsafe.dll" />
     <None Pack="true" Visible="false" PackagePath="lib/net472" Include="$(OutputPath)\net472\$(RuntimeIdentifier)\System.Threading.Tasks.Extensions.dll" />
-
+  </ItemGroup>
+  <ItemGroup>
     <None Pack="true" Visible="false" PackagePath="lib/net6.0" Include="$(OutputPath)\net6.0\$(RuntimeIdentifier)\System.Reflection.MetadataLoadContext.dll" />
     <None Pack="true" Visible="false" PackagePath="lib/net6.0" Include="$(OutputPath)\net6.0\$(RuntimeIdentifier)\Microsoft.CodeAnalysis.dll" />
     <None Pack="true" Visible="false" PackagePath="lib/net6.0" Include="$(OutputPath)\net6.0\$(RuntimeIdentifier)\Microsoft.JavaScript.NodeApi.dll" />
     <None Pack="true" Visible="false" PackagePath="lib/net6.0" Include="$(OutputPath)\net6.0\$(RuntimeIdentifier)\Microsoft.JavaScript.NodeApi.DotNetHost.dll" />
-
-    <!-- Pack MSBuild props and targets files that configure and invoke the generator. -->
-    <None Pack="true" PackagePath="build\$(AssemblyName).props" Include="NodeApi.Generator.props" />
-    <None Pack="true" PackagePath="build\$(AssemblyName).targets" Include="NodeApi.Generator.targets" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NodeApi.Generator/NodeApi.Generator.targets
+++ b/src/NodeApi.Generator/NodeApi.Generator.targets
@@ -4,7 +4,16 @@
     <NodeApiTypeDefinitionsFileName Condition=" '$(NodeApiTypeDefinitionsFileName)' == '' ">$(TargetName).d.ts</NodeApiTypeDefinitionsFileName>
 
     <NodeApiGeneratorAssemblyName>Microsoft.JavaScript.NodeApi.Generator</NodeApiGeneratorAssemblyName>
-    <NodeApiGeneratorAssemblyPath>$(MSBuildThisFileDirectory)../analyzers/dotnet/cs/$(NodeApiGeneratorAssemblyName).dll</NodeApiGeneratorAssemblyPath>
+    <NodeApiGeneratorDirectory>$(MSBuildThisFileDirectory)../lib/net6.0/</NodeApiGeneratorDirectory>
+    <NodeApiGeneratorNet4xDirectory>$(MSBuildThisFileDirectory)../lib/net472/</NodeApiGeneratorNet4xDirectory>
+    <NodeApiGeneratorNetStandardDirectory>$(MSBuildThisFileDirectory)../lib/netstandard2.0/</NodeApiGeneratorNetStandardDirectory>
+
+    <!--
+      With .NET Framework 4.x, invoke the generator executable; otherwise use the dotnet CLI (which will check the runtimeconfig.json).
+      The TS generator tool selection is based on the current project target framework, NOT the current MSBuild .NET version.
+    -->
+    <NodeApiGeneratorCommand Condition=" $(TargetFramework.StartsWith('net4')) ">&quot;$(NodeApiGeneratorNet4xDirectory)$(NodeApiGeneratorAssemblyName).exe&quot;</NodeApiGeneratorCommand>
+    <NodeApiGeneratorCommand Condition=" !$(TargetFramework.StartsWith('net4')) ">dotnet &quot;$(NodeApiGeneratorDirectory)$(NodeApiGeneratorAssemblyName).dll&quot;</NodeApiGeneratorCommand>
 
     <!-- Try to infer the module type from package.json in the project directory. Otherwise default to generating both module types.-->
     <NodeApiPackageJson Condition=" '$(NodeApiPackageJson)' == '' ">$(ProjectDir)package.json</NodeApiPackageJson>
@@ -13,6 +22,20 @@
 
     <NodeApiTypeDefinitionsGeneratorOptions>--module $(NodeApiJSModuleType) --framework $(TargetFramework) $(NodeApiTypedefsGeneratorOptions)</NodeApiTypeDefinitionsGeneratorOptions>
   </PropertyGroup>
+
+  <!--
+    Resolves NodeApi source-generator (analyzer) assemblies.
+    The recommended practice is to build analyzers targeting only .NET Standard 2.0, and place them in a special "analyzers" directory
+    in the package where they are found automatically. But this package contains separate targets for .NET Standard 2.0, .NET Framework 4.x,
+    and .NET 6.0 (and later) in the "lib" directory. This task chooses the correct target based on the currnet MSBuild process's .NET version
+    (NOT the current target framework), and adds the assemblies to the Analyzer item group.
+  -->
+  <Target Name="ResolveNodeApiAnalyzer" AfterTargets="ResolvePackageDependenciesForBuild">
+    <ItemGroup>
+      <Analyzer Condition=" $([System.Environment]::Version.Major) &gt; 4 " Include="$(NodeApiGeneratorDirectory)*.dll" />
+      <Analyzer Condition=" $([System.Environment]::Version.Major) &lt;= 4 " Include="$(NodeApiGeneratorNetStandardDirectory)*.dll" />
+    </ItemGroup>
+  </Target>
 
   <Target Name="ConfigureNodeApiTypeDefinitions"
     Condition=" '$(GenerateNodeApiTypeDefinitions)' == 'true' "
@@ -49,7 +72,7 @@
     <WriteLinesToFile File="$(NodeApiGeneratorResponseFile)" Lines="$(NodeApiTypeDefinitionsGeneratorOptions)" />
 
     <!-- Run the generator using args from the response file. Note the '@' indicates the response file NOT an MSBuild item-list. -->
-    <Exec Command="dotnet &quot;$(NodeApiGeneratorAssemblyPath)&quot; &quot;@$(NodeApiGeneratorResponseFile)&quot;"
+    <Exec Command="$(NodeApiGeneratorCommand) &quot;@$(NodeApiGeneratorResponseFile)&quot;"
       ConsoleToMSBuild="true" />
   </Target>
 
@@ -135,7 +158,7 @@
     <WriteLinesToFile File="$(NodeApiGeneratorResponseFile)" Lines="$(NodeApiTypeDefinitionsGeneratorOptions)" />
 
     <!-- Run the generator using args from the response file. Note the '@' indicates the response file NOT an MSBuild item-list. -->
-    <Exec Command="dotnet &quot;$(NodeApiGeneratorAssemblyPath)&quot; &quot;@$(NodeApiGeneratorResponseFile)&quot;"
+    <Exec Command="$(NodeApiGeneratorCommand) &quot;@$(NodeApiGeneratorResponseFile)&quot;"
       ConsoleToMSBuild="true" />
   </Target>
 

--- a/src/NodeApi.Generator/StringExtensions.cs
+++ b/src/NodeApi.Generator/StringExtensions.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#if NETFRAMEWORK
+#if NETFRAMEWORK || NETSTANDARD
 
 using System;
 

--- a/src/NodeApi.Generator/TypeExtensions.cs
+++ b/src/NodeApi.Generator/TypeExtensions.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+
+#if NETFRAMEWORK || NETSTANDARD
+
+namespace Microsoft.JavaScript.NodeApi.Generator;
+
+internal static class TypeExtensions
+{
+    //https://github.com/dotnet/runtime/issues/23493
+    public static bool IsGenericTypeParameter(this Type target)
+    {
+        return target.IsGenericParameter &&
+               target.DeclaringType != null &&
+               target.DeclaringMethod == null;
+    }
+
+    //https://github.com/dotnet/runtime/issues/23493
+    public static bool IsGenericMethodParameter(this Type target)
+    {
+        return target.IsGenericParameter &&
+               target.DeclaringMethod != null;
+    }
+}
+
+#endif

--- a/src/NodeApi/DotNetHost/HostFxr.cs
+++ b/src/NodeApi/DotNetHost/HostFxr.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#if !NETFRAMEWORK
+#if !(NETFRAMEWORK || NETSTANDARD)
 
 using System;
 using System.IO;

--- a/src/NodeApi/DotNetHost/HostFxr.cs
+++ b/src/NodeApi/DotNetHost/HostFxr.cs
@@ -306,4 +306,4 @@ internal static partial class HostFxr
     }
 }
 
-#endif // NETFRAMEWORK
+#endif

--- a/src/NodeApi/DotNetHost/MSCorEE.cs
+++ b/src/NodeApi/DotNetHost/MSCorEE.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 // Note while this code is used to load the .NET Framework host, it is compiled using .NET Native AOT.
-#if !NETFRAMEWORK
+#if !(NETFRAMEWORK || NETSTANDARD)
 
 using System;
 using System.Runtime.InteropServices;

--- a/src/NodeApi/DotNetHost/MSCorEE.cs
+++ b/src/NodeApi/DotNetHost/MSCorEE.cs
@@ -332,4 +332,4 @@ internal static unsafe partial class MSCorEE
     }
 }
 
-#endif // NETFRAMEWORK
+#endif

--- a/src/NodeApi/DotNetHost/NativeHost.cs
+++ b/src/NodeApi/DotNetHost/NativeHost.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#if !NETFRAMEWORK
+#if !(NETFRAMEWORK || NETSTANDARD)
 
 using System;
 using System.IO;
@@ -137,7 +137,7 @@ internal unsafe partial class NativeHost : IDisposable
             else
             {
                 // .NET 5 or later
-#if NETFRAMEWORK
+#if NETFRAMEWORK || NETSTANDARD
                 Version dotnetVersion = Version.Parse(targetFramework.Substring(3));
 #else
                 Version dotnetVersion = Version.Parse(targetFramework.AsSpan(3));

--- a/src/NodeApi/DotNetHost/NativeHost.cs
+++ b/src/NodeApi/DotNetHost/NativeHost.cs
@@ -382,4 +382,4 @@ internal unsafe partial class NativeHost : IDisposable
     }
 }
 
-#endif // NETFRAMEWORK
+#endif

--- a/src/NodeApi/Interop/EmptyAttributes.cs
+++ b/src/NodeApi/Interop/EmptyAttributes.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#if NETFRAMEWORK
+#if NETFRAMEWORK || NETSTANDARD
 
 // This file provides empty definitions for attributes that are not available in .NET Framework.
 

--- a/src/NodeApi/Interop/JSCollectionExtensions.cs
+++ b/src/NodeApi/Interop/JSCollectionExtensions.cs
@@ -84,14 +84,14 @@ public static class JSCollectionExtensions
         => ((JSValue)set).IsNullOrUndefined() ? null! :
             new JSSetCollection<T>((JSValue)set, fromJS, toJS);
 
-#if !NETFRAMEWORK
+#if READONLY_SET
     /// <summary>
     /// Creates a read-only set adapter for a JS Set object, without copying.
     /// </summary>
     public static IReadOnlySet<T> AsReadOnlySet<T>(this JSSet set, JSValue.To<T> fromJS, JSValue.From<T> toJS)
         => ((JSValue)set).IsNullOrUndefined() ? null! :
             new JSSetReadOnlySet<T>((JSValue)set, fromJS, toJS);
-#endif // !NETFRAMEWORK
+#endif
 
     /// <summary>
     /// Creates a set adapter for a JS Set object, without copying.
@@ -426,7 +426,7 @@ internal class JSSetCollection<T> : JSSetReadOnlyCollection<T>, ICollection<T>
     public bool Remove(T item) => (bool)Value.CallMethod("delete", ToJS(item));
 }
 
-#if !NETFRAMEWORK
+#if READONLY_SET
 internal class JSSetReadOnlySet<T> : JSSetReadOnlyCollection<T>, IReadOnlySet<T>
 {
     internal JSSetReadOnlySet(JSValue value, JSValue.To<T> fromJS, JSValue.From<T> toJS)
@@ -522,7 +522,7 @@ internal class JSMapReadOnlyDictionary<TKey, TValue> :
 
     public bool ContainsKey(TKey key) => (bool)Value.CallMethod("has", KeyToJS(key));
 
-#if NETFRAMEWORK
+#if NETFRAMEWORK || NETSTANDARD
     public bool TryGetValue(TKey key, out TValue value)
 #else
     public bool TryGetValue(TKey key, [MaybeNullWhen(false)] out TValue value)

--- a/src/NodeApi/Interop/JSCollectionExtensions.cs
+++ b/src/NodeApi/Interop/JSCollectionExtensions.cs
@@ -446,7 +446,7 @@ internal class JSSetReadOnlySet<T> : JSSetReadOnlyCollection<T>, IReadOnlySet<T>
     public bool Overlaps(IEnumerable<T> other) => throw new NotImplementedException();
     public bool SetEquals(IEnumerable<T> other) => throw new NotImplementedException();
 }
-#endif // !NETFRAMEWORK
+#endif
 
 internal class JSSetSet<T> : JSSetCollection<T>, ISet<T>
 {

--- a/src/NodeApi/Interop/JSCollectionProxies.cs
+++ b/src/NodeApi/Interop/JSCollectionProxies.cs
@@ -226,7 +226,6 @@ internal static class JSCollectionProxies
         });
     }
 
-
     /// <summary>
     /// Creates a proxy handler for a proxy that wraps an <see cref="IReadOnlyList{T}"/>
     /// as a JS Array.
@@ -332,7 +331,7 @@ internal static class JSCollectionProxies
         };
     }
 
-#if !NETFRAMEWORK
+#if READONLY_SET
     /// <summary>
     /// Creates a proxy handler for a proxy that wraps an <see cref="IReadOnlySet{T}"/>
     /// as a JS Set.

--- a/src/NodeApi/Interop/JSCollectionProxies.cs
+++ b/src/NodeApi/Interop/JSCollectionProxies.cs
@@ -373,7 +373,7 @@ internal static class JSCollectionProxies
             },
         };
     }
-#endif // !NETFRAMEWORK
+#endif
 
     /// <summary>
     /// Creates a proxy handler for a proxy that wraps an <see cref="ISet{T}"/>

--- a/src/NodeApi/Interop/JSRuntimeContext.cs
+++ b/src/NodeApi/Interop/JSRuntimeContext.cs
@@ -360,7 +360,7 @@ public sealed class JSRuntimeContext : IDisposable
             wrapperReference = CreateWrapper(obj);
 
             // Use AddOrUpdate() in case the constructor just added the object.
-#if NETFRAMEWORK
+#if NETFRAMEWORK || NETSTANDARD
             _objectMap.Remove(obj);
             _objectMap.Add(obj, wrapperReference);
 #else
@@ -376,7 +376,7 @@ public sealed class JSRuntimeContext : IDisposable
                 // Create a new wrapper JS object and update the reference in the map.
                 wrapperReference.Dispose();
                 wrapperReference = CreateWrapper(obj);
-#if NETFRAMEWORK
+#if NETFRAMEWORK || NETSTANDARD
                 _objectMap.Remove(obj);
                 _objectMap.Add(obj, wrapperReference);
 #else
@@ -474,7 +474,7 @@ public sealed class JSRuntimeContext : IDisposable
             });
     }
 
-#if !NETFRAMEWORK
+#if READONLY_SET
     public JSValue GetOrCreateCollectionWrapper<T>(
         IReadOnlySet<T> collection,
         JSValue.From<T> toJS,
@@ -489,7 +489,7 @@ public sealed class JSRuntimeContext : IDisposable
                 return new JSProxy(new JSSet(), proxyHandler, collection);
             });
     }
-#endif // !NETFRAMEWORK
+#endif
 
     public JSValue GetOrCreateCollectionWrapper<T>(
         ISet<T> collection,
@@ -563,7 +563,7 @@ public sealed class JSRuntimeContext : IDisposable
                 wrapperReference.Dispose();
                 wrapper = createWrapper();
                 wrapperReference = new JSReference(wrapper.Value, isWeak: true);
-#if NETFRAMEWORK
+#if NETFRAMEWORK || NETSTANDARD
                 _objectMap.Remove(collection);
                 _objectMap.Add(collection, wrapperReference);
 #else
@@ -715,7 +715,7 @@ public sealed class JSRuntimeContext : IDisposable
 
         SynchronizationContext.Dispose();
 
-#if !NETFRAMEWORK
+#if !(NETFRAMEWORK || NETSTANDARD)
         // ConditionalWeakTable<> is not enumerable in .NET Framework.
         // The JS references will still be released eventually by their finalizers.
         DisposeReferences(_objectMap.Select((entry) => entry.Value));
@@ -821,7 +821,7 @@ public sealed class JSRuntimeContext : IDisposable
         handle.Free();
     }
 
-#if NETFRAMEWORK
+#if NETFRAMEWORK || NETSTANDARD
     private class ReferenceEqualityComparer : IEqualityComparer<object>
     {
         public static ReferenceEqualityComparer Instance { get; } = new();

--- a/src/NodeApi/Interop/NodeStream.Proxy.cs
+++ b/src/NodeApi/Interop/NodeStream.Proxy.cs
@@ -175,10 +175,10 @@ public partial class NodeStream
         byte[] buffer = ArrayPool<byte>.Shared.Rent(ReadChunkSize);
         try
         {
-#if NETFRAMEWORK
-            int count = await stream.ReadAsync(buffer, 0, ReadChunkSize);
-#else
+#if STREAM_MEMORY
             int count = await stream.ReadAsync(buffer.AsMemory(0, ReadChunkSize));
+#else
+            int count = await stream.ReadAsync(buffer, 0, ReadChunkSize);
 #endif
 
             nodeStream = nodeStreamReference.GetValue()!.Value;
@@ -247,10 +247,10 @@ public partial class NodeStream
         using JSReference callbackReference = new(callback);
         try
         {
-#if NETFRAMEWORK
-            await stream.WriteAsync(chunk.ToArray(), 0, chunk.Length);
-#else
+#if STREAM_MEMORY
             await stream.WriteAsync(chunk);
+#else
+            await stream.WriteAsync(chunk.ToArray(), 0, chunk.Length);
 #endif
 
             callback = callbackReference.GetValue()!.Value;

--- a/src/NodeApi/Interop/NodeStream.cs
+++ b/src/NodeApi/Interop/NodeStream.cs
@@ -98,10 +98,10 @@ public partial class NodeStream : Stream
 
     /// <inheritdoc/>
 #pragma warning disable IDE0060 // Unused parameter 'buffer'
-#if NETFRAMEWORK
-    public int Read(Span<byte> buffer)
-#else
+#if STREAM_MEMORY
     public override int Read(Span<byte> buffer)
+#else
+    public int Read(Span<byte> buffer)
 #endif
 #pragma warning restore IDE0060
     {
@@ -120,10 +120,10 @@ public partial class NodeStream : Stream
         => ReadAsync(buffer.AsMemory(offset, count), cancellation).AsTask();
 
     /// <inheritdoc/>
-#if NETFRAMEWORK
-    public async ValueTask<int> ReadAsync(
-#else
+#if STREAM_MEMORY
     public override async ValueTask<int> ReadAsync(
+#else
+    public async ValueTask<int> ReadAsync(
 #endif
         Memory<byte> buffer,
         CancellationToken cancellation = default)
@@ -205,10 +205,10 @@ public partial class NodeStream : Stream
     }
 
     /// <inheritdoc/>
-#if NETFRAMEWORK
-    public async ValueTask WriteAsync(
-#else
+#if STREAM_MEMORY
     public override async ValueTask WriteAsync(
+#else
+    public async ValueTask WriteAsync(
 #endif
         ReadOnlyMemory<byte> buffer,
         CancellationToken cancellation = default)

--- a/src/NodeApi/JSAsyncIterable.Enumerator.cs
+++ b/src/NodeApi/JSAsyncIterable.Enumerator.cs
@@ -45,4 +45,3 @@ public partial struct JSAsyncIterable
         readonly ValueTask IAsyncDisposable.DisposeAsync() => default;
     }
 }
-

--- a/src/NodeApi/JSError.cs
+++ b/src/NodeApi/JSError.cs
@@ -28,7 +28,7 @@ internal record struct JSErrorInfo(string? Message, napi_status Status)
 
         if (errorInfo.Value.error_message != null)
         {
-#if NETFRAMEWORK
+#if NETFRAMEWORK || NETSTANDARD
             string message = PtrToStringUTF8(errorInfo.Value.error_message)!;
 #else
             string message = Marshal.PtrToStringUTF8((nint)errorInfo.Value.error_message)!;
@@ -39,7 +39,7 @@ internal record struct JSErrorInfo(string? Message, napi_status Status)
         return new JSErrorInfo(null, errorInfo.Value.error_code);
     }
 
-#if NETFRAMEWORK
+#if NETFRAMEWORK || NETSTANDARD
     private static unsafe string? PtrToStringUTF8(byte* ptr)
     {
         if (ptr == null) return null;

--- a/src/NodeApi/NodeApi.csproj
+++ b/src/NodeApi/NodeApi.csproj
@@ -20,7 +20,7 @@
     <UseSystemResourceKeys>true</UseSystemResourceKeys><!-- Trim detailed system exception messages. -->
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(NetFramework)' == 'true' ">
+  <ItemGroup Condition=" $(NetFramework) OR $(NetStandard) ">
     <PackageReference Include="System.Memory" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
   </ItemGroup>

--- a/src/NodeApi/Runtime/JSRuntime.Types.cs
+++ b/src/NodeApi/Runtime/JSRuntime.Types.cs
@@ -113,7 +113,7 @@ public unsafe partial class JSRuntime
 
     public record struct napi_callback(nint Handle)
     {
-#if NET6_0_OR_GREATER
+#if UNMANAGED_DELEGATES
         public napi_callback(
             delegate* unmanaged[Cdecl]<napi_env, napi_callback_info, napi_value> handle)
             : this((nint)handle) { }
@@ -128,7 +128,7 @@ public unsafe partial class JSRuntime
 
     public record struct napi_finalize(nint Handle)
     {
-#if NET6_0_OR_GREATER
+#if UNMANAGED_DELEGATES
         public napi_finalize(delegate* unmanaged[Cdecl]<napi_env, nint, nint, void> handle)
             : this((nint)handle) { }
 #else

--- a/src/NodeApi/Runtime/NativeLibrary.cs
+++ b/src/NodeApi/Runtime/NativeLibrary.cs
@@ -5,7 +5,7 @@
 
 using System;
 using System.Runtime.InteropServices;
-#if !NETFRAMEWORK
+#if !(NETFRAMEWORK || NETSTANDARD)
 using SysNativeLibrary = System.Runtime.InteropServices.NativeLibrary;
 #endif
 
@@ -43,7 +43,7 @@ public static class NativeLibrary
     /// <returns>The OS handle for the loaded native library.</returns>
     public static nint Load(string libraryName)
     {
-#if NETFRAMEWORK
+#if NETFRAMEWORK || NETSTANDARD
         return LoadLibrary(libraryName);
 #else
         return SysNativeLibrary.Load(libraryName);
@@ -58,7 +58,7 @@ public static class NativeLibrary
     /// <returns>The address of the symbol.</returns>
     public static nint GetExport(nint handle, string name)
     {
-#if NETFRAMEWORK
+#if NETFRAMEWORK || NETSTANDARD
         return GetProcAddress(handle, name);
 #else
         return SysNativeLibrary.GetExport(handle, name);
@@ -67,7 +67,7 @@ public static class NativeLibrary
 
     public static bool TryGetExport(nint handle, string name, out nint procAddress)
     {
-#if NETFRAMEWORK
+#if NETFRAMEWORK || NETSTANDARD
         procAddress = GetProcAddress(handle, name);
         return procAddress != default;
 #else

--- a/src/NodeApi/Runtime/NodejsEnvironment.cs
+++ b/src/NodeApi/Runtime/NodejsEnvironment.cs
@@ -108,9 +108,13 @@ public sealed class NodejsEnvironment : IDisposable
 
         // The import keyword is not a function and is only available through use of an
         // external helper module.
+#if NETFRAMEWORK || NETSTANDARD
+        string assemblyLocation = new Uri(typeof(NodejsEnvironment).Assembly.CodeBase).LocalPath;
+#else
 #pragma warning disable IL3000 // Assembly.Location returns an empty string for assemblies embedded in a single-file app
         string assemblyLocation = typeof(NodejsEnvironment).Assembly.Location;
 #pragma warning restore IL3000
+#endif
         if (!string.IsNullOrEmpty(assemblyLocation))
         {
             string importAdapterModulePath = Path.Combine(

--- a/src/NodeApi/Runtime/NodejsRuntime.Types.cs
+++ b/src/NodeApi/Runtime/NodejsRuntime.Types.cs
@@ -55,7 +55,7 @@ public unsafe partial class NodejsRuntime
     {
         public nint Handle;
 
-#if NETFRAMEWORK
+#if !UNMANAGED_DELEGATES
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         public delegate void Delegate(
             napi_env env, napi_value js_callback, nint context, nint data);

--- a/src/NodeApi/Runtime/PooledBuffer.cs
+++ b/src/NodeApi/Runtime/PooledBuffer.cs
@@ -14,7 +14,7 @@ internal struct PooledBuffer : IDisposable
         Length = 0;
     }
 
-#if NETFRAMEWORK
+#if NETFRAMEWORK || NETSTANDARD
 
     // Avoid a dependency on System.Buffers with .NET Framwork.
     // It is available as a nuget package, but might not be installed in the application.

--- a/src/NodeApi/Runtime/TracingJSRuntime.cs
+++ b/src/NodeApi/Runtime/TracingJSRuntime.cs
@@ -231,10 +231,10 @@ public class TracingJSRuntime : JSRuntime
         if (value?.Length > 32)
         {
 
-#if NETFRAMEWORK
-            value = value.Substring(0, 32) + "...";
-#else
+#if STRING_AS_SPAN
             value = string.Concat(value.AsSpan(0, 32), "...");
+#else
+            value = value.Substring(0, 32) + "...";
 #endif
         }
 
@@ -359,7 +359,7 @@ public class TracingJSRuntime : JSRuntime
         return status;
     }
 
-#if NETFRAMEWORK
+#if !UNMANAGED_DELEGATES
     private static readonly napi_callback.Delegate s_traceFunctionCallback = TraceFunctionCallback;
     private static readonly napi_callback.Delegate s_traceMethodCallback = TraceMethodCallback;
     private static readonly napi_callback.Delegate s_traceGetterCallback = TraceGetterCallback;

--- a/test/NodeApi.Test.csproj
+++ b/test/NodeApi.Test.csproj
@@ -1,6 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <!-- Exclude netstandard2.0 from target frameworks for tests. -->
+    <TargetFrameworks Condition=" ! $([MSBuild]::IsOsPlatform('Windows')) ">net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks Condition=" $([MSBuild]::IsOsPlatform('Windows')) ">net8.0;net6.0;net472</TargetFrameworks>
+
     <RootNamespace>Microsoft.JavaScript.NodeApi.Test</RootNamespace>
     <AssemblyName>Microsoft.JavaScript.NodeApi.Test</AssemblyName>
     <SelfContained>false</SelfContained>

--- a/test/TypeDefsGeneratorTests.cs
+++ b/test/TypeDefsGeneratorTests.cs
@@ -11,7 +11,7 @@ using Xunit;
 
 namespace Microsoft.JavaScript.NodeApi.Test;
 
-#if !NETFRAMEWORK
+#if !(NETFRAMEWORK || NETSTANDARD)
 #pragma warning disable CA1822 // Mark members as static
 
 public class TypeDefsGeneratorTests

--- a/test/TypeDefsGeneratorTests.cs
+++ b/test/TypeDefsGeneratorTests.cs
@@ -338,4 +338,4 @@ public static class SimpleClassExtensions
         => value.TestMethod();
 }
 
-#endif // !NETFRAMEWORK
+#endif


### PR DESCRIPTION
Fixes: #216, #285

When building inside Visual Studio, VS runs MSBuild and the C# compiler on .NET Framework 4.x -- unlike with `dotnet build` where they run on the .NET 6+ runtime matching the current .NET SDK, even when building a project targeting .NET Framework 4.x. That means analyzer assemblies (which the NodeApi source-generator is) must support the same .NET runtime that the compiler is using in either case. The general guidance is to build analyzers to target `netstandard2.0`.

So we have to add a `netstandard2.0` target framework to all the library projects and make most of the code compatible. Fortunately since it was already compatible with both .NET Framework 4.x and .NET 6+, it wasn't too difficult to additionally support .NET Standard 2.0.

Then it gets a little more complicated since we also launch the same generator assembly during the build as an executable tool for generating typedefs, and _that_ should match the target framework of the project being built, which may be different from the current MSBuild runtime version. Some new logic in `Microsoft.NodeApi.Generator.targets` handles that.

After all the changes I found that some tests were hitting bug #216 more frequently on .NET Framework 4.x, so I did a simple fix for that also (though we may consider better error-handling there later).