### PR TITLE
Enable globalization in managed host runtimeconfig

### DIFF
--- a/src/NodeApi/NodeApi.csproj
+++ b/src/NodeApi/NodeApi.csproj
@@ -12,9 +12,7 @@
 
   <PropertyGroup Condition=" '$(PublishAot)' == 'true' ">
     <PublishNodeModule>true</PublishNodeModule>
-  </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(Configuration)'=='Release' ">
     <!-- These trimming options are not required, but reduce the native binary size by around 600 KB. -->
     <InvariantGlobalization>true</InvariantGlobalization><!-- Trim globalization-specific code and data. -->
     <UseSystemResourceKeys>true</UseSystemResourceKeys><!-- Trim detailed system exception messages. -->


### PR DESCRIPTION
Fixes: #309 

The runtimeconfig globalization options intended for Native AOT should only be set when `'$(PublishAot)' == 'true'`.