### PR TITLE
Fix winui-fluid example

### DIFF
--- a/examples/winui-fluid/App.xaml.cs
+++ b/examples/winui-fluid/App.xaml.cs
@@ -24,12 +24,11 @@ public partial class App : Application
         // Node.js require() searches for modules/packages relative to the CWD.
         Environment.CurrentDirectory = Path.GetDirectoryName(typeof(App).Assembly.Location)!;
 
-        string libnodePath = Path.Combine(
-            Path.GetDirectoryName(typeof(App).Assembly.Location)!,
-            "libnode.dll");
+        string appDir = Path.GetDirectoryName(typeof(App).Assembly.Location)!;
+        string libnodePath = Path.Combine(appDir, "libnode.dll");
         NodejsPlatform nodejsPlatform = new(libnodePath);
 
-        Nodejs = nodejsPlatform.CreateEnvironment();
+        Nodejs = nodejsPlatform.CreateEnvironment(appDir);
         if (Debugger.IsAttached)
         {
             int pid = Process.GetCurrentProcess().Id;

--- a/examples/winui-fluid/CollabEditBox.xaml.cs
+++ b/examples/winui-fluid/CollabEditBox.xaml.cs
@@ -68,7 +68,7 @@ public sealed partial class CollabEditBox : UserControl
         {
             JSValue logFunction = JSValue.CreateFunction("send", (args) =>
             {
-                var e = this.marshaller.To<TelemetryBaseEvent>(args[0]);
+                var e = this.marshaller.FromJS<TelemetryBaseEvent>(args[0]);
                 Debug.WriteLine($"[fluid:{e.Category}] {e.EventName}");
                 return JSValue.Undefined;
             });
@@ -89,8 +89,8 @@ public sealed partial class CollabEditBox : UserControl
 
             JSValue tinyliciousClient =
                 this.nodejs.Import("@fluidframework/tinylicious-client", "TinyliciousClient")
-                .CallAsConstructor(this.marshaller.From(clientProps));
-            this.fluidClient = this.marshaller.To<ITinyliciousClient>(tinyliciousClient);
+                .CallAsConstructor(this.marshaller.ToJS(clientProps));
+            this.fluidClient = this.marshaller.FromJS<ITinyliciousClient>(tinyliciousClient);
         });
     }
 
@@ -124,7 +124,7 @@ public sealed partial class CollabEditBox : UserControl
             "sequenceDelta",
             JSValue.CreateFunction("sequenceDelta", OnSharedStringDelta));
 
-        return this.marshaller.To<ISharedString>(sharedString);
+        return this.marshaller.FromJS<ISharedString>(sharedString);
     }
 
     private IDictionary<string, (int, int)> GetSharedSelections()
@@ -431,7 +431,7 @@ public sealed partial class CollabEditBox : UserControl
 
     private JSValue OnSharedStringDelta(JSCallbackArgs args)
     {
-        var deltaEvent = this.marshaller.To<SequenceDeltaEvent>(args[0]);
+        var deltaEvent = this.marshaller.FromJS<SequenceDeltaEvent>(args[0]);
 
         Debug.WriteLine(
             $"SequenceDelta(IsLocal={deltaEvent.IsLocal}, ClientId={deltaEvent.ClientId})");
@@ -527,7 +527,7 @@ public sealed partial class CollabEditBox : UserControl
 
     private JSValue OnSharedMapValueChanged(JSCallbackArgs args)
     {
-        var changedEvent = this.marshaller.To<SharedMapValueChangedEvent>(args[0]);
+        var changedEvent = this.marshaller.FromJS<SharedMapValueChangedEvent>(args[0]);
         bool isLocal = (bool)args[1];
 
         if (!isLocal)

--- a/examples/winui-fluid/Directory.Build.props
+++ b/examples/winui-fluid/Directory.Build.props
@@ -1,6 +1,0 @@
-<Project>
-  <PropertyGroup>
-    <!-- Use a local nuget package cache folder that is easy to wipe when testing. -->
-    <RestorePackagesPath>$(MSBuildThisFileDirectory)..\..\out\pkg</RestorePackagesPath>
-  </PropertyGroup>
-</Project>

--- a/examples/winui-fluid/winui-fluid.csproj
+++ b/examples/winui-fluid/winui-fluid.csproj
@@ -52,7 +52,7 @@
     <PackageReference Include="Microsoft.JavaScript.NodeApi" Version="$(NodeApiDotnetPackageVersion)" />
     <PackageReference Include="Microsoft.JavaScript.NodeApi.DotNetHost" Version="$(NodeApiDotnetPackageVersion)" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.*" />
-    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.755" />
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.756" />
     <Manifest Include="$(ApplicationManifest)" />
   </ItemGroup>
 


### PR DESCRIPTION
 - Fix example code that had been broken by some API changes.
 - Delete `Directory.build.props` which was redundant with the one in the parent directory and prevented `$(NodeApiDotnetPackageVersion)` from being resolved.