### PR TITLE
Propagate .NET stack to JS for async errors

### DIFF
--- a/src/NodeApi/JSPromise.cs
+++ b/src/NodeApi/JSPromise.cs
@@ -96,19 +96,21 @@ public readonly struct JSPromise : IEquatable<JSValue>
     public JSPromise(AsyncResolveCallback callback)
     {
         _value = JSValue.CreatePromise(out Deferred deferred);
-        async void AsyncCallback()
+        ResolveDeferred(callback, deferred);
+    }
+
+    private static async void ResolveDeferred(
+        AsyncResolveCallback callback, Deferred deferred)
+    {
+        using var asyncScope = new JSAsyncScope();
+        try
         {
-            using var asyncScope = new JSAsyncScope();
-            try
-            {
-                await callback(deferred.Resolve);
-            }
-            catch (Exception ex)
-            {
-                deferred.Reject(ex);
-            }
+            await callback(deferred.Resolve);
         }
-        AsyncCallback();
+        catch (Exception ex)
+        {
+            deferred.Reject(ex);
+        }
     }
 
     /// <summary>
@@ -124,19 +126,21 @@ public readonly struct JSPromise : IEquatable<JSValue>
     public JSPromise(AsyncResolveRejectCallback callback)
     {
         _value = JSValue.CreatePromise(out Deferred deferred);
-        async void AsyncCallback()
+        ResolveDeferred(callback, deferred);
+    }
+
+    private static async void ResolveDeferred(
+        AsyncResolveRejectCallback callback, Deferred deferred)
+    {
+        using var asyncScope = new JSAsyncScope();
+        try
         {
-            using var asyncScope = new JSAsyncScope();
-            try
-            {
-                await callback(deferred.Resolve, deferred.Reject);
-            }
-            catch (Exception ex)
-            {
-                deferred.Reject(ex);
-            }
+            await callback(deferred.Resolve, deferred.Reject);
         }
-        AsyncCallback();
+        catch (Exception ex)
+        {
+            deferred.Reject(ex);
+        }
     }
 
     /// <summary>

--- a/test/TestCases/napi-dotnet/Errors.cs
+++ b/test/TestCases/napi-dotnet/Errors.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Threading.Tasks;
 
 namespace Microsoft.JavaScript.NodeApi.TestCases;
 
@@ -16,6 +17,12 @@ public static class Errors
     public static void ThrowJSError(string message, IJSErrors jsErrors)
     {
         jsErrors.ThrowJSError(message);
+    }
+
+    public static async Task ThrowAsyncDotnetError(string message)
+    {
+        await Task.Yield();
+        throw new Exception(message);
     }
 }
 

--- a/test/TestCases/napi-dotnet/errors.js
+++ b/test/TestCases/napi-dotnet/errors.js
@@ -21,6 +21,7 @@ function catchDotnetError() {
 
   assert(typeof error.stack === 'string');
   console.log(error.stack);
+  console.log();
 
   const stack = error.stack.split('\n').map((line) => line.trim());
 
@@ -56,6 +57,7 @@ function catchJSError() {
 
   assert(typeof error.stack === 'string');
   console.log(error.stack);
+  console.log();
 
   const stack = error.stack.split('\n').map((line) => line.trim());
 
@@ -82,3 +84,34 @@ function catchJSError() {
   assert(stack[0].startsWith(`at ${catchJSError.name} `));
 }
 catchJSError();
+
+async function catchAsyncDotnetError() {
+  let error = undefined;
+  try {
+    await Errors.throwAsyncDotnetError('test');
+  } catch (e) {
+    error = e;
+  }
+
+  assert(error instanceof Error);
+  assert.strictEqual(error.message, 'test');
+
+  assert(typeof error.stack === 'string');
+  console.log(error.stack);
+  console.log();
+
+  const stack = error.stack.split('\n').map((line) => line.trim());
+
+  // The stack should be prefixed with the error type and message.
+  const firstLine = stack.shift();
+  assert.strictEqual(firstLine, 'Error: test');
+
+  // The first line of the stack trace should refer to the .NET method that threw.
+  assert(stack[0].startsWith(`at ${dotnetNamespacePrefix}`));
+  assert(stack[0].includes('Errors.ThrowAsyncDotnetError('));
+
+  // Unfortunately the JS stack trace is not available for errors thrown by a .NET async method.
+  // That is because the Task to Promise conversion uses Promise APIs which do not preserve
+  // the JS stack. See https://v8.dev/blog/fast-async#improved-developer-experience
+}
+catchAsyncDotnetError();

--- a/test/TestCases/napi-dotnet/errors.js
+++ b/test/TestCases/napi-dotnet/errors.js
@@ -108,7 +108,7 @@ async function catchAsyncDotnetError() {
 
   // The first line of the stack trace should refer to the .NET method that threw.
   assert(stack[0].startsWith(`at ${dotnetNamespacePrefix}`));
-  assert(stack[0].includes('Errors.ThrowAsyncDotnetError('));
+  assert(stack[0].includes('ThrowAsyncDotnetError'));
 
   // Unfortunately the JS stack trace is not available for errors thrown by a .NET async method.
   // That is because the Task to Promise conversion uses Promise APIs which do not preserve


### PR DESCRIPTION
When JS invokes/awaits an async .NET method, and the async .NET method throws an exception, the .NET stack trace was not propagated via the `Error` object thrown back to JS; only the error message was available. This fixes that by ensuring `JSError` captures the stack when constructed from the callbacks used when converting a .NET `Task` to JS `Promise`.

Unfortunately we don't get the JS part of the stack (as we do for sync errors); I could not find a way to do that for async errors. But the .NET part of the stack, where the error was actually thrown from, is likely to sufficient in most cases and is at least better than nothing.