### PR TITLE
Fix ValueTask bugs

### DIFF
--- a/src/NodeApi.DotNetHost/JSMarshaller.cs
+++ b/src/NodeApi.DotNetHost/JSMarshaller.cs
@@ -2622,7 +2622,7 @@ public class JSMarshaller
         Type delegateType = typeof(JSValue.From<>).MakeGenericType(fromType);
         string delegateName = "from_" + FullTypeName(fromType);
 
-        Expression ConvertPromiseToJSValueExpression(Expression promiseExpression)
+        static Expression ConvertPromiseToJSValueExpression(Expression promiseExpression)
         {
             return Expression.Convert(
                 promiseExpression,

--- a/src/NodeApi.Generator/SymbolExtensions.cs
+++ b/src/NodeApi.Generator/SymbolExtensions.cs
@@ -162,7 +162,7 @@ internal static class SymbolExtensions
 
         // Generating the containing type will also generate the nested type,
         // so it should be found in the SymbolicTypes dictionary afterward.
-        typeSymbol.ContainingType?.AsType(genericTypeParameters: null, buildType);
+        typeSymbol.ContainingType?.AsType(genericTypeParameters, buildType);
 
         if (SymbolicTypes.TryGetValue(typeFullName, out Type? symbolicType))
         {

--- a/src/NodeApi/TaskExtensions.cs
+++ b/src/NodeApi/TaskExtensions.cs
@@ -63,6 +63,35 @@ public static class TaskExtensions
         return fromJS(await jsTask);
     }
 
+    public static async ValueTask<JSValue> AsValueTask(this JSPromise promise)
+    {
+        return await promise.AsTask();
+    }
+
+    public static async ValueTask<JSValue> AsValueTask(
+        this JSPromise promise,
+        CancellationToken cancellation)
+    {
+        return await promise.AsTask(cancellation);
+    }
+
+    public static async ValueTask<T> AsValueTask<T>(
+        this JSPromise promise,
+        JSValue.To<T> fromJS)
+    {
+        ValueTask<JSValue> jsTask = promise.AsValueTask();
+        return fromJS(await jsTask);
+    }
+
+    public static async ValueTask<T> AsValueTask<T>(
+        this JSPromise promise,
+        JSValue.To<T> fromJS,
+        CancellationToken cancellation)
+    {
+        ValueTask<JSValue> jsTask = promise.AsValueTask(cancellation);
+        return fromJS(await jsTask);
+    }
+
     public static JSPromise AsPromise(this Task task)
     {
         if (task.Status == TaskStatus.RanToCompletion)

--- a/test/TestCases/napi-dotnet/AsyncMethods.cs
+++ b/test/TestCases/napi-dotnet/AsyncMethods.cs
@@ -50,6 +50,20 @@ public static class AsyncMethods
             return $"Hey {greeter}!";
         }
     }
+
+
+    [JSExport("async_method_valuetask")]
+    public static async ValueTask ValueTaskTest()
+    {
+        await Task.Yield();
+    }
+
+    [JSExport("async_method_valuetask_of_string")]
+    public static async ValueTask<string> ValueTaskTest(string greeter)
+    {
+        await Task.Delay(50);
+        return $"Hey {greeter}!";
+    }
 }
 
 [JSExport]

--- a/test/TestCases/napi-dotnet/async_methods.js
+++ b/test/TestCases/napi-dotnet/async_methods.js
@@ -27,5 +27,10 @@ common.runTest(async () => {
   // A JS object that implements an interface can be returned from C#.
   binding.async_interface = asyncInterfaceImpl;
   assert.strictEqual(binding.async_interface, asyncInterfaceImpl);
+
+  // Invoke C# methods that return ValueTask.
+  await binding.async_method_valuetask();
+  const result5 = await binding.async_method_valuetask_of_string('buddy');
+  assert.strictEqual(result5, 'Hey buddy!');
 });
 


### PR DESCRIPTION
Fixes: #337

The generic type parameters were not getting propagated in one place, which caused a bug when reflecting on certain methods in a nested type, such as `ConfiguredValueTaskAwaitable<TResult>.ConfiguredValueTaskAwaiter` referenced by `ValueTask`.

Additionally the JS marshaller was missing some support for `ValueTask`.