### PR TITLE
Improve date/time marshalling

### DIFF
--- a/Docs/dates.md
+++ b/Docs/dates.md
@@ -1,0 +1,59 @@
+# Date and time types in .NET and JavaScript
+
+## JS Date / .NET DateTime & DateTimeOffset
+There is not a clean mapping between the built-in types for dates and times in .NET and JS.
+In particular the built-in JavaScript `Date` class has very limited and somewhat confusing
+functionality. For this reason many applications use the popular `moment.js` library, but this
+project prefers to avoid depending on an external library. Also [a new "Temporal" API is
+proposed for standardization](https://tc39.es/proposal-temporal/docs/), but it is not widely
+available yet.
+
+A JavaScript [`Date`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date)
+object is fundamentally a wrapper around a single primitive numeric value that is a UTC timestamp
+(milliseconds since the epoch). It does not hold any other state related to offsets or time zones.
+This UTC primitive value is returned by the `Date.valueOf()` function, and is one type of value
+accepted by the `Date()` constructor. The confusing thing about it is that other constructors and
+most `Date` methods operate in the context of the current local time zone, automatically converting
+to/from UTC as needed. That includes the default `toString()` method, though alternatives like
+`toUTCString()` and `toISOString()` can get the time in UTC instead.
+
+In .NET, both `DateTime` and `DateTimeOffset` are widely used. While the latter is more modern
+and fully-featured, the simpler `DateTime` is still sufficient for many scenarios. So for best
+interoperability, both types of .NET values are convertible to and from JS `Date` values. This is
+accomplished by adding either a `kind` or `offset` property to a regular `Date` object.
+
+```TypeScript
+type DateTime = Date | { kind?: 'utc' | 'local' | 'unspecified' }
+```
+
+When a .NET `DateTime` is marshalled to a JS `Date`, the date's UTC timestamp value becomes the
+JS `Date` value, regardless of the `DateTime.Kind` property. Then the `kind` property is added to
+facilitate consistent round-tripping, so that a `DateTime` can be passed from .NET to JS and
+back to .NET without its `Kind` changing. (As noted above, the JS `Date.toString()` always
+displays local time, and that remains true even for a `Date` with `kind == 'utc'`.) If a
+regular JS `Date` object without a `kind` hint is marshalled to .NET, it becomes a `DateTime`
+with `Utc` kind. (Defaulting to `Unspecified` would be more likely to result in undesirable
+conversions to/from local-time.)
+
+```TypeScript
+type DateTimeOffset = Date | { offset?: number }
+```
+
+When a .NET `DateTimeOffset` is marshalled to a JS `Date`, the UTC timestamp value _without the
+offset_ becomes the JS `Date` value. Then the `offset` property is added to the object. The
+`offset` is a positive or negative integer number of minutes, equivalent to
+[DateTimeOffset.TotalOffsetMinumtes](https://learn.microsoft.com/en-us/dotnet/api/system.datetimeoffset.totaloffsetminutes).
+Additionally, the `toString()` method of the `Date` object is overridden such that it displays
+the time _with the offset applied_, followed by the offset, in the form
+`YYYY-MM-DD HH:mm:SS (+/-)HH:mm`, consistent with how .NET `DateTimeOffset` is displayed.
+If a regular JS `Date` object without an `offset` value is marshalled to .NET, it becomes a
+`DateTimeOffset` with zero offset (not local time-zone offset).
+
+## JS number / .NET TimeSpan
+JavaScript lacks a built-in type for representing time spans (at least until the "Temporal" API
+is standardized). The common practice is to represent basic time spans as a number of milliseconds.
+So a .NET `TimeSpan` is marshalled to or from a simple JS `number` value.
+
+Note the `Date.offset` property introduced above is intentionally NOT a millisecond timespan value.
+It is a whole (positive or negative) number of minutes, because `DateTimeOffset` does not support
+second or millisecond precision for offsets.

--- a/Docs/typescript.md
+++ b/Docs/typescript.md
@@ -104,8 +104,8 @@ properties. So C# `(string A, int B)` becomes TypeScript `[string, number]`, not
 
 ### Special types
 
-| C# Type            | TypeScript Projection |
-|--------------------|-----------------------|
+| C# Type            | TypeScript Projection   |
+|--------------------|-------------------------|
 | `Task`             | `Promise<void>`         |
 | `Task<T>`          | `Promise<T>`            |
 | `BigInteger`       | `BigInt`                |

--- a/Docs/typescript.md
+++ b/Docs/typescript.md
@@ -106,18 +106,16 @@ properties. So C# `(string A, int B)` becomes TypeScript `[string, number]`, not
 
 | C# Type            | TypeScript Projection |
 |--------------------|-----------------------|
-| `Task`             | `Promise<void>`       |
-| `Task<T>`          | `Promise<T>`          |
-| `DateTime`         | `Date`                |
-| `DateTimeOffset`   | `[Date, number]`      |
-| `TimeSpan`         | `number`              |
-| `BigInteger`       | `BigInt`              |
-| `Tuple<A, B, ...>` | `[A, B, ...]`         |
-| `Stream`           | `Duplex`              |
+| `Task`             | `Promise<void>`         |
+| `Task<T>`          | `Promise<T>`            |
+| `BigInteger`       | `BigInt`                |
+| `Tuple<A, B, ...>` | `[A, B, ...]`           |
+| `Stream`           | `Duplex`                |
+| `DateTime`         | `Date \| { kind?: 'utc' \| 'local' \| 'unspecified'}` |
+| `DateTimeOffset`   | `Date \| { offset?: number }` (Date is UTC; offset is +/- minutes) |
+| `TimeSpan`         | `number` (milliseconds) |
 
-Dates marshalled from JavaScript will always be `Utc` kind. A `TimeSpan` is projected to JavaScript
-as a decimal number of milliseconds. A `DateTimeOffset` is projected as a tuple of the UTC date-time
-and the offset in (positive or negative) milliseconds.
+For more about date and time marshalling, see [Date and time types in .NET and JavaScript](./dates.md).
 
 ### Methods with `ref` or `out` parameters
 JavaScript does not support `ref` or `out` parameters, so some transformations are applied

--- a/src/NodeApi.DotNetHost/JSMarshaller.cs
+++ b/src/NodeApi.DotNetHost/JSMarshaller.cs
@@ -2036,13 +2036,24 @@ public class JSMarshaller
             }
             else if (toType == typeof(TimeSpan))
             {
-                MethodInfo asString = typeof(JSValue).GetExplicitConversion(
-                    typeof(JSValue), typeof(string));
+                MethodInfo asDouble = typeof(JSValue).GetExplicitConversion(
+                    typeof(JSValue), typeof(double));
                 MethodInfo toTimeSpan = typeof(TimeSpan).GetStaticMethod(
-                    nameof(TimeSpan.Parse), new[] { typeof(string) });
+                    nameof(TimeSpan.FromMilliseconds));
                 statements = new[]
                 {
-                    Expression.Call(toTimeSpan, Expression.Call(asString, valueParameter)),
+                    Expression.Call(toTimeSpan, Expression.Call(asDouble, valueParameter)),
+                };
+            }
+            else if (toType == typeof(DateTimeOffset))
+            {
+                MethodInfo asJSDate = typeof(JSDate).GetExplicitConversion(
+                    typeof(JSValue), typeof(JSDate));
+                MethodInfo toDateTimeOffset = typeof(JSDate).GetInstanceMethod(
+                    nameof(JSDate.ToDateTimeOffset));
+                statements = new[]
+                {
+                    Expression.Call(Expression.Call(asJSDate, valueParameter), toDateTimeOffset),
                 };
             }
             else if (toType == typeof(Guid))
@@ -2343,13 +2354,24 @@ public class JSMarshaller
             }
             else if (fromType == typeof(TimeSpan))
             {
-                MethodInfo toString = typeof(TimeSpan).GetInstanceMethod(
-                    nameof(TimeSpan.ToString), []);
+                PropertyInfo doubleValue = typeof(TimeSpan).GetInstanceProperty(
+                    nameof(TimeSpan.TotalMilliseconds));
                 MethodInfo asJSValue = typeof(JSValue).GetImplicitConversion(
-                    typeof(string), typeof(JSValue));
+                    typeof(double), typeof(JSValue));
                 statements = new[]
                 {
-                    Expression.Call(asJSValue, Expression.Call(valueParameter, toString)),
+                    Expression.Call(asJSValue, Expression.Property(valueParameter, doubleValue)),
+                };
+            }
+            else if (fromType == typeof(DateTimeOffset))
+            {
+                MethodInfo fromDateTimeOffset = typeof(JSDate).GetStaticMethod(
+                    nameof(JSDate.FromDateTimeOffset));
+                MethodInfo asJSValue = typeof(JSDate).GetImplicitConversion(
+                    typeof(JSDate), typeof(JSValue));
+                statements = new[]
+                {
+                    Expression.Call(asJSValue, Expression.Call(fromDateTimeOffset, valueParameter)),
                 };
             }
             else if (fromType == typeof(Guid))

--- a/src/NodeApi.Generator/TypeDefinitionsGenerator.cs
+++ b/src/NodeApi.Generator/TypeDefinitionsGenerator.cs
@@ -746,7 +746,7 @@ import { Duplex } from 'stream';
         if (_emitDateTimeOffset)
         {
             s.Insert(insertIndex, _isSystemAssembly ? @"
-namespace js { type DateTimeOffset = Date | { offset?: number } }
+declare namespace js { type DateTimeOffset = Date | { offset?: number } }
 " : @"
 type DateTimeOffset = Date | { offset?: number }
 ");
@@ -755,7 +755,7 @@ type DateTimeOffset = Date | { offset?: number }
         if (_emitDateTime)
         {
             s.Insert(insertIndex, _isSystemAssembly ? @"
-namespace js { type DateTime = Date | { kind?: 'utc' | 'local' | 'unspecified' } }
+declare namespace js { type DateTime = Date | { kind?: 'utc' | 'local' | 'unspecified' } }
 " : @"
 type DateTime = Date | { kind?: 'utc' | 'local' | 'unspecified' }
 ");

--- a/src/NodeApi/JSDate.cs
+++ b/src/NodeApi/JSDate.cs
@@ -77,7 +77,7 @@ public readonly struct JSDate : IEquatable<JSValue>
     public static JSDate FromDateTimeOffset(DateTimeOffset value)
     {
         long dateValue = value.ToUnixTimeMilliseconds();
-        JSDate jsDate = new JSDate(dateValue);
+        JSDate jsDate = new(dateValue);
 
         jsDate._value.SetProperty("offset", value.Offset.TotalMinutes);
         jsDate._value.SetProperty("toString", new JSFunction(JSDateWithOffsetToString));
@@ -91,7 +91,7 @@ public readonly struct JSDate : IEquatable<JSValue>
         JSValue value = thisDate.CallMethod("valueOf");
         JSValue offset = thisDate.GetProperty("offset");
 
-        if (!offset.IsNumber() || !value.IsNumber() || Double.IsNaN((double)value))
+        if (!offset.IsNumber() || !value.IsNumber() || double.IsNaN((double)value))
         {
             JSValue dateClass = JSRuntimeContext.Current.Import(null, "Date");
             return dateClass.GetProperty("prototype").GetProperty("toString").Call(thisDate);

--- a/test/TestCases/napi-dotnet/ComplexTypes.cs
+++ b/test/TestCases/napi-dotnet/ComplexTypes.cs
@@ -66,9 +66,19 @@ public static class ComplexTypes
 
     public static TestEnum TestEnum { get; set; }
 
-    public static DateTime Date { get; set; } = new DateTime(2023, 2, 1, 0, 0, 0, DateTimeKind.Utc);
+    public static DateTime DateTime { get; set; }
+        = new DateTime(2023, 4, 5, 6, 7, 8, DateTimeKind.Unspecified);
 
-    public static TimeSpan Time { get; set; } = new TimeSpan(1, 12, 30, 45);
+    public static DateTime DateTimeLocal { get; }
+        = new DateTime(2023, 4, 5, 6, 7, 8, DateTimeKind.Local);
+
+    public static DateTime DateTimeUtc { get; }
+        = new DateTime(2023, 4, 5, 6, 7, 8, DateTimeKind.Utc);
+
+    public static TimeSpan TimeSpan { get; set; } = new TimeSpan(1, 12, 30, 45);
+
+    public static DateTimeOffset DateTimeOffset { get; set; }
+        = new DateTimeOffset(DateTime, -TimeSpan.FromMinutes(90));
 
     public static KeyValuePair<string, int> Pair { get; set; }
         = new KeyValuePair<string, int>("pair", 1);

--- a/test/TestCases/napi-dotnet/complex_types.js
+++ b/test/TestCases/napi-dotnet/complex_types.js
@@ -198,18 +198,49 @@ ComplexTypes.testEnum = enumType.Two;
 assert.strictEqual(ComplexTypes.testEnum, enumType.Two);
 
 // DateTime
-const dateValue = ComplexTypes.date;
+/** @type {Date | { kind: 'utc' | 'local' | 'unspecified' }} */
+const dateValue = ComplexTypes.dateTime;
 assert(dateValue instanceof Date);
-assert.deepStrictEqual(dateValue, new Date("2023-02-01"));
-ComplexTypes.date = new Date("2024-03-02T11:00");
-assert.deepStrictEqual(ComplexTypes.date, new Date("2024-03-02T11:00"));
+assert.strictEqual(dateValue.valueOf(), new Date('2023-04-05T06:07:08').valueOf());
+assert.strictEqual(dateValue.kind, 'unspecified');
+ComplexTypes.dateTime = new Date('2024-03-02T11:00');
+assert.strictEqual(ComplexTypes.dateTime.valueOf(), new Date('2024-03-02T11:00').valueOf());
+assert.strictEqual(ComplexTypes.dateTime.kind, 'utc');
+/** @type {Date | { kind: 'utc' | 'local' | 'unspecified' }} */
+const dateValue2 = new Date('2024-03-02T11:00');
+dateValue2.kind = 'local';
+ComplexTypes.dateTime = dateValue2;
+assert.strictEqual(ComplexTypes.dateTime.valueOf(), new Date('2024-03-02T11:00').valueOf());
+assert.strictEqual(ComplexTypes.dateTime.kind, 'local');
+assert.strictEqual(ComplexTypes.dateTimeLocal.valueOf(), new Date('2023-04-05T06:07:08').valueOf());
+assert.strictEqual(ComplexTypes.dateTimeLocal.kind, 'local');
+assert.strictEqual(
+  ComplexTypes.dateTimeUtc.valueOf(),
+  new Date(Date.UTC(2023, 3, 5, 6, 7, 8)).valueOf());
+assert.strictEqual(ComplexTypes.dateTimeUtc.kind, 'utc');
 
 // TimeSpan
-const timeValue = ComplexTypes.time;
-assert.strictEqual(typeof timeValue, 'string');
-assert.strictEqual(timeValue, '1.12:30:45');
-ComplexTypes.time = '2.23:34:45';
-assert.strictEqual(ComplexTypes.time, '2.23:34:45');
+const timeValue = ComplexTypes.timeSpan;
+assert.strictEqual(typeof timeValue, 'number');
+assert.strictEqual(timeValue, (36*60*60 + 30*60 + 45) * 1000);
+ComplexTypes.timeSpan = (2*24*60*60 + 23*60*60 + 34*60 + 45) * 1000;
+assert.strictEqual(ComplexTypes.timeSpan, (2*24*60*60 + 23*60*60 + 34*60 + 45) * 1000);
+
+// DateTimeOffset
+/** @type {Date | { offset: number }} */
+const dateTimeOffsetValue = ComplexTypes.dateTimeOffset;
+assert(dateTimeOffsetValue instanceof Date);
+// A negative offset means the UTC time is later than the local time,
+// so the offset is added to the local time to get the expected UTC time here.
+assert.strictEqual(dateTimeOffsetValue.valueOf(), Date.UTC(2023, 3, 5, 6, 7, 8) + 90 * 60 * 1000);
+assert.strictEqual(dateTimeOffsetValue.offset, -90);
+assert.strictEqual(dateTimeOffsetValue.toString(), '2023-04-05 06:07:08.000 -01:30');
+/** @type {Date | { offset: number }} */
+const dateTimeOffsetValue2 = new Date(Date.UTC(2024, 2, 2, 1, 0, 0));
+dateTimeOffsetValue2.offset = 120;
+ComplexTypes.dateTimeOffset = dateTimeOffsetValue2;
+assert.strictEqual(ComplexTypes.dateTimeOffset.valueOf(), dateTimeOffsetValue2.valueOf());
+assert.strictEqual(ComplexTypes.dateTimeOffset.toString(), '2024-03-02 03:00:00.000 +02:00');
 
 // Tuples
 const pairValue = ComplexTypes.pair;


### PR DESCRIPTION
Fixes: #277 

Previously the marshalling of .NET `DateTime`, `DateTimeOffset`, and `TimeSpan` types to/from JavaScript was incomplete and inconsistent with the doc. This PR fully implements the marshalling of these types. See documentation in `Docs/dates.md` for a design overview.
