### PR TITLE
Fix generator bugs with un-namespaced types

### DIFF
--- a/src/NodeApi.DotNetHost/JSMarshaller.cs
+++ b/src/NodeApi.DotNetHost/JSMarshaller.cs
@@ -577,8 +577,9 @@ public class JSMarshaller
             string name = method.Name;
             if (method.DeclaringType!.IsInterface)
             {
-                name = method.DeclaringType.Namespace + '.' +
-                    method.DeclaringType.Name + '.' + name;
+                string nsPrefix = method.DeclaringType.Namespace != null ?
+                    method.DeclaringType.Namespace + '.' : string.Empty;
+                name = nsPrefix + method.DeclaringType.Name + '.' + name;
             }
 
             ParameterInfo[] allMethodParameters = method.GetParameters();
@@ -1097,8 +1098,9 @@ public class JSMarshaller
             string name = "get_" + property.Name;
             if (property.DeclaringType!.IsInterface)
             {
-                name = property.DeclaringType.Namespace + '.' +
-                    property.DeclaringType.Name + '.' + name;
+                string nsPrefix = property.DeclaringType.Namespace != null ?
+                    property.DeclaringType.Namespace + '.' : string.Empty;
+                name = nsPrefix + property.DeclaringType.Name + '.' + name;
             }
 
             ParameterExpression thisParameter = Expression.Parameter(typeof(JSValue), "__this");
@@ -1167,8 +1169,9 @@ public class JSMarshaller
             string name = "set_" + property.Name;
             if (property.DeclaringType!.IsInterface)
             {
-                name = property.DeclaringType.Namespace + '.' +
-                    property.DeclaringType.Name + '.' + name;
+                string nsPrefix = property.DeclaringType.Namespace != null ?
+                    property.DeclaringType.Namespace + '.' : string.Empty;
+                name = nsPrefix + property.DeclaringType.Name + '.' + name;
             }
 
             ParameterExpression thisParameter =

--- a/src/NodeApi.Generator/ExpressionExtensions.cs
+++ b/src/NodeApi.Generator/ExpressionExtensions.cs
@@ -339,7 +339,8 @@ internal static class ExpressionExtensions
             }
             else
             {
-                return $"{type.Namespace}.{type.Name.Substring(0, type.Name.IndexOf('`'))}<{typeArgs}>";
+                string nsPrefix = type.Namespace != null ? type.Namespace + "." : string.Empty;
+                return $"{nsPrefix}{type.Name.Substring(0, type.Name.IndexOf('`'))}<{typeArgs}>";
             }
         }
         else if (type.IsNested)

--- a/src/NodeApi.Generator/ModuleGenerator.cs
+++ b/src/NodeApi.Generator/ModuleGenerator.cs
@@ -837,7 +837,12 @@ public class ModuleGenerator : SourceGenerator, ISourceGenerator
         JSMarshaller _marshaller)
     {
         string ns = GetNamespace(interfaceType);
-        string adapterName = $"proxy_{ns.Replace('.', '_')}_{interfaceType.Name}";
+        if (ns.Length > 0)
+        {
+            ns += '_';
+        }
+
+        string adapterName = $"proxy_{ns.Replace('.', '_')}{interfaceType.Name}";
 
         static string ReplaceMethodVariables(string cs) =>
             cs.Replace(typeof(JSValue).Namespace + ".", "")


### PR DESCRIPTION
Related: #265 

This fixes a few cases in which the module generator produced invalid code for un-namespaced types exported from C# with `[JSExport]`.

I didn't add new test cases for this because it would require duplicating a lot of existing tests. But I did run all the existing module-export tests without namespaces to verify the fixes.

This does not add support for dynamic invocation of un-namespaced types. I am unsure whether it is a good idea to support that at all: with the way types from all loaded assemblies are merged into a combined namespace hierarchy, it could be easy to encounter name conflicts among un-namespaced types.