### PR TITLE
Less dynamic runtime to better support build tools like Webpack

### DIFF
--- a/src/node-api-dotnet/init.js
+++ b/src/node-api-dotnet/init.js
@@ -41,6 +41,11 @@ function initialize(targetFramework) {
     targetFramework = defaultTargetFramework;
   }
 
+  /**
+   * Build tools like webpack are not able to package up dynamic includes like the default case.
+   * The switch supports the currently packaged DLLs to work with build tools while maintaining 
+   * potential backwards and future compatibility utilizing the default case. 
+   */
   const assemblyName = 'Microsoft.JavaScript.NodeApi';
   let nativeHost;
   switch(rid) {
@@ -60,6 +65,7 @@ function initialize(targetFramework) {
       nativeHost = require(`./linux-x64/${assemblyName}.node`);
       break;
     default:
+      // Handle unknown platform (Likely will not work with build tools e.g. webpack)
       nativeHost = require(__dirname + `/${rid}/${assemblyName}.node`);
   }
 

--- a/src/node-api-dotnet/init.js
+++ b/src/node-api-dotnet/init.js
@@ -42,10 +42,28 @@ function initialize(targetFramework) {
   }
 
   const assemblyName = 'Microsoft.JavaScript.NodeApi';
-  const nativeHostPath = __dirname + `/${rid}/${assemblyName}.node`;
-  const managedHostPath = __dirname + `/${targetFramework}/${assemblyName}.DotNetHost.dll`
+  let nativeHost;
+  switch(rid) {
+    case 'win-x64':
+      nativeHost = require(`./win-x64/${assemblyName}.node`);
+      break;
+    case 'win-arm64':
+      nativeHost = require(`./win-arm64/${assemblyName}.node`);
+      break;
+    case 'osx-x64':
+      nativeHost = require(`./osx-x64/${assemblyName}.node`);
+      break;
+    case 'osx-arm64':
+      nativeHost = require(`./osx-arm64/${assemblyName}.node`);
+      break;
+    case 'linux-x64':
+      nativeHost = require(`./linux-x64/${assemblyName}.node`);
+      break;
+    default:
+      nativeHost = require(__dirname + `/${rid}/${assemblyName}.node`);
+  }
 
-  const nativeHost = require(nativeHostPath);
+  const managedHostPath = __dirname + `/${targetFramework}/${assemblyName}.DotNetHost.dll`
 
   // Pass require() and import() functions to the host initialize() method.
   // Since `import` is a keyword and not a function it has to be wrapped in a function value.


### PR DESCRIPTION
This should address #300 based on my testing of these code changes with the NPM packaged code. I'm not sure what impacts these changes have with development/testing or other similar things.

This supports static paths for the currently supported platforms that I saw included, but also preserves the previous functionality. Feel free to merge, modify, close and make your own pull, I really don't care, but some sort of solution to the issue would be appreciated.