### PR TITLE
Disable CodeQL for OSX ARM64

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -142,6 +142,8 @@ extends:
 
               variables:
                 DotNetMoniker: net8.0
+                ${{ if and( variables.DisableOsxArm64CodeQL, eq( MatrixEntry.TargetRuntime, 'osx-arm64' )) }}:
+                  ONEES_ENFORCED_CODEQL_ENABLED: false
 
               templateContext:
                 outputs:
@@ -149,9 +151,6 @@ extends:
                     pathtoPublish: $(Build.ArtifactStagingDirectory)
                     artifactName: ${{ MatrixEntry.TargetRuntime }}
                     targetPath: $(Build.StagingDirectory)/AOT/${{ MatrixEntry.TargetRuntime }}
-                variables:
-                  ${{ if and( variables.DisableOsxArm64CodeQL, eq( MatrixEntry.TargetRuntime, 'osx-arm64' )) }}:
-                    Codeql.Enabled: false
                   
               pool: ${{ MatrixEntry.Pool }}
 
@@ -224,10 +223,9 @@ extends:
             - job: test_${{ MatrixEntry.Name }}
               displayName: Test ${{ MatrixEntry.TargetRuntime }} ${{ MatrixEntry.DotnetVersion }}
 
-              templateContext:
-                variables:
-                  ${{ if and( variables.DisableOsxArm64CodeQL, eq( MatrixEntry.TargetRuntime, 'osx-arm64' )) }}:
-                    Codeql.Enabled: false
+              variables:
+                ${{ if and( variables.DisableOsxArm64CodeQL, eq( MatrixEntry.TargetRuntime, 'osx-arm64' )) }}:
+                  ONEES_ENFORCED_CODEQL_ENABLED: false
 
               pool: ${{ MatrixEntry.Pool }}
 


### PR DESCRIPTION
Currently the CodeQL code is automatically injected into the build pipeline and it fails installation of .Net on OSX ARM64.
We previously disabled it for the same reason, but the new base build template requires a new way to disable it.
In this PR we set the `ONEES_ENFORCED_CODEQL_ENABLED` variable to `false` and it seems to work.
There may be a better way, but there are no docs and this is what I found reading the code for the base template.