### PR TITLE
Include inner message in exception thrown from JS thread

### DIFF
--- a/src/NodeApi/JSException.cs
+++ b/src/NodeApi/JSException.cs
@@ -43,7 +43,7 @@ public class JSException : Exception
     /// This constructor must be called while still on the JS thread.
     /// </remarks>
     internal JSException(Exception innerException)
-        : this("Exception thrown from JS thread. See inner exception for details.", innerException)
+        : this("Exception thrown from JS thread: " + innerException?.Message, innerException)
     {
         JSException? innerJSException = innerException as JSException;
         JSValue? jsError = innerJSException?.Error?.Value;

--- a/test/NodejsEmbeddingTests.cs
+++ b/test/NodejsEmbeddingTests.cs
@@ -214,7 +214,7 @@ public class NodejsEmbeddingTests
             });
         });
 
-        Assert.StartsWith("Exception thrown from JS thread.", exception.Message);
+        Assert.Equal("Exception thrown from JS thread: test", exception.Message);
         Assert.IsType<JSException>(exception.InnerException);
 
         exception = (JSException)exception.InnerException;


### PR DESCRIPTION
In many cases (like in #366) it may not be easy to get the inner exception message, so "see inner exception for details" wasn't very helpful. It is better to append the inner exception message to the outer exception message.