### PR TITLE
Improve assembly resolve behavior

### DIFF
--- a/docs/scenarios/js-dotnet-dynamic.md
+++ b/docs/scenarios/js-dotnet-dynamic.md
@@ -104,9 +104,9 @@ For examples of this scenario, see one of these directories in the repo:
    of bin-placing all dependencies together. If some dependencies are are in another location,
    set up a `resolving` event handler _before_ loading the target assembly:
    ```JavaScript
-   dotnet.addListener('resolving', (name, version) => {
+   dotnet.addListener('resolving', (name, version, resolve) => {
        const filePath = path.join(__dirname, 'bin', name + '.dll');
-       if (fs.existsSync(filePath)) dotnet.load(filePath);
+       if (fs.existsSync(filePath)) resolve(filePath);
    });
    ```
 

--- a/examples/semantic-kernel/example.js
+++ b/examples/semantic-kernel/example.js
@@ -2,9 +2,6 @@
 // Licensed under the MIT License.
 
 import dotnet from 'node-api-dotnet';
-import './bin/System.Text.Encodings.Web.js';
-import './bin/Microsoft.Extensions.DependencyInjection.js';
-import './bin/Microsoft.Extensions.Logging.Abstractions.js';
 import './bin/Microsoft.SemanticKernel.Abstractions.js';
 import './bin/Microsoft.SemanticKernel.Core.js';
 import './bin/Microsoft.SemanticKernel.Connectors.OpenAI.js';

--- a/src/NodeApi.DotNetHost/ManagedHost.cs
+++ b/src/NodeApi.DotNetHost/ManagedHost.cs
@@ -39,17 +39,6 @@ public sealed class ManagedHost : JSEventEmitter, IDisposable
     private readonly AssemblyLoadContext _loadContext = new(name: default);
 #endif
 
-    /// <summary>
-    /// Path to the assembly currently being loaded, or null when not loading.
-    /// </summary>
-    /// <remarks>
-    /// This is used to automatically load dependency assemblies from the same directory as
-    /// the initially loaded assembly, if there was no location provided by a resolve handler.
-    /// Note since a .NET host cannot be shared by multiple JS threads (workers), only one
-    /// assembly can be loaded at a time.
-    /// </remarks>
-    private string? _loadingPath;
-
     private JSValueScope? _rootScope;
 
     /// <summary>
@@ -67,6 +56,11 @@ public sealed class ManagedHost : JSEventEmitter, IDisposable
     /// loaded assemblies.
     /// </summary>
     private readonly Dictionary<string, Assembly> _loadedAssembliesByName = new();
+
+    /// <summary>
+    /// Tracks names of assemblies that have been exported to JS.
+    /// </summary>
+    private readonly HashSet<string> _exportedAssembliesByName = new();
 
     /// <summary>
     /// Mapping from assembly file paths to strong references to module exports.
@@ -139,16 +133,11 @@ public sealed class ManagedHost : JSEventEmitter, IDisposable
                 Environment.GetEnvironmentVariable("NODE_API_DELAYLOAD") != "0"
         };
 
-        // Export the System.Runtime and System.Console assemblies by default.
-        _typeExporter.ExportAssemblyTypes(typeof(object).Assembly);
-        _loadedAssembliesByName.Add(
-            typeof(object).Assembly.GetName().Name!, typeof(object).Assembly);
-
+        // System.Runtime and System.Console assembly types are auto-exported on first use.
+        _exportedAssembliesByName.Add(typeof(object).Assembly.GetName().Name!);
         if (typeof(Console).Assembly != typeof(object).Assembly)
         {
-            _typeExporter.ExportAssemblyTypes(typeof(Console).Assembly);
-            _loadedAssembliesByName.Add(
-                typeof(Console).Assembly.GetName().Name!, typeof(Console).Assembly);
+            _exportedAssembliesByName.Add(typeof(Console).Assembly.GetName().Name!);
         }
     }
 
@@ -276,40 +265,63 @@ public sealed class ManagedHost : JSEventEmitter, IDisposable
             return typeof(ManagedHost).Assembly;
         }
 
-        Trace($"    Resolving assembly: {assemblyName} {assemblyVersion}");
-        Emit(ResolvingEventName, assemblyName, assemblyVersion!);
+        Trace($"> ManagedHost.OnResolvingAssembly({assemblyName}, {assemblyVersion})");
 
-        // Resolve listeners may call load(assemblyFilePath) to load the requested assembly.
-        // The version of the loaded assembly might not match the requested version.
-        if (_loadedAssembliesByName.TryGetValue(assemblyName, out Assembly? assembly))
+        // Try to load the named assembly from .NET system directories.
+        Assembly? assembly;
+        try
         {
-            Trace($"        Resolved at: {assembly.Location}");
-            return assembly;
+            assembly = LoadAssembly(assemblyName, allowNativeLibrary: false);
+        }
+        catch (FileNotFoundException)
+        {
+            // The assembly was not found in the system directories.
+            // Emit a resolving event to allow listeners to load the assembly.
+            // Resolve listeners may call load(assemblyFilePath) to load the requested assembly.
+            Emit(
+                ResolvingEventName,
+                assemblyName,
+                assemblyVersion!,
+                new JSFunction(ResolveAssembly));
+            _loadedAssembliesByName.TryGetValue(assemblyName, out assembly);
         }
 
-        if (!string.IsNullOrEmpty(_loadingPath))
+        if (assembly == null)
         {
             // The dependency assembly was not resolved by an event-handler.
-            // Look for it in the same directory as the initially loaded assembly.
-            string adjacentPath = Path.Combine(
-                Path.GetDirectoryName(_loadingPath) ?? string.Empty,
-                assemblyName + ".dll");
-            try
+            // Look for it in the same directory as any already-loaded assemblies.
+            foreach (var loadedAssemblyFile in
+                _loadedModules.Keys.Concat(_loadedAssembliesByPath.Keys))
             {
-                assembly = LoadAssembly(adjacentPath);
+                string assemblyDirectory =
+                    Path.GetDirectoryName(loadedAssemblyFile) ?? string.Empty;
+                if (!string.IsNullOrEmpty(assemblyDirectory))
+                {
+                    string adjacentPath = Path.Combine(assemblyDirectory, assemblyName + ".dll");
+                    try
+                    {
+                        assembly = LoadAssembly(adjacentPath, allowNativeLibrary: false);
+                        break;
+                    }
+                    catch (FileNotFoundException)
+                    {
+                        Trace($"  ManagedHost.OnResolvingAssembly(" +
+                            $"{assemblyName}) not found at {adjacentPath}");
+                    }
+                }
             }
-            catch (FileNotFoundException)
-            {
-                Trace($"    Assembly not found at: {adjacentPath}");
-                return default;
-            }
-
-            Trace($"        Resolved at: {assembly.Location}");
-            return assembly;
         }
 
-        Trace($"    Assembly not resolved: {assemblyName}");
-        return default;
+        if (assembly != null)
+        {
+            Trace($"< ManagedHost.OnResolvingAssembly({assemblyName}) => {assembly.Location}");
+            return assembly;
+        }
+        else
+        {
+            Trace($"< ManagedHost.OnResolvingAssembly({assemblyName}) => not resolved");
+            return default;
+        }
     }
 
     public static JSValue GetRuntimeVersion(JSCallbackArgs _)
@@ -349,22 +361,13 @@ public sealed class ManagedHost : JSEventEmitter, IDisposable
         }
 
         Assembly assembly;
-        string? previousLoadingPath = _loadingPath;
-        try
-        {
-            _loadingPath = assemblyFilePath;
 
 #if NETFRAMEWORK || NETSTANDARD
-            // TODO: Load module assemblies in separate appdomains.
-            assembly = Assembly.LoadFrom(assemblyFilePath);
+        // TODO: Load module assemblies in separate appdomains.
+        assembly = Assembly.LoadFrom(assemblyFilePath);
 #else
-            assembly = _loadContext.LoadFromAssemblyPath(assemblyFilePath);
+        assembly = _loadContext.LoadFromAssemblyPath(assemblyFilePath);
 #endif
-        }
-        finally
-        {
-            _loadingPath = previousLoadingPath;
-        }
 
         MethodInfo? initializeMethod = null;
 
@@ -455,16 +458,34 @@ public sealed class ManagedHost : JSEventEmitter, IDisposable
     {
         string assemblyNameOrFilePath = (string)args[0];
 
-        if (!_loadedAssembliesByPath.ContainsKey(assemblyNameOrFilePath) &&
-            !_loadedAssembliesByName.ContainsKey(assemblyNameOrFilePath))
+        Assembly? assembly;
+        if (!_loadedAssembliesByPath.TryGetValue(assemblyNameOrFilePath, out assembly) &&
+            !_loadedAssembliesByName.TryGetValue(assemblyNameOrFilePath, out assembly))
         {
-            LoadAssembly(assemblyNameOrFilePath, allowNativeLibrary: true);
+            assembly = LoadAssembly(assemblyNameOrFilePath, allowNativeLibrary: true);
+        }
+
+        if (!_exportedAssembliesByName.Contains(assembly.GetName().Name!))
+        {
+            _typeExporter.ExportAssemblyTypes(assembly);
+            _exportedAssembliesByName.Add(assembly.GetName().Name!);
         }
 
         return default;
     }
 
-    private Assembly LoadAssembly(string assemblyNameOrFilePath, bool allowNativeLibrary = false)
+    /// <summary>
+    /// Callback from the 'resolving' event which completes the resolve operation by loading an
+    /// assembly from a file path specified by the event listener.
+    /// </summary>
+    private JSValue ResolveAssembly(JSCallbackArgs args)
+    {
+        string assemblyFilePath = (string)args[0];
+        LoadAssembly(assemblyFilePath, allowNativeLibrary: false);
+        return default;
+    }
+
+    private Assembly LoadAssembly(string assemblyNameOrFilePath, bool allowNativeLibrary)
     {
         Trace($"> ManagedHost.LoadAssembly({assemblyNameOrFilePath})");
 
@@ -477,14 +498,21 @@ public sealed class ManagedHost : JSEventEmitter, IDisposable
                 Path.GetDirectoryName(typeof(object).Assembly.Location)!,
                 assemblyFilePath + ".dll");
 
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            // Also support loading ASP.NET system assemblies.
+            string assemblyFilePath2 = assemblyFilePath.Replace(
+                    "Microsoft.NETCore.App", "Microsoft.AspNetCore.App");
+            if (File.Exists(assemblyFilePath2))
+            {
+                assemblyFilePath = assemblyFilePath2;
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 // Also support loading Windows-specific system assemblies.
-                string assemblyFilePath2 = assemblyFilePath.Replace(
+                string assemblyFilePath3 = assemblyFilePath.Replace(
                     "Microsoft.NETCore.App", "Microsoft.WindowsDesktop.App");
-                if (File.Exists(assemblyFilePath2))
+                if (File.Exists(assemblyFilePath3))
                 {
-                    assemblyFilePath = assemblyFilePath2;
+                    assemblyFilePath = assemblyFilePath3;
                 }
             }
         }
@@ -496,19 +524,14 @@ public sealed class ManagedHost : JSEventEmitter, IDisposable
         }
 
         Assembly assembly;
-        string? previousLoadingPath = _loadingPath;
         try
         {
-            _loadingPath = assemblyFilePath;
-
 #if NETFRAMEWORK || NETSTANDARD
             // TODO: Load assemblies in a separate appdomain.
             assembly = Assembly.LoadFrom(assemblyFilePath);
 #else
             assembly = _loadContext.LoadFromAssemblyPath(assemblyFilePath);
 #endif
-
-            _typeExporter.ExportAssemblyTypes(assembly);
         }
         catch (BadImageFormatException)
         {
@@ -522,18 +545,19 @@ public sealed class ManagedHost : JSEventEmitter, IDisposable
             // any later DllImport operations for the same library name.
             NativeLibrary.Load(assemblyFilePath);
 
-            Trace("< ManagedHost.LoadAssembly() => loaded native library");
+            Trace($"< ManagedHost.LoadAssembly() => {assemblyFilePath} (native library)");
             return null!;
         }
-        finally
+        catch (FileNotFoundException fnfex)
         {
-            _loadingPath = previousLoadingPath;
+            throw new FileNotFoundException(
+                $"Assembly file not found: {assemblyNameOrFilePath}", fnfex);
         }
 
         _loadedAssembliesByPath.Add(assemblyFilePath, assembly);
         _loadedAssembliesByName.Add(assembly.GetName().Name!, assembly);
 
-        Trace("< ManagedHost.LoadAssembly() => newly loaded");
+        Trace($"< ManagedHost.LoadAssembly() => {assemblyFilePath}, {assembly.GetName().Version}");
         return assembly;
     }
 

--- a/src/NodeApi.DotNetHost/ManagedHost.cs
+++ b/src/NodeApi.DotNetHost/ManagedHost.cs
@@ -290,7 +290,7 @@ public sealed class ManagedHost : JSEventEmitter, IDisposable
         {
             // The dependency assembly was not resolved by an event-handler.
             // Look for it in the same directory as any already-loaded assemblies.
-            foreach (var loadedAssemblyFile in
+            foreach (string? loadedAssemblyFile in
                 _loadedModules.Keys.Concat(_loadedAssembliesByPath.Keys))
             {
                 string assemblyDirectory =
@@ -458,8 +458,7 @@ public sealed class ManagedHost : JSEventEmitter, IDisposable
     {
         string assemblyNameOrFilePath = (string)args[0];
 
-        Assembly? assembly;
-        if (!_loadedAssembliesByPath.TryGetValue(assemblyNameOrFilePath, out assembly) &&
+        if (!_loadedAssembliesByPath.TryGetValue(assemblyNameOrFilePath, out Assembly? assembly) &&
             !_loadedAssembliesByName.TryGetValue(assemblyNameOrFilePath, out assembly))
         {
             assembly = LoadAssembly(assemblyNameOrFilePath, allowNativeLibrary: true);

--- a/src/node-api-dotnet/index.d.ts
+++ b/src/node-api-dotnet/index.d.ts
@@ -71,12 +71,20 @@ export function load(assemblyNameOrFilePath: string): void;
 
 /**
  * Adds a listener for the `resolving` event, which is raised when a .NET assembly requires
- * an additional dependent assembly to be resolved and loaded. The listener must call `load()`
- * to load the requested assembly file.
+ * an additional dependent assembly to be resolved and loaded. The listener may call `resolve()`
+ * to load the requested assembly from a resolved file path. If the listener does not call
+ * `resolve()`, the runtime will then attempt to resolve the assembly by searching in the same
+ * application directory as other already-loaded assemblies, if there were any.
  */
 export function addListener(
   event: 'resolving',
-  listener: (assemblyName: string, assemblyVersion: string) => void,
+  /**
+   * Resolving event listener funciton to be invokved when a .NET assembly is being resolved.
+   * @param assemblyName Name of the assembly to be resolved.
+   * @param assemblyVersion Version of the assembly to be resolved.
+   * @param resolve Callback to invoke with the full path to the resolved assembly file.
+   */
+  listener: (assemblyName: string, assemblyVersion: string, resolve: (string) => void) => void,
 ): void;
 
 /**

--- a/version.json
+++ b/version.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
 
-	"version": "0.7",
+	"version": "0.8",
 
 	"publicReleaseRefSpec": [
 		"^refs/heads/main$",


### PR DESCRIPTION
Fixes: #286 

 - Update the `resolving` event to separate the functionality of resolving an assembly from dynamically exporting an assembly's types.
 - Search .NET system directories (`Microsoft.NETCore.App`, `Microsoft.AspNetCore.App`, and `Microsoft.WindowsDesktop.App` if present) when resolving assemblies, before raising the `resolving` event.
 - Search directories of already-resolved assemblies when an assembly is not resolved by the `resolving` event listener.
 - Defer dynamic export of `System.Runtime` and `System.Console` assembly types until the first time the `dotnet.System` property is accessed from JavaScript. This significantly improves startup time for scenarios that do not use dynamic export.
 - Bump version to `0.8`