### PR TITLE
JS Reference API improvements

### DIFF
--- a/bench/Benchmarks.cs
+++ b/bench/Benchmarks.cs
@@ -217,7 +217,7 @@ public abstract class Benchmarks
     [Benchmark]
     public void ReferenceGet()
     {
-        _ = _reference.GetValue()!.Value;
+        _ = _reference.GetValue();
     }
 
     [Benchmark]

--- a/src/NodeApi.DotNetHost/JSMarshaller.cs
+++ b/src/NodeApi.DotNetHost/JSMarshaller.cs
@@ -892,7 +892,7 @@ public class JSMarshaller
          * var __valueRef = new JSReference(__value);
          * var __syncContext = JSSynchronizationContext.Current;
          * return (...args) => __syncContext.Run(() =>
-         *     __valueRef.GetValue().Value.Call(...args));
+         *     __valueRef.GetValue().Call(...args));
          */
         ParameterExpression valueParameter = Expression.Parameter(typeof(JSValue), "__value");
         ParameterExpression valueRefVariable = Expression.Variable(
@@ -912,11 +912,9 @@ public class JSMarshaller
             syncContextVariable,
             Expression.Property(null, typeof(JSSynchronizationContext).GetStaticProperty(
                 nameof(JSSynchronizationContext.Current))));
-        Expression getValueExpression = Expression.Property(
-            Expression.Call(
+        Expression getValueExpression = Expression.Call(
                 valueRefVariable,
-                typeof(JSReference).GetInstanceMethod(nameof(JSReference.GetValue))),
-            "Value");
+                typeof(JSReference).GetInstanceMethod(nameof(JSReference.GetValue)));
 
         ParameterExpression[] parameters = invokeMethod.GetParameters()
             .Select(Parameter).ToArray();

--- a/src/NodeApi.DotNetHost/ManagedHost.cs
+++ b/src/NodeApi.DotNetHost/ManagedHost.cs
@@ -345,7 +345,7 @@ public sealed class ManagedHost : JSEventEmitter, IDisposable
         if (_loadedModules.TryGetValue(assemblyFilePath, out JSReference? exportsRef))
         {
             Trace("< ManagedHost.LoadModule() => already loaded");
-            return exportsRef.GetValue()!.Value;
+            return exportsRef.GetValue();
         }
 
         Assembly assembly;

--- a/src/NodeApi.DotNetHost/NamespaceProxy.cs
+++ b/src/NodeApi.DotNetHost/NamespaceProxy.cs
@@ -90,7 +90,7 @@ internal class NamespaceProxy
     {
         if (_valueReference != null)
         {
-            return (JSProxy)_valueReference.GetValue()!.Value;
+            return (JSProxy)_valueReference.GetValue();
         }
 
         JSProxy proxy = new(new JSObject(), CreateProxyHandler());
@@ -102,7 +102,7 @@ internal class NamespaceProxy
     {
         if (_tostringReference != null)
         {
-            return (JSFunction)_tostringReference.GetValue()!.Value;
+            return (JSFunction)_tostringReference.GetValue();
         }
 
         // Calling `toString()` on a namespace returns the full namespace name.

--- a/src/NodeApi.DotNetHost/TypeExporter.cs
+++ b/src/NodeApi.DotNetHost/TypeExporter.cs
@@ -125,7 +125,7 @@ public class TypeExporter
                 if (_namespaces != null)
                 {
                     // Add a property on the namespaces JS object.
-                    JSObject namespacesObject = (JSObject)_namespaces.GetValue()!.Value;
+                    JSObject namespacesObject = (JSObject)_namespaces.GetValue();
                     namespacesObject[namespaceParts[0]] = parentNamespace.Value;
                 }
             }

--- a/src/NodeApi/DotNetHost/NativeHost.cs
+++ b/src/NodeApi/DotNetHost/NativeHost.cs
@@ -105,7 +105,7 @@ internal unsafe partial class NativeHost : IDisposable
                 // Normally this shouldn't happen because the host package initialization
                 // script would only be loaded once by require(). But certain situations like
                 // drive letter or path casing inconsistencies can cause it to be loaded twice.
-                return _exports.GetValue()!.Value;
+                return _exports.GetValue();
             }
             else
             {

--- a/src/NodeApi/Interop/JSAbortSignal.cs
+++ b/src/NodeApi/Interop/JSAbortSignal.cs
@@ -90,7 +90,7 @@ public readonly struct JSAbortSignal : IEquatable<JSValue>
                 JSSynchronizationContext syncContext = JSSynchronizationContext.Current!;
                 cancellation.Register(() => syncContext.Post(() =>
                 {
-                    controllerReference.GetValue()!.Value.CallMethod("abort");
+                    controllerReference.GetValue().CallMethod("abort");
                     controllerReference.Dispose();
                 }));
                 return new JSAbortSignal(controller["signal"]);

--- a/src/NodeApi/Interop/JSCollectionExtensions.cs
+++ b/src/NodeApi/Interop/JSCollectionExtensions.cs
@@ -367,7 +367,7 @@ internal class JSIterableEnumerable<T> : IEnumerable<T>, IEquatable<JSValue>, ID
 
     private readonly JSReference _iterableReference;
 
-    internal JSValue Value => _iterableReference.GetValue()!.Value;
+    internal JSValue Value => _iterableReference.GetValue();
 
     protected void Run(Action<JSValue> action) => _iterableReference.Run(action);
     protected TResult Run<TResult>(Func<JSValue, TResult> action) => _iterableReference.Run(action);
@@ -664,7 +664,7 @@ internal class JSMapReadOnlyDictionary<TKey, TValue> :
     protected void Run(Action<JSValue> action) => _mapReference.Run(action);
     protected TResult Run<TResult>(Func<JSValue, TResult> action) => _mapReference.Run(action);
 
-    internal JSValue Value => _mapReference.GetValue()!.Value;
+    internal JSValue Value => _mapReference.GetValue();
 
     bool IEquatable<JSValue>.Equals(JSValue other) => Run((map) => map.Equals(other));
 

--- a/src/NodeApi/Interop/JSInterface.cs
+++ b/src/NodeApi/Interop/JSInterface.cs
@@ -31,7 +31,7 @@ public abstract class JSInterface
     /// <summary>
     /// Gets the underlying JS value.
     /// </summary>
-    protected JSValue Value => ValueReference.GetValue()!.Value;
+    protected JSValue Value => ValueReference.GetValue();
 
     /// <summary>
     /// Dynamically invokes an interface method JS adapter delegate after obtaining the JS `this`

--- a/src/NodeApi/Interop/JSRuntimeContext.cs
+++ b/src/NodeApi/Interop/JSRuntimeContext.cs
@@ -311,7 +311,7 @@ public sealed class JSRuntimeContext : IDisposable
 
         if (_objectMap.TryGetValue(obj, out JSReference? existingWrapperWeakRef))
         {
-            if (!existingWrapperWeakRef.IsDisposed && existingWrapperWeakRef.GetValue().HasValue)
+            if (!existingWrapperWeakRef.IsDisposed && existingWrapperWeakRef.TryGetValue(out _))
             {
                 // If the .NET object is already mapped to a non-released JS object, then
                 // another one should not be created.
@@ -626,6 +626,9 @@ public sealed class JSRuntimeContext : IDisposable
 
         JSReference reference = _importMap.GetOrAdd((module, property), (_) =>
         {
+            // TODO: Consider what to do if the imported property is undefined
+            // or not a referenceable type.
+
             if (module == null || module == "global")
             {
                 // Importing a built-in object from `global`.
@@ -656,9 +659,8 @@ public sealed class JSRuntimeContext : IDisposable
                     return new JSReference(propertyValue);
                 }
             }
-
         });
-        return reference.GetValue() ?? JSValue.Undefined;
+        return reference.GetValue();
     }
 
     /// <summary>

--- a/src/NodeApi/Interop/NodeStream.Proxy.cs
+++ b/src/NodeApi/Interop/NodeStream.Proxy.cs
@@ -97,7 +97,7 @@ public partial class NodeStream
         {
             if (s_duplexStreamAdapterReference != null)
             {
-                return s_duplexStreamAdapterReference.GetValue()!.Value;
+                return s_duplexStreamAdapterReference.GetValue();
             }
 
             var streamAdapter = new JSObject
@@ -116,7 +116,7 @@ public partial class NodeStream
         {
             if (s_readableStreamAdapterReference != null)
             {
-                return s_readableStreamAdapterReference.GetValue()!.Value;
+                return s_readableStreamAdapterReference.GetValue();
             }
 
             var streamAdapter = new JSObject
@@ -132,7 +132,7 @@ public partial class NodeStream
         {
             if (s_writableStreamAdapterReference != null)
             {
-                return s_writableStreamAdapterReference.GetValue()!.Value;
+                return s_writableStreamAdapterReference.GetValue();
             }
 
             var streamAdapter = new JSObject
@@ -181,7 +181,7 @@ public partial class NodeStream
             int count = await stream.ReadAsync(buffer, 0, ReadChunkSize);
 #endif
 
-            nodeStream = nodeStreamReference.GetValue()!.Value;
+            nodeStream = nodeStreamReference.GetValue();
             nodeStream.CallMethod(
                 "push", count == 0 ? JSValue.Null : new JSTypedArray<byte>(buffer, 0, count));
         }
@@ -189,7 +189,7 @@ public partial class NodeStream
         {
             try
             {
-                nodeStream = nodeStreamReference.GetValue()!.Value;
+                nodeStream = nodeStreamReference.GetValue();
                 nodeStream.CallMethod("destroy", new JSError(ex).Value);
             }
             catch (Exception)
@@ -253,7 +253,7 @@ public partial class NodeStream
             await stream.WriteAsync(chunk.ToArray(), 0, chunk.Length);
 #endif
 
-            callback = callbackReference.GetValue()!.Value;
+            callback = callbackReference.GetValue();
             callback.Call();
         }
         catch (Exception ex)
@@ -261,7 +261,7 @@ public partial class NodeStream
             bool isExceptionPending5 = JSError.IsExceptionPending();
             try
             {
-                callback = callbackReference.GetValue()!.Value;
+                callback = callbackReference.GetValue();
                 callback.Call(thisArg: JSValue.Undefined, new JSError(ex).Value);
             }
             catch (Exception)
@@ -292,14 +292,14 @@ public partial class NodeStream
         {
             await stream.FlushAsync();
 
-            callback = callbackReference.GetValue()!.Value;
+            callback = callbackReference.GetValue();
             callback.Call();
         }
         catch (Exception ex)
         {
             try
             {
-                callback = callbackReference.GetValue()!.Value;
+                callback = callbackReference.GetValue();
                 callback.Call(thisArg: JSValue.Undefined, new JSError(ex).Value);
             }
             catch (Exception)

--- a/src/NodeApi/Interop/NodeStream.cs
+++ b/src/NodeApi/Interop/NodeStream.cs
@@ -18,7 +18,7 @@ public partial class NodeStream : Stream
 
     public static explicit operator NodeStream(JSValue value) => new(value);
     public static implicit operator JSValue(NodeStream stream)
-        => stream._valueReference.GetValue() ?? default;
+        => stream._valueReference.GetValue();
 
     private NodeStream(JSValue value)
     {
@@ -53,8 +53,7 @@ public partial class NodeStream : Stream
         }));
     }
 
-    private JSValue Value => _valueReference.GetValue() ??
-        throw new ObjectDisposedException(nameof(NodeStream));
+    private JSValue Value => _valueReference.GetValue();
 
     public override bool CanRead => Value.HasProperty("read");
 

--- a/src/NodeApi/JSError.cs
+++ b/src/NodeApi/JSError.cs
@@ -153,7 +153,7 @@ public struct JSError
             {
                 try
                 {
-                    _message = (string?)_errorRef.GetValue()?["message"];
+                    _message = (string?)_errorRef.GetValue()["message"];
                 }
                 catch
                 {

--- a/src/NodeApi/JSEventEmitter.cs
+++ b/src/NodeApi/JSEventEmitter.cs
@@ -41,7 +41,7 @@ public class JSEventEmitter : IDisposable
     {
         if (_nodeEmitter != null)
         {
-            _nodeEmitter.GetValue()!.Value.CallMethod("addListener", eventName, listener);
+            _nodeEmitter.GetValue().CallMethod("addListener", eventName, listener);
             return;
         }
 
@@ -53,7 +53,7 @@ public class JSEventEmitter : IDisposable
         JSArray eventListeners;
         if (_listeners!.TryGetValue(eventName, out JSReference? eventListenersReference))
         {
-            eventListeners = (JSArray)eventListenersReference.GetValue()!.Value;
+            eventListeners = (JSArray)eventListenersReference.GetValue();
         }
         else
         {
@@ -68,13 +68,13 @@ public class JSEventEmitter : IDisposable
     {
         if (_nodeEmitter != null)
         {
-            _nodeEmitter.GetValue()!.Value.CallMethod("removeListener", eventName, listener);
+            _nodeEmitter.GetValue().CallMethod("removeListener", eventName, listener);
             return;
         }
 
         if (_listeners!.TryGetValue(eventName, out JSReference? eventListenersReference))
         {
-            JSArray eventListeners = (JSArray)eventListenersReference.GetValue()!.Value;
+            JSArray eventListeners = (JSArray)eventListenersReference.GetValue();
             eventListeners.Remove(listener);
         }
     }
@@ -83,7 +83,7 @@ public class JSEventEmitter : IDisposable
     {
         if (_nodeEmitter != null)
         {
-            _nodeEmitter.GetValue()!.Value.CallMethod(
+            _nodeEmitter.GetValue().CallMethod(
                 "once", eventName, JSValue.CreateFunction(eventName, listener));
             return;
         }
@@ -103,7 +103,7 @@ public class JSEventEmitter : IDisposable
     {
         if (_nodeEmitter != null)
         {
-            _nodeEmitter.GetValue()!.Value.CallMethod("once", eventName, listener);
+            _nodeEmitter.GetValue().CallMethod("once", eventName, listener);
             return;
         }
 
@@ -139,13 +139,13 @@ public class JSEventEmitter : IDisposable
     {
         if (_nodeEmitter != null)
         {
-            _nodeEmitter.GetValue()!.Value.CallMethod("emit", eventName);
+            _nodeEmitter.GetValue().CallMethod("emit", eventName);
             return;
         }
 
         if (_listeners!.TryGetValue(eventName, out JSReference? eventListenersReference))
         {
-            JSArray eventListeners = (JSArray)eventListenersReference.GetValue()!.Value;
+            JSArray eventListeners = (JSArray)eventListenersReference.GetValue();
             foreach (JSValue listener in eventListeners)
             {
                 listener.Call(thisArg: default);
@@ -157,13 +157,13 @@ public class JSEventEmitter : IDisposable
     {
         if (_nodeEmitter != null)
         {
-            _nodeEmitter.GetValue()!.Value.CallMethod("emit", eventName, arg);
+            _nodeEmitter.GetValue().CallMethod("emit", eventName, arg);
             return;
         }
 
         if (_listeners!.TryGetValue(eventName, out JSReference? eventListenersReference))
         {
-            JSArray eventListeners = (JSArray)eventListenersReference.GetValue()!.Value;
+            JSArray eventListeners = (JSArray)eventListenersReference.GetValue();
             foreach (JSValue listener in eventListeners)
             {
                 listener.Call(thisArg: default, arg);
@@ -178,13 +178,13 @@ public class JSEventEmitter : IDisposable
             JSValue[] argsArray = new JSValue[args.Length + 1];
             argsArray[0] = eventName;
             args.CopyTo(argsArray, 1);
-            _nodeEmitter.GetValue()!.Value.CallMethod("emit", argsArray);
+            _nodeEmitter.GetValue().CallMethod("emit", argsArray);
             return;
         }
 
         if (_listeners!.TryGetValue(eventName, out JSReference? eventListenersReference))
         {
-            JSArray eventListeners = (JSArray)eventListenersReference.GetValue()!.Value;
+            JSArray eventListeners = (JSArray)eventListenersReference.GetValue();
             foreach (JSValue listener in eventListeners)
             {
                 listener.Call(thisArg: default, args);

--- a/src/NodeApi/JSReference.cs
+++ b/src/NodeApi/JSReference.cs
@@ -28,8 +28,15 @@ public class JSReference : IDisposable
     private readonly napi_env _env;
     private readonly JSRuntimeContext? _context;
 
-    public bool IsWeak { get; private set; }
-
+    /// <summary>
+    /// Creates a new instance of a <see cref="JSReference"/> that holds a strong or weak
+    /// reference to a JS value.
+    /// </summary>
+    /// <param name="value">The JavaScript value to reference.</param>
+    /// <param name="isWeak">True if the reference will be "weak", meaning the reference does not
+    /// prevent the value from being released and garbage-collected. The default is false,
+    /// meaning the value will remain available at least until the "strong" reference is disposed.
+    /// </param>
     public JSReference(JSValue value, bool isWeak = false)
         : this(value.Runtime.CreateReference(
                   (napi_env)JSValueScope.Current,
@@ -40,6 +47,13 @@ public class JSReference : IDisposable
     {
     }
 
+    /// <summary>
+    /// Creates a new instance of a <see cref="JSReference"/> that holds a strong or weak
+    /// reference to a JS value.
+    /// </summary>
+    /// <param name="handle">The reference handle.</param>
+    /// <param name="isWeak">True if the handle is for a weak reference. This must match
+    /// the existing state of the handle.</param>
     public JSReference(napi_ref handle, bool isWeak = false)
     {
         JSValueScope currentScope = JSValueScope.Current;
@@ -50,6 +64,12 @@ public class JSReference : IDisposable
         _context = currentScope.RuntimeContext;
         IsWeak = isWeak;
     }
+
+    /// <summary>
+    /// Gets a value indicating whether the reference is weak.
+    /// </summary>
+    /// <returns>True if the reference is weak, false if it is strong.
+    public bool IsWeak { get; private set; }
 
     /// <summary>
     /// Gets the value handle, or throws an exception if access from the current thread is invalid.
@@ -73,6 +93,16 @@ public class JSReference : IDisposable
         return reference.Handle;
     }
 
+    /// <summary>
+    /// Creates a reference to a JS value, if the value is an object, function, or symbol.
+    /// </summary>
+    /// <param name="value">The JS value to reference.</param>
+    /// <param name="isWeak">True to create a weak reference, false to create a strong
+    /// reference.</param>
+    /// <param name="result">Returns the created reference, or <c>default(JSValue)</c>, equivalent
+    /// to <c>undefined</c>, if the value is not a referencable type.</param>
+    /// <returns>True if the reference was created, false if the reference could not be created
+    /// because the value is not a supported type for references.</returns>
     public static bool TryCreateReference(
         JSValue value, bool isWeak, [NotNullWhen(true)] out JSReference? result)
     {
@@ -139,15 +169,52 @@ public class JSReference : IDisposable
     }
 
     /// <summary>
-    /// Gets the referenced JS value, or null if the reference is weak and the value is
-    /// no longer available.
+    /// Gets the referenced JS value.
     /// </summary>
+    /// <returns>The referenced JS value.</returns>
     /// <exception cref="ObjectDisposedException">The reference is disposed.</exception>
-    public JSValue? GetValue()
+    /// <exception cref="NullReferenceException">The reference is weak and the weakly-referenced
+    /// JS value is not available.</exception>
+    /// <remarks>
+    /// Use this method with strong references when the referenced value is expected to be always
+    /// available. For weak references, use <see cref="TryGetValue(out JSValue)" /> instead.
+    /// </remarks>
+    public JSValue GetValue()
     {
         JSValueScope.CurrentRuntime.GetReferenceValue(Env, _handle, out napi_value result)
             .ThrowIfFailed();
+
+        // napi_get_reference_value() returns a null handle if the weak reference is invalid.
+        if (result == default)
+        {
+            throw new NullReferenceException("The weakly-referenced JS value not available.");
+        }
+
         return result;
+    }
+
+    /// <summary>
+    /// Attempts to get the referenced JS value.
+    /// </summary>
+    /// <param name="value">Returns the referenced JS value, or <c>default(JSValue)</c>, equivalent
+    /// to <c>undefined</c>, if the reference is weak and the value is not available.</param>
+    /// <returns>True if the value was obtained, false if the reference is weak and the value is
+    /// not available.</returns>
+    /// <exception cref="ObjectDisposedException">The reference is disposed.</exception>
+    public bool TryGetValue(out JSValue value)
+    {
+        JSValueScope.CurrentRuntime.GetReferenceValue(Env, _handle, out napi_value result)
+            .ThrowIfFailed();
+
+        // napi_get_reference_value() returns a null handle if the weak reference is invalid.
+        if (result == default)
+        {
+            value = default;
+            return false;
+        }
+
+        value = new JSValue(result);
+        return true;
     }
 
     /// <summary>

--- a/src/NodeApi/JSReference.cs
+++ b/src/NodeApi/JSReference.cs
@@ -18,9 +18,13 @@ namespace Microsoft.JavaScript.NodeApi;
 /// <see cref="JSReference"/> to maintain a reference to a JS value beyond a single scope.
 /// <para/>
 /// A <see cref="JSReference"/> should be disposed when no longer needed; this allows the JS value
-/// to be collected by the GC if it has no other references. The <see cref="JSReference"/> class
+/// to be collected by the JS GC if it has no other references. The <see cref="JSReference"/> class
 /// also has a finalizer so that the reference will be released when the C# object is GC'd. However
 /// explicit disposal is still preferable when possible.
+/// <para/>
+/// A "strong" reference ensures the JS value is available at least until the reference is disposed.
+/// A "weak" reference does not prevent the JS value from being released collected by the JS
+/// garbage-collector, but allows the value to be optimistically retrieved until then.
 /// </remarks>
 public class JSReference : IDisposable
 {
@@ -34,8 +38,9 @@ public class JSReference : IDisposable
     /// </summary>
     /// <param name="value">The JavaScript value to reference.</param>
     /// <param name="isWeak">True if the reference will be "weak", meaning the reference does not
-    /// prevent the value from being released and garbage-collected. The default is false,
-    /// meaning the value will remain available at least until the "strong" reference is disposed.
+    /// prevent the value from being released and collected by the JS garbage-collector. The
+    /// default is false, meaning the value will remain available at least until the "strong"
+    /// reference is disposed.
     /// </param>
     public JSReference(JSValue value, bool isWeak = false)
         : this(value.Runtime.CreateReference(

--- a/src/NodeApi/JSTypedArray.cs
+++ b/src/NodeApi/JSTypedArray.cs
@@ -217,8 +217,7 @@ public readonly struct JSTypedArray<T> : IEquatable<JSValue> where T : struct
             _typedArrayReference = new JSReference(typedArray);
         }
 
-        public JSValue JSValue => _typedArrayReference.GetValue() ??
-            throw new ObjectDisposedException(nameof(JSTypedArray<T>));
+        public JSValue JSValue => _typedArrayReference.GetValue();
 
         public override Span<T> GetSpan()
         {

--- a/src/NodeApi/Runtime/NodejsEnvironment.cs
+++ b/src/NodeApi/Runtime/NodejsEnvironment.cs
@@ -90,7 +90,7 @@ public sealed class NodejsEnvironment : IDisposable
         JSReference originalRequireRef = new(originalRequire);
         JSFunction envRequire = new("require", (modulePath) =>
         {
-            JSValue require = originalRequireRef.GetValue()!.Value;
+            JSValue require = originalRequireRef.GetValue();
             JSValue resolvedPath = ResolveModulePath(require, modulePath, baseDir);
             return require.Call(thisArg: default, resolvedPath);
         });
@@ -99,7 +99,7 @@ public sealed class NodejsEnvironment : IDisposable
         JSValue requireObject = (JSValue)envRequire;
         requireObject["resolve"] = new JSFunction("resolve", (modulePath) =>
         {
-            JSValue require = originalRequireRef.GetValue()!.Value;
+            JSValue require = originalRequireRef.GetValue();
             return ResolveModulePath(require, modulePath, baseDir);
         });
 
@@ -126,10 +126,10 @@ public sealed class NodejsEnvironment : IDisposable
                 JSReference originalImportRef = new(originalImport);
                 JSFunction envImport = new("import", (modulePath) =>
                 {
-                    JSValue require = originalRequireRef.GetValue()!.Value;
+                    JSValue require = originalRequireRef.GetValue();
                     JSValue resolvedPath = ResolveModulePath(require, modulePath, baseDir);
                     JSValue moduleUri = "file://" + (string)resolvedPath;
-                    JSValue import = originalImportRef.GetValue()!.Value;
+                    JSValue import = originalImportRef.GetValue();
                     return import.Call(thisArg: default, moduleUri);
                 });
 
@@ -286,7 +286,7 @@ public sealed class NodejsEnvironment : IDisposable
 
     private void RemoveUnhandledPromiseRejectionListener()
     {
-        JSValue listener = _unhandledPromiseRejectionListener!.GetValue()!.Value;
+        JSValue listener = _unhandledPromiseRejectionListener!.GetValue();
         JSValue.Global["process"].CallMethod("off", "unhandledRejection", listener);
         _unhandledPromiseRejectionListener.Dispose();
         _unhandledPromiseRejectionListener = null;

--- a/test/JSReferenceTests.cs
+++ b/test/JSReferenceTests.cs
@@ -25,7 +25,7 @@ public class JSReferenceTests
 
         JSValue value = JSValue.CreateObject();
         JSReference reference = new(value);
-        Assert.True(reference.GetValue()?.IsObject() ?? false);
+        Assert.True(reference.GetValue().IsObject());
     }
 
     [Fact]
@@ -40,7 +40,7 @@ public class JSReferenceTests
             reference = new JSReference(value);
         }
 
-        Assert.True(reference.GetValue()?.IsObject() ?? false);
+        Assert.True(reference.GetValue().IsObject());
     }
 
     [Fact]
@@ -72,5 +72,40 @@ public class JSReferenceTests
             using JSValueScope rootScope2 = TestScope(JSValueScopeType.Root);
             Assert.Throws<JSInvalidThreadAccessException>(() => reference.GetValue());
         }).Wait();
+    }
+
+    [Fact]
+    public void GetWeakReferenceUnavailable()
+    {
+        using JSValueScope rootScope = TestScope(JSValueScopeType.Root);
+
+        JSValue value = JSValue.CreateObject();
+        var reference = new JSReference(value, isWeak: true);
+
+        _mockRuntime.MockReleaseWeakReferenceValue(reference.Handle);
+        Assert.Throws<NullReferenceException>(() => reference.GetValue());
+    }
+
+    [Fact]
+    public void TryGetWeakReferenceValue()
+    {
+        using JSValueScope rootScope = TestScope(JSValueScopeType.Root);
+
+        JSValue value = JSValue.CreateObject();
+        JSReference reference = new(value);
+        Assert.True(reference.TryGetValue(out JSValue result));
+        Assert.True(result.IsObject());
+    }
+
+    [Fact]
+    public void TryGetWeakReferenceUnavailable()
+    {
+        using JSValueScope rootScope = TestScope(JSValueScopeType.Root);
+
+        JSValue value = JSValue.CreateObject();
+        var reference = new JSReference(value, isWeak: true);
+
+        _mockRuntime.MockReleaseWeakReferenceValue(reference.Handle);
+        Assert.False(reference.TryGetValue(out _));
     }
 }

--- a/test/MockJSRuntime.cs
+++ b/test/MockJSRuntime.cs
@@ -187,6 +187,17 @@ internal class MockJSRuntime : JSRuntime
         return _references.Remove(@ref.Handle) ? napi_ok : napi_invalid_arg;
     }
 
+    /// <summary>
+    /// Simulates the behavior of the JS runtime when a weakly-referenced value is released.
+    /// </summary>
+    public void MockReleaseWeakReferenceValue(napi_ref @ref)
+    {
+        if (_references.TryGetValue(@ref.Handle, out MockJSRef? mockRef))
+        {
+            mockRef.ValueHandle = 0;
+        }
+    }
+
     // Mocking the sync context prevents the runtime mock from having to implement APIs
     // to support initializing the thread-safe-function for the sync context.
     // Unit tests that use the mock runtime don't currently use the sync context.

--- a/test/TestCases/node-addon-api/binding.cs
+++ b/test/TestCases/node-addon-api/binding.cs
@@ -26,7 +26,7 @@ public class Binding
     {
         if (_testObjects.TryGetValue(typeof(T), out JSReference? testRef))
         {
-            return testRef.GetValue() ?? JSValue.Undefined;
+            return testRef.GetValue();
         }
 
         JSValue obj = new T().Init();


### PR DESCRIPTION
Fixes: #197 

 - Add a `JSReference.TryGetValue(out JSValue value)` method:
    - Returns `true` and the value if it succeeds.
    - Returns `false` and `default(JSValue)` if the reference is weak and the JS value is unavailable.
    - Throws `ObjectDisposedException` if the reference is disposed.
 - Change the `JSReference.GetValue()` method return type to a non-nullable `JSValue`, instead of the previous nullable return type.
    - Returns the value if it succeeds.
    - Throws `NullReferenceException` if the reference is weak and the JS value is unavailable.
    - Throws `ObjectDisposedException` if the reference is disposed.
 - Replace many instances of `GetValue()!.Value` with `GetValue()` in the codebase.
 - Update documentation.

I considered also adding generic variants of the methods above, to return more specific JS value types, but that will have to wait for #196 which adds the generic value type conversions.