### PR TITLE
Strip JS end-comment tokens when generating typedefs

### DIFF
--- a/src/NodeApi.Generator/TypeDefinitionsGenerator.cs
+++ b/src/NodeApi.Generator/TypeDefinitionsGenerator.cs
@@ -2196,7 +2196,7 @@ type DateTime = Date | { kind?: 'utc' | 'local' | 'unspecified' }
             }
         }
 
-        var text = node?.ToString() ?? string.Empty;
+        string text = node?.ToString() ?? string.Empty;
         text = s_newlineRegex.Replace(text.Replace("\r", ""), " ");
 
         // Remove end-comment tokens to prevent them from ending the JS doc-comments.

--- a/src/NodeApi.Generator/TypeDefinitionsGenerator.cs
+++ b/src/NodeApi.Generator/TypeDefinitionsGenerator.cs
@@ -2196,8 +2196,14 @@ type DateTime = Date | { kind?: 'utc' | 'local' | 'unspecified' }
             }
         }
 
-        return s_newlineRegex.Replace(
-            (node?.ToString() ?? string.Empty).Replace("\r", "").Trim(), " ");
+        var text = node?.ToString() ?? string.Empty;
+        text = s_newlineRegex.Replace(text.Replace("\r", ""), " ");
+
+        // Remove end-comment tokens to prevent them from ending the JS doc-comments.
+        text = text.Replace("*/", string.Empty);
+
+        text = text.Trim();
+        return text;
     }
 
     private static string FormatDocMethodName(MethodInfo method)

--- a/test/TypeDefsGeneratorTests.cs
+++ b/test/TypeDefsGeneratorTests.cs
@@ -156,7 +156,7 @@ public class TypeDefsGeneratorTests
             """.ReplaceLineEndings(),
         GenerateTypeDefinition(typeof(TestEnum), new Dictionary<string, string>
         {
-            ["T:TestEnum"] = "enum",
+            ["T:TestEnum"] = "enum */",
             ["F:TestEnum.Zero"] = "zero",
             ["F:TestEnum.One"] = "one",
         }));


### PR DESCRIPTION
Fixes: #329 