### PR TITLE
Support inheritdoc in generated typedefs

### DIFF
--- a/src/NodeApi.Generator/SourceGenerator.cs
+++ b/src/NodeApi.Generator/SourceGenerator.cs
@@ -44,6 +44,7 @@ public abstract class SourceGenerator
         UnsupportedIndexer,
         ReferenedTypeNotExported,
         ESModulePropertiesAreConst,
+        DocLoadError,
     }
 
     public static string GetNamespace(ISymbol symbol)

--- a/test/TypeDefsGeneratorTests.cs
+++ b/test/TypeDefsGeneratorTests.cs
@@ -32,14 +32,15 @@ public class TypeDefsGeneratorTests
             docs.Select((pair) => new XElement("member",
                 new XAttribute("name", insertNamespace ? pair.Key.Insert(2, ns) : pair.Key),
                 pair.Value)))));
-        return new TypeDefinitionsGenerator(
+        TypeDefinitionsGenerator generator = new(
             typeof(TypeDefsGeneratorTests).Assembly,
-            assemblyDoc: docsXml,
             referenceAssemblies: new Dictionary<string, Assembly>())
         {
             ExportAll = true,
             SuppressWarnings = true,
         };
+        generator.LoadAssemblyDoc(typeof(TypeDefsGeneratorTests).Assembly.GetName().Name!, docsXml);
+        return generator;
     }
 
     private string GenerateTypeDefinition(


### PR DESCRIPTION
Fixes: #111

Inherited docs can come from other assemblies, so now the generator loads the XML docs for all reference assemblies. Then the closest inherited declaration is used when resolving `<inheritdoc/>` tags.