### PR TITLE
Build and publish symbol nuget packages

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -223,7 +223,7 @@ jobs:
           ConnectedServiceName: ESRP-JsHost2
           FolderPath: $(Build.SourcesDirectory)/out/pkg
           Pattern: |
-            **/Microsoft.JavaScript.NodeApi.*.nupkg
+            **/Microsoft.JavaScript.NodeApi.*.*nupkg
           UseMinimatch: true
           signConfigType: inlineSignParams
           inlineOperation: |
@@ -250,7 +250,7 @@ jobs:
           sourceFolder: $(Build.SourcesDirectory)/out/pkg
           targetFolder: $(Build.StagingDirectory)/pkg
           contents: |
-            *.nupkg
+            *.*nupkg
             *.tgz
 
       - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,7 +72,7 @@ jobs:
       with:
         name: ${{ matrix.os }}-${{ matrix.configuration }}-packages
         path: |
-          out/pkg/*.nupkg
+          out/pkg/*.*nupkg
           out/pkg/*.tgz
 
     - name: Test

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -23,6 +23,11 @@
     <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
+
   <PropertyGroup Condition=" '$(PublishAot)' == 'true' ">
     <!-- Modify the build output paths when publishing for AOT. This enables separately compiling
          AOT and non-AOT flavors of the same project, which is necessary because .NET 8 blocks


### PR DESCRIPTION
Part of #177

 - Produce symbol nuget packages (`.snupkg`) with `dotnet pack`.
 - Publish both library and symbol packages (`*.*nupkg`) as build artifacts. (A separate release pipeline consumes the build artifacts and pushes to nuget.)
 - When pushing to nuget, the symbol packages in the same directory [should be automatically pushed also](https://learn.microsoft.com/en-us/nuget/create-packages/symbol-packages-snupkg#publishing-a-symbol-package).
