### PR TITLE
Fix crash due to released weakref in object map

### DIFF
--- a/src/NodeApi/JSReference.cs
+++ b/src/NodeApi/JSReference.cs
@@ -151,12 +151,6 @@ public class JSReference : IDisposable
     }
 
     /// <summary>
-    /// Gets a value indicating whether the referenced JS value is still available (not released).
-    /// Returns false (does not throw) if the reference is disposed.
-    /// </summary>
-    public bool HasValue => !IsDisposed && (!IsWeak || GetValue().HasValue);
-
-    /// <summary>
     /// Runs an action with the referenced value, using the <see cref="JSSynchronizationContext" />
     /// associated with the reference to switch to the JS thread (if necessary) while operating
     /// on the value.
@@ -220,8 +214,8 @@ public class JSReference : IDisposable
     /// Gets a value indicating whether the reference has been disposed.
     /// </summary>
     /// <remarks>
-    /// Note that a weakly- referenced JS value may have been released without the JS reference
-    /// itself being disposed. Use <see cref="HasValue"/> to check if the referenced value is
+    /// Note that a weakly-referenced JS value may have been released without the JS reference
+    /// itself being disposed. Call <see cref="GetValue()"/> to check if the referenced value is
     /// still available.
     /// </remarks>
     public bool IsDisposed { get; private set; }


### PR DESCRIPTION
Fixes: #292

When repeatedly passing the same .NET object to JS, and then releasing the JS objects (but not the .NET object), the internal .NET-to-JS object mapping code could encounter an exception due to incorrect handling of the weak JS reference.

 - Add a `JSReference.HasValue` property that checks if a reference is both not disposed and has an available value.
 - Add doc-comments on `JSReference` methods about when `ObjectDisposedException` may be thrown.
 - Fix object mapping code working with the JS weak references, and reduce code duplication.
