### PR TITLE
Fix subclass typedefs

### DIFF
--- a/examples/semantic-kernel/package.json
+++ b/examples/semantic-kernel/package.json
@@ -9,6 +9,6 @@
   },
   "devDependencies": {
     "@types/node": "^20.8.10",
-    "typescript": "^5.3.3"
+    "typescript": "~5.5.4"
   }
 }

--- a/src/NodeApi.DotNetHost/JSMarshaller.cs
+++ b/src/NodeApi.DotNetHost/JSMarshaller.cs
@@ -2181,9 +2181,9 @@ public class JSMarshaller
             else if (toType == typeof(CancellationToken))
             {
                 MethodInfo toAbortSignal = typeof(JSAbortSignal).GetExplicitConversion(
-                    typeof(JSValue), typeof(JSAbortSignal));
+                    typeof(JSValue), typeof(JSAbortSignal?));
                 MethodInfo toCancellationToken = typeof(JSAbortSignal).GetExplicitConversion(
-                    typeof(JSAbortSignal), typeof(CancellationToken));
+                    typeof(JSAbortSignal?), typeof(CancellationToken));
                 statements = new[]
                 {
                     Expression.Call(

--- a/src/NodeApi.Generator/SourceGenerator.cs
+++ b/src/NodeApi.Generator/SourceGenerator.cs
@@ -42,6 +42,7 @@ public abstract class SourceGenerator
         UnsupportedMethodReturnType,
         UnsupportedOverloads,
         UnsupportedIndexer,
+        UnsupportedExtensionMethod,
         ReferenedTypeNotExported,
         ESModulePropertiesAreConst,
         DocLoadError,

--- a/src/NodeApi.Generator/TypeDefinitionsGenerator.cs
+++ b/src/NodeApi.Generator/TypeDefinitionsGenerator.cs
@@ -1897,9 +1897,12 @@ type DateTime = Date | { kind?: 'utc' | 'local' | 'unspecified' }
         NullabilityInfo? nullability,
         bool allowTypeParams = true)
     {
+        // Types exported from a module are not namespaced.
+        string nsPrefix = !_isModule && type.Namespace != null ? type.Namespace + '.' : "";
+
         string tsType = type.IsNested ?
             GetTSType(type.DeclaringType!, null, allowTypeParams) + '.' + type.Name :
-            (type.Namespace != null ? type.Namespace + '.' + type.Name : type.Name);
+            nsPrefix + type.Name;
 
         int typeNameEnd = tsType.IndexOf('`');
         if (typeNameEnd > 0)

--- a/src/NodeApi/Interop/JSAbortSignal.cs
+++ b/src/NodeApi/Interop/JSAbortSignal.cs
@@ -55,6 +55,9 @@ public readonly struct JSAbortSignal : IJSValue<JSAbortSignal>
     public static explicit operator CancellationToken(JSAbortSignal signal)
         => signal.ToCancellationToken();
 
+    public static explicit operator CancellationToken(JSAbortSignal? signal)
+        => signal?.ToCancellationToken() ?? default;
+
     public static explicit operator JSAbortSignal(CancellationToken cancellation)
         => FromCancellationToken(cancellation);
 

--- a/test/TestCases/projects/js-cjs-dynamic/package.json
+++ b/test/TestCases/projects/js-cjs-dynamic/package.json
@@ -8,6 +8,6 @@
   },
   "devDependencies": {
     "@types/node": "^18.16.14",
-    "typescript": "^5.0.4"
+    "typescript": "~5.5.4"
   }
 }

--- a/test/TestCases/projects/js-cjs-module/package.json
+++ b/test/TestCases/projects/js-cjs-module/package.json
@@ -8,6 +8,6 @@
   },
   "devDependencies": {
     "@types/node": "^18.16.14",
-    "typescript": "^5.0.4"
+    "typescript": "~5.5.4"
   }
 }

--- a/test/TestCases/projects/js-esm-dynamic/package.json
+++ b/test/TestCases/projects/js-esm-dynamic/package.json
@@ -9,6 +9,6 @@
   },
   "devDependencies": {
     "@types/node": "^18.16.14",
-    "typescript": "^5.0.4"
+    "typescript": "~5.5.4"
   }
 }

--- a/test/TestCases/projects/js-esm-module/package.json
+++ b/test/TestCases/projects/js-esm-module/package.json
@@ -9,6 +9,6 @@
   },
   "devDependencies": {
     "@types/node": "^18.16.14",
-    "typescript": "^5.0.4"
+    "typescript": "~5.5.4"
   }
 }

--- a/test/TestCases/projects/ts-cjs-dynamic/package.json
+++ b/test/TestCases/projects/ts-cjs-dynamic/package.json
@@ -8,6 +8,6 @@
   },
   "devDependencies": {
     "@types/node": "^18.16.14",
-    "typescript": "^5.0.4"
+    "typescript": "~5.5.4"
   }
 }

--- a/test/TestCases/projects/ts-cjs-module/package.json
+++ b/test/TestCases/projects/ts-cjs-module/package.json
@@ -8,6 +8,6 @@
   },
   "devDependencies": {
     "@types/node": "^18.16.14",
-    "typescript": "^5.0.4"
+    "typescript": "~5.5.4"
   }
 }

--- a/test/TestCases/projects/ts-esm-dynamic/package.json
+++ b/test/TestCases/projects/ts-esm-dynamic/package.json
@@ -9,6 +9,6 @@
   },
   "devDependencies": {
     "@types/node": "^18.16.14",
-    "typescript": "^5.0.4"
+    "typescript": "~5.5.4"
   }
 }

--- a/test/TestCases/projects/ts-esm-module/package.json
+++ b/test/TestCases/projects/ts-esm-module/package.json
@@ -9,6 +9,6 @@
   },
   "devDependencies": {
     "@types/node": "^18.16.14",
-    "typescript": "^5.0.4"
+    "typescript": "~5.5.4"
   }
 }

--- a/test/TypeDefsGeneratorTests.cs
+++ b/test/TypeDefsGeneratorTests.cs
@@ -198,7 +198,7 @@ public class TypeDefsGeneratorTests
             /** generic-class */
             export class GenericClass$1<T> implements GenericInterface$1<T> {
             	/** constructor */
-            	new(value: T): GenericClass$1<T>;
+            	constructor(value: T);
 
             	/** instance-property */
             	TestProperty: T;


### PR DESCRIPTION
So far the subclass (`extends`) information has been missing from the generated typedefs. Instead, subclasses included all inherited members, so the hierarchy was flattened. That could cause problems working with some APIs that depend on polymorphism. I'm pretty sure I did it that way because I had trouble getting subclasses to compile without errors originally, and just forgot to come back to it. There were some complexities related to overloads, extension methods, and base type references, which I've managed to resolve now.

This also fixes marshalling of optional `AbortSignal` to/from `CancellationToken` which I noticed while testing the semantic-kernel example.