### PR TITLE
Fix camel-case conversions to ignore allcaps

### DIFF
--- a/src/NodeApi.DotNetHost/JSMarshaller.cs
+++ b/src/NodeApi.DotNetHost/JSMarshaller.cs
@@ -163,7 +163,7 @@ public class JSMarshaller
         return name;
     }
 
-    private Expression JSMemberNameExpression(MemberInfo member)
+    private UnaryExpression JSMemberNameExpression(MemberInfo member)
     {
         string name = member.Name;
         int lastDotIndex = name.LastIndexOf('.');

--- a/src/NodeApi.DotNetHost/JSMarshaller.cs
+++ b/src/NodeApi.DotNetHost/JSMarshaller.cs
@@ -143,6 +143,11 @@ public class JSMarshaller
         while (name[firstLetterIndex] == '_')
         {
             firstLetterIndex++;
+            if (firstLetterIndex == name.Length)
+            {
+                // Only underscores.
+                return name;
+            }
         }
 
         // Only convert if it looks like title-case. (Avoid converting ALLCAPS.)

--- a/src/NodeApi.DotNetHost/JSMarshaller.cs
+++ b/src/NodeApi.DotNetHost/JSMarshaller.cs
@@ -131,13 +131,54 @@ public class JSMarshaller
     /// </summary>
     public bool AutoCamelCase { get; set; }
 
-    private string ToCamelCase(string name)
+    public static string ToCamelCase(string name)
     {
-        if (!AutoCamelCase) return name;
+        if (name.Length == 0)
+        {
+            return name;
+        }
 
-        StringBuilder sb = new(name);
-        sb[0] = char.ToLowerInvariant(sb[0]);
-        return sb.ToString();
+        // Skip leading underscores.
+        int firstLetterIndex = 0;
+        while (name[firstLetterIndex] == '_')
+        {
+            firstLetterIndex++;
+        }
+
+        // Only convert if it looks like title-case. (Avoid converting ALLCAPS.)
+        if (char.IsUpper(name[firstLetterIndex]))
+        {
+            for (int i = firstLetterIndex + 1; i < name.Length; i++)
+            {
+                if (char.IsLower(name[i]))
+                {
+                    // Found at least one lowercase letter. Convert to camel-case and return.
+                    char[] chars = name.ToCharArray();
+                    chars[firstLetterIndex] = char.ToLower(name[firstLetterIndex]);
+                    return new string(chars);
+                }
+            }
+        }
+
+        return name;
+    }
+
+    private Expression JSMemberNameExpression(MemberInfo member)
+    {
+        string name = member.Name;
+        int lastDotIndex = name.LastIndexOf('.');
+        if (lastDotIndex > 0)
+        {
+            // For explicit interface implementations, use the simple name.
+            name = name.Substring(lastDotIndex + 1);
+        }
+
+        string jsName = AutoCamelCase ? ToCamelCase(name) : name;
+
+        return Expression.Convert(
+            Expression.Constant(jsName),
+            typeof(JSValue),
+            typeof(JSValue).GetImplicitConversion(typeof(string), typeof(JSValue)));
     }
 
     /// <summary>
@@ -603,14 +644,7 @@ public class JSMarshaller
              * }
              */
 
-            // If the method is an explicit interface implementation, parse off the simple name.
-            // Then convert to JSValue for use as a JS property name.
-            int dotIndex = method.Name.LastIndexOf('.');
-            Expression methodName = Expression.Convert(
-                Expression.Constant(ToCamelCase(
-                    dotIndex >= 0 ? method.Name.Substring(dotIndex + 1) : method.Name)),
-                typeof(JSValue),
-                typeof(JSValue).GetImplicitConversion(typeof(string), typeof(JSValue)));
+            Expression methodName = JSMemberNameExpression(method);
 
             Expression ParameterToJSValue(int index) => InlineOrInvoke(
                 GetToJSValueExpression(methodParameters[index].ParameterType),
@@ -1114,10 +1148,7 @@ public class JSMarshaller
              * }
              */
 
-            Expression propertyName = Expression.Convert(
-                Expression.Constant(ToCamelCase(property.Name)),
-                typeof(JSValue),
-                typeof(JSValue).GetImplicitConversion(typeof(string), typeof(JSValue)));
+            Expression propertyName = JSMemberNameExpression(property);
 
             Expression getStatement = Expression.Assign(
                 resultVariable,
@@ -1189,10 +1220,7 @@ public class JSMarshaller
              * }
              */
 
-            Expression propertyName = Expression.Convert(
-                Expression.Constant(ToCamelCase(property.Name)),
-                typeof(JSValue),
-                typeof(JSValue).GetImplicitConversion(typeof(string), typeof(JSValue)));
+            Expression propertyName = JSMemberNameExpression(property);
 
             Expression convertStatement = Expression.Assign(
                 jsValueVariable,
@@ -2962,7 +2990,8 @@ public class JSMarshaller
                 continue;
             }
 
-            Expression propertyName = Expression.Constant(ToCamelCase(property.Name));
+            Expression propertyName = Expression.Constant(
+                AutoCamelCase ? ToCamelCase(property.Name) : property.Name);
             memberBindings.Add(Expression.Bind(property, InlineOrInvoke(
                 GetFromJSValueExpression(property.PropertyType),
                 Expression.Property(valueVariable, s_valueItem, propertyName),
@@ -3021,7 +3050,8 @@ public class JSMarshaller
                 continue;
             }
 
-            Expression propertyName = Expression.Constant(ToCamelCase(property.Name));
+            Expression propertyName = Expression.Constant(
+                AutoCamelCase ? ToCamelCase(property.Name) : property.Name);
             yield return Expression.Assign(
                 Expression.Property(jsValueVariable, s_valueItem, propertyName),
                 InlineOrInvoke(

--- a/src/NodeApi.Generator/ModuleGenerator.cs
+++ b/src/NodeApi.Generator/ModuleGenerator.cs
@@ -859,7 +859,7 @@ public class ModuleGenerator : SourceGenerator, ISourceGenerator
         }
 
         // Member names are automatically formatted as camelCase; type names are not.
-        return symbol is ITypeSymbol ? symbol.Name : ToCamelCase(symbol.Name);
+        return symbol is ITypeSymbol ? symbol.Name : JSMarshaller.ToCamelCase(symbol.Name);
     }
 
     /// <summary>

--- a/src/NodeApi.Generator/SourceGenerator.cs
+++ b/src/NodeApi.Generator/SourceGenerator.cs
@@ -77,13 +77,6 @@ public abstract class SourceGenerator
         return string.IsNullOrEmpty(ns) ? name : $"{ns}.{name}";
     }
 
-    public static string ToCamelCase(string name)
-    {
-        StringBuilder sb = new(name);
-        sb[0] = char.ToLowerInvariant(sb[0]);
-        return sb.ToString();
-    }
-
     public void ReportException(Exception ex)
     {
         // The compiler diagnostic will only show up to the first \r or \n.

--- a/src/NodeApi.Generator/TypeDefinitionsGenerator.cs
+++ b/src/NodeApi.Generator/TypeDefinitionsGenerator.cs
@@ -15,6 +15,7 @@ using System.Threading.Tasks;
 using System.Xml.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.JavaScript.NodeApi.DotNetHost;
 using Microsoft.JavaScript.NodeApi.Interop;
 using static Microsoft.JavaScript.NodeApi.DotNetHost.JSMarshaller;
 using NullabilityInfo = System.Reflection.NullabilityInfo;
@@ -2010,7 +2011,7 @@ type DateTime = Date & { kind?: 'utc' | 'local' | 'unspecified' }
                 }
             }
 
-            return _autoCamelCase && member is not Type ? ToCamelCase(name) : name;
+            return _autoCamelCase && member is not Type ? JSMarshaller.ToCamelCase(name) : name;
         }
     }
 


### PR DESCRIPTION
Fixes: #390

 - Improve code in `ToCamelCase()` to only convert identifiers that look like TitleCase - ignoring ALLCAPS.
 - Create `JSMemberNameExpression()` helper method (that uses `ToCamelCase()`) to simplify a common pattern in `JSMarshaller`.
 - Re-use `JSMarshaller.ToCamelCase()` in the generator to avoid duplication.