### PR TITLE
Handle pointer types when converting type symbols to types

### DIFF
--- a/src/NodeApi.Generator/SymbolExtensions.cs
+++ b/src/NodeApi.Generator/SymbolExtensions.cs
@@ -113,6 +113,11 @@ internal static class SymbolExtensions
             return arrayTypeSymbol.ElementType.AsType(genericTypeParameters, buildType)
                 .MakeArrayType();
         }
+        else if (typeSymbol is IPointerTypeSymbol pointerTypeSymbol)
+        {
+            return pointerTypeSymbol.PointedAtType.AsType(genericTypeParameters, buildType)
+                .MakePointerType();
+        }
 
         if (typeSymbol is ITypeParameterSymbol typeParameterSymbol)
         {


### PR DESCRIPTION
Fixes: #387

While pointer types aren't supported by the JS marshaller, they don't get excluded until a later phase of the code-generation, so they need to be handled during the phase of converting type symbols to types.

Issue #387 occurred only inside Visual Studio because VS uses .NET Framework for compilation which has a slightly different definition of `Memory<>`, which has a public constructor that has a pointer parameter.