### PR TITLE
LibNode Discovery

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,7 +7,7 @@
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.1.0" /><!-- 4.1.0 is compatible with .NET Standard -->
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" />
-    <PackageVersion Include="Microsoft.JavaScript.LibNode" Version="20.1800.202-alethic.4" />
+    <PackageVersion Include="Microsoft.JavaScript.LibNode" Version="20.1800.203" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <PackageVersion Include="Nerdbank.GitVersioning" Version="3.6.133" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,7 +7,7 @@
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.1.0" /><!-- 4.1.0 is compatible with .NET Standard -->
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" />
-    <PackageVersion Include="Microsoft.JavaScript.LibNode" Version="20.1800.202" />
+    <PackageVersion Include="Microsoft.JavaScript.LibNode" Version="20.1800.202-alethic.4" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <PackageVersion Include="Nerdbank.GitVersioning" Version="3.6.133" />

--- a/bench/Benchmarks.cs
+++ b/bench/Benchmarks.cs
@@ -83,7 +83,6 @@ public abstract class Benchmarks
     protected void Setup()
     {
         NodeEmbeddingPlatform platform = new(
-            null,
             new NodeEmbeddingPlatformSettings { Args = s_settings });
 
         // This setup avoids using NodejsEmbeddingThreadRuntime so benchmarks can run on

--- a/bench/Benchmarks.cs
+++ b/bench/Benchmarks.cs
@@ -44,12 +44,6 @@ public abstract class Benchmarks
             .WithOptions(ConfigOptions.JoinSummary));
     }
 
-    private static string LibnodePath { get; } = Path.Combine(
-        GetRepoRootDirectory(),
-        "bin",
-        GetCurrentPlatformRuntimeIdentifier(),
-        "libnode" + GetSharedLibraryExtension());
-
     private NodeEmbeddingRuntime? _runtime;
     private NodeEmbeddingNodeApiScope? _nodeApiScope;
     private JSValue _jsString;
@@ -89,7 +83,7 @@ public abstract class Benchmarks
     protected void Setup()
     {
         NodeEmbeddingPlatform platform = new(
-            LibnodePath,
+            null,
             new NodeEmbeddingPlatformSettings { Args = s_settings });
 
         // This setup avoids using NodejsEmbeddingThreadRuntime so benchmarks can run on

--- a/src/NodeApi.DotNetHost/JSMarshaller.cs
+++ b/src/NodeApi.DotNetHost/JSMarshaller.cs
@@ -475,7 +475,7 @@ public class JSMarshaller
 
         ParameterExpression resultVariable = Expression.Variable(
             constructor.DeclaringType!, "__result");
-        variables = new List<ParameterExpression>(argVariables.Append(resultVariable));
+        variables = [.. argVariables.Append(resultVariable)];
         statements.Add(Expression.Assign(resultVariable,
             Expression.New(constructor, argVariables)));
 

--- a/src/NodeApi.Generator/ExpressionExtensions.cs
+++ b/src/NodeApi.Generator/ExpressionExtensions.cs
@@ -59,9 +59,8 @@ internal static class ExpressionExtensions
                 (variables is null ? FormatType(lambda.ReturnType) + " " + lambda.Name + "(" +
                   string.Join(", ", lambda.Parameters.Select((p) => p.ToCS())) + ")\n" :
                 "(" + string.Join(", ", lambda.Parameters.Select((p) => p.ToCS())) + ") =>\n") +
-                ToCS(lambda.Body, path, new HashSet<string>(
-                    (variables ?? Enumerable.Empty<string>()).Union(
-                        lambda.Parameters.Select((p) => p.Name!)))),
+                ToCS(lambda.Body, path, [.. (variables ?? Enumerable.Empty<string>()).Union(
+                        lambda.Parameters.Select((p) => p.Name!))]),
 
             ParameterExpression parameter =>
                 (parameter.IsByRef && parameter.Name?.StartsWith(OutParameterPrefix) == true) ?
@@ -285,7 +284,7 @@ internal static class ExpressionExtensions
             if (assignment.Left is ParameterExpression variable &&
                 !variables.Contains(variable.Name!))
             {
-                variables = new HashSet<string>(variables.Union(new[] { variable.Name! }));
+                variables = [.. variables.Union(new[] { variable.Name! })];
                 s += FormatType(variable.Type) + " " + s;
             }
         }

--- a/src/NodeApi.Generator/TypeDefinitionsGenerator.cs
+++ b/src/NodeApi.Generator/TypeDefinitionsGenerator.cs
@@ -333,7 +333,7 @@ dotnet.load(assemblyName);";
 
     private static Version InferReferenceAssemblyVersionFromPath(string assemblyPath)
     {
-        var pathParts = assemblyPath.Split(
+        List<string> pathParts = assemblyPath.Split(
             Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar).ToList();
 
         // Infer the version from a system reference assembly path such as
@@ -1230,7 +1230,7 @@ type DateTime = Date & { kind?: 'utc' | 'local' | 'unspecified' }
             return;
         }
 
-        List<string> namespaceParts = new(type.Namespace?.Split('.') ?? Enumerable.Empty<string>());
+        List<string> namespaceParts = [.. type.Namespace?.Split('.') ?? Enumerable.Empty<string>()];
 
         int namespacePartsCount = namespaceParts.Count;
         Type? declaringType = type.DeclaringType;

--- a/src/NodeApi/Runtime/NativeLibrary.cs
+++ b/src/NodeApi/Runtime/NativeLibrary.cs
@@ -6,7 +6,6 @@
 using System;
 using System.ComponentModel;
 using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.ComTypes;
 
 namespace Microsoft.JavaScript.NodeApi.Runtime;
 

--- a/src/NodeApi/Runtime/NativeLibrary.cs
+++ b/src/NodeApi/Runtime/NativeLibrary.cs
@@ -141,7 +141,7 @@ public static class NativeLibrary
         {
             dlerror();
             procAddress = dlsym(handle, name);
-            return dlerror() != 0;
+            return dlerror() == 0;
         }
 #else
         return SysNativeLibrary.TryGetExport(handle, name, out procAddress);

--- a/src/NodeApi/Runtime/NativeLibrary.cs
+++ b/src/NodeApi/Runtime/NativeLibrary.cs
@@ -133,7 +133,7 @@ public static class NativeLibrary
         {
             nint procAddress = GetProcAddress(handle, name);
             if (procAddress == 0 && throwOnError)
-                throw new DllNotFoundException(new Win32Exception(Marshal.GetLastWin32Error()).Message);
+                throw new EntryPointNotFoundException(new Win32Exception(Marshal.GetLastWin32Error()).Message);
 
             return procAddress;
         }

--- a/src/NodeApi/Runtime/NativeLibrary.cs
+++ b/src/NodeApi/Runtime/NativeLibrary.cs
@@ -167,19 +167,29 @@ public static class NativeLibrary
 
     private static nint dlerror()
     {
-        // Some Linux distros / versions have libdl version 2 only.
-        // Mac OS only has the unversioned library.
+        // some operating systems have dlerror in libc, some in libdl, some in libdl.so.2
+        // attempt in that order
         try
         {
-            return dlerror2();
+            return dlerror0();
         }
         catch (DllNotFoundException)
         {
-            return dlerror1();
+            try
+            {
+                return dlerror1();
+            }
+            catch (DllNotFoundException)
+            {
+                return dlerror2();
+            }
         }
     }
 
-    [DllImport("libdl", EntryPoint = "dlerror")]
+    [DllImport("c", EntryPoint = "dlerror")]
+    private static extern nint dlerror0();
+
+    [DllImport("dl", EntryPoint = "dlerror")]
     private static extern nint dlerror1();
 
     [DllImport("libdl.so.2", EntryPoint = "dlerror")]
@@ -187,19 +197,29 @@ public static class NativeLibrary
 
     private static nint dlopen(string? fileName, int flags)
     {
-        // Some Linux distros / versions have libdl version 2 only.
-        // Mac OS only has the unversioned library.
+        // some operating systems have dlopen in libc, some in libdl, some in libdl.so.2
+        // attempt in that order
         try
         {
-            return dlopen2(fileName, flags);
+            return dlopen0(fileName, flags);
         }
         catch (DllNotFoundException)
         {
-            return dlopen1(fileName, flags);
+            try
+            {
+                return dlopen1(fileName, flags);
+            }
+            catch (DllNotFoundException)
+            {
+                return dlopen2(fileName, flags);
+            }
         }
     }
 
-    [DllImport("libdl", EntryPoint = "dlopen")]
+    [DllImport("c", EntryPoint = "dlopen")]
+    private static extern nint dlopen0(string? fileName, int flags);
+
+    [DllImport("dl", EntryPoint = "dlopen")]
     private static extern nint dlopen1(string? fileName, int flags);
 
     [DllImport("libdl.so.2", EntryPoint = "dlopen")]
@@ -207,19 +227,29 @@ public static class NativeLibrary
 
     private static nint dlsym(nint handle, string symbol)
     {
-        // Some Linux distros / versions have libdl version 2 only.
-        // Mac OS only has the unversioned library.
+        // some operating systems have dlsym in libc, some in libdl, some in libdl.so.2
+        // attempt in that order
         try
         {
-            return dlsym2(handle, symbol);
+            return dlsym0(handle, symbol);
         }
         catch (DllNotFoundException)
         {
-            return dlsym1(handle, symbol);
+            try
+            {
+                return dlsym1(handle, symbol);
+            }
+            catch (DllNotFoundException)
+            {
+                return dlsym2(handle, symbol);
+            }
         }
     }
 
-    [DllImport("libdl", EntryPoint = "dlsym")]
+    [DllImport("c", EntryPoint = "dlsym")]
+    private static extern nint dlsym0(nint handle, string symbol);
+
+    [DllImport("dl", EntryPoint = "dlsym")]
     private static extern nint dlsym1(nint handle, string symbol);
 
     [DllImport("libdl.so.2", EntryPoint = "dlsym")]

--- a/src/NodeApi/Runtime/NativeLibrary.cs
+++ b/src/NodeApi/Runtime/NativeLibrary.cs
@@ -1,14 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#if !NET7_0_OR_GREATER
+#if !NETCOREAPP3_0_OR_GREATER
 
 using System;
 using System.ComponentModel;
 using System.Runtime.InteropServices;
-#if !(NETFRAMEWORK || NETSTANDARD)
-using SysNativeLibrary = System.Runtime.InteropServices.NativeLibrary;
-#endif
 
 namespace Microsoft.JavaScript.NodeApi.Runtime;
 
@@ -44,11 +41,7 @@ public static class NativeLibrary
     /// <returns>The OS handle for the loaded native library.</returns>
     public static nint Load(string libraryPath)
     {
-#if NETFRAMEWORK || NETSTANDARD
         return LoadFromPath(libraryPath, throwOnError: true);
-#else
-        return SysNativeLibrary.Load(libraryName);
-#endif
     }
 
     /// <summary>
@@ -59,12 +52,8 @@ public static class NativeLibrary
     /// <returns><c>true</c> if the native library was loaded successfully; otherwise, <c>false</c>.</returns>
     public static bool TryLoad(string libraryPath, out nint handle)
     {
-#if NETFRAMEWORK || NETSTANDARD
         handle = LoadFromPath(libraryPath, throwOnError: false);
         return handle != 0;
-#else
-        return SysNativeLibrary.TryLoad(libraryName, out handle);
-#endif
     }
 
     static nint LoadFromPath(string libraryPath, bool throwOnError)
@@ -105,21 +94,13 @@ public static class NativeLibrary
     /// <returns>The address of the symbol.</returns>
     public static nint GetExport(nint handle, string name)
     {
-#if NETFRAMEWORK || NETSTANDARD
         return GetSymbol(handle, name, throwOnError: true);
-#else
-        return SysNativeLibrary.GetExport(handle, name);
-#endif
     }
 
     public static bool TryGetExport(nint handle, string name, out nint procAddress)
     {
-#if NETFRAMEWORK || NETSTANDARD
         procAddress = GetSymbol(handle, name, throwOnError: false);
         return procAddress != 0;
-#else
-        return SysNativeLibrary.TryGetExport(handle, name, out procAddress);
-#endif
     }
 
     static nint GetSymbol(nint handle, string name, bool throwOnError)

--- a/src/NodeApi/Runtime/NativeLibrary.cs
+++ b/src/NodeApi/Runtime/NativeLibrary.cs
@@ -185,7 +185,7 @@ public static class NativeLibrary
     [DllImport("libdl.so.2", EntryPoint = "dlerror")]
     private static extern nint dlerror2();
 
-    private static nint dlopen(string fileName, int flags)
+    private static nint dlopen(string? fileName, int flags)
     {
         // Some Linux distros / versions have libdl version 2 only.
         // Mac OS only has the unversioned library.
@@ -200,10 +200,10 @@ public static class NativeLibrary
     }
 
     [DllImport("libdl", EntryPoint = "dlopen")]
-    private static extern nint dlopen1(string fileName, int flags);
+    private static extern nint dlopen1(string? fileName, int flags);
 
     [DllImport("libdl.so.2", EntryPoint = "dlopen")]
-    private static extern nint dlopen2(string fileName, int flags);
+    private static extern nint dlopen2(string? fileName, int flags);
 
     private static nint dlsym(nint handle, string symbol)
     {

--- a/src/NodeApi/Runtime/NativeLibrary.cs
+++ b/src/NodeApi/Runtime/NativeLibrary.cs
@@ -205,25 +205,25 @@ public static class NativeLibrary
     [DllImport("libdl.so.2", EntryPoint = "dlopen")]
     private static extern nint dlopen2(string fileName, int flags);
 
-    private static nint dlsym(nint handle, string name)
+    private static nint dlsym(nint handle, string symbol)
     {
         // Some Linux distros / versions have libdl version 2 only.
         // Mac OS only has the unversioned library.
         try
         {
-            return dlsym2(handle, name);
+            return dlsym2(handle, symbol);
         }
         catch (DllNotFoundException)
         {
-            return dlsym1(handle, name);
+            return dlsym1(handle, symbol);
         }
     }
 
     [DllImport("libdl", EntryPoint = "dlsym")]
-    private static extern nint dlsym1(nint fileName, string flags);
+    private static extern nint dlsym1(nint handle, string symbol);
 
     [DllImport("libdl.so.2", EntryPoint = "dlsym")]
-    private static extern nint dlsym2(nint fileName, string flags);
+    private static extern nint dlsym2(nint handle, string symbol);
 
     private const int RTLD_LAZY = 1;
 

--- a/src/NodeApi/Runtime/NativeLibrary.cs
+++ b/src/NodeApi/Runtime/NativeLibrary.cs
@@ -63,7 +63,7 @@ public static class NativeLibrary
         handle = LoadFromPath(libraryPath, throwOnError: false);
         return handle != 0;
 #else
-        return SysNativeLibrary.TryLoad(libraryName);
+        return SysNativeLibrary.TryLoad(libraryName, out handle);
 #endif
     }
 

--- a/src/NodeApi/Runtime/NodeEmbedding.cs
+++ b/src/NodeApi/Runtime/NodeEmbedding.cs
@@ -43,7 +43,7 @@ public sealed class NodeEmbedding
     /// <returns></returns>
     static string? GetFallbackRuntimeIdentifier()
     {
-        var arch = RuntimeInformation.ProcessArchitecture switch
+        string? arch = RuntimeInformation.ProcessArchitecture switch
         {
             Architecture.X86 => "x86",
             Architecture.X64 => "x64",
@@ -53,13 +53,13 @@ public sealed class NodeEmbedding
         };
 
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            return $"win-{arch}";
+            return arch is not null ? $"win-{arch}" : "win";
 
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-            return $"linux-{arch}";
+            return arch is not null ? $"linux-{arch}" : "linux";
 
         if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-            return $"osx-{arch}";
+            return arch is not null ? $"osx-{arch}" : "osx";
 
         return null;
     }
@@ -79,10 +79,11 @@ public sealed class NodeEmbedding
 
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             return name + ".dll";
+
         if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             return name + ".dylib";
-        else
-            return name + ".so";
+
+        return name + ".so";
     }
 
     /// <summary>

--- a/src/NodeApi/Runtime/NodeEmbedding.cs
+++ b/src/NodeApi/Runtime/NodeEmbedding.cs
@@ -111,15 +111,15 @@ public sealed class NodeEmbedding
     static nint LoadDefaultLibNode()
     {
 #if NETFRAMEWORK || NETSTANDARD
-        if (NativeLibrary.TryLoad("libnode", out var handle))
+        if (NativeLibrary.TryLoad("libnode", out nint handle))
             return handle;
 #else
-        if (NativeLibrary.TryLoad("libnode", typeof(NodeEmbedding).Assembly, null, out var handle))
+        if (NativeLibrary.TryLoad("libnode", typeof(NodeEmbedding).Assembly, null, out nint handle))
             return handle;
 #endif
 
 #if NETFRAMEWORK || NETSTANDARD
-        var path = FindFallbackLibNode();
+        string? path = FindFallbackLibNode();
         if (path is not null)
             return NativeLibrary.Load(path);
 #endif

--- a/src/NodeApi/Runtime/NodeEmbeddingPlatform.cs
+++ b/src/NodeApi/Runtime/NodeEmbeddingPlatform.cs
@@ -29,7 +29,7 @@ public sealed class NodeEmbeddingPlatform : IDisposable
     /// <param name="settings">Optional platform settings.</param>
     /// <exception cref="InvalidOperationException">A Node.js platform instance has already been
     /// loaded in the current process.</exception>
-    public NodeEmbeddingPlatform(string? libNodePath, NodeEmbeddingPlatformSettings? settings)
+    public NodeEmbeddingPlatform(NodeEmbeddingPlatformSettings? settings)
     {
         if (Current != null)
         {
@@ -37,7 +37,7 @@ public sealed class NodeEmbeddingPlatform : IDisposable
                 "Only one Node.js platform instance per process is allowed.");
         }
         Current = this;
-        Initialize(libNodePath);
+        Initialize(settings?.LibNodePath);
 
         using FunctorRef<node_embedding_platform_configure_callback> functorRef =
             CreatePlatformConfigureFunctorRef(settings?.CreateConfigurePlatformCallback());

--- a/src/NodeApi/Runtime/NodeEmbeddingPlatform.cs
+++ b/src/NodeApi/Runtime/NodeEmbeddingPlatform.cs
@@ -29,7 +29,7 @@ public sealed class NodeEmbeddingPlatform : IDisposable
     /// <param name="settings">Optional platform settings.</param>
     /// <exception cref="InvalidOperationException">A Node.js platform instance has already been
     /// loaded in the current process.</exception>
-    public NodeEmbeddingPlatform(string libNodePath, NodeEmbeddingPlatformSettings? settings)
+    public NodeEmbeddingPlatform(string? libNodePath, NodeEmbeddingPlatformSettings? settings)
     {
         if (Current != null)
         {

--- a/src/NodeApi/Runtime/NodeEmbeddingPlatformSettings.cs
+++ b/src/NodeApi/Runtime/NodeEmbeddingPlatformSettings.cs
@@ -8,6 +8,7 @@ using static NodejsRuntime;
 
 public class NodeEmbeddingPlatformSettings
 {
+    public string? LibNodePath { get; set; }
     public NodeEmbeddingPlatformFlags? PlatformFlags { get; set; }
     public string[]? Args { get; set; }
     public ConfigurePlatformCallback? ConfigurePlatform { get; set; }

--- a/src/NodeApi/Runtime/TracingJSRuntime.cs
+++ b/src/NodeApi/Runtime/TracingJSRuntime.cs
@@ -178,7 +178,7 @@ public class TracingJSRuntime : JSRuntime
                         valueString = $" {GetValueString(env, functionName)}()";
                     }
                     break;
-            };
+            }
 
             return $"{value.Handle:X16} {valueType.ToString().Substring(5)}{valueString}";
         }

--- a/test/GCTests.cs
+++ b/test/GCTests.cs
@@ -10,7 +10,6 @@ namespace Microsoft.JavaScript.NodeApi.Test;
 
 public class GCTests
 {
-    private static string LibnodePath { get; } = GetLibnodePath();
 
     [Fact]
     public void GCHandles()

--- a/test/NodejsEmbeddingTests.cs
+++ b/test/NodejsEmbeddingTests.cs
@@ -22,11 +22,9 @@ public class NodejsEmbeddingTests
     private static string MainScript { get; } =
         "globalThis.require = require('module').createRequire(process.execPath);\n";
 
-    private static string LibnodePath { get; } = GetLibnodePath();
-
     // The Node.js platform may only be initialized once per process.
     internal static NodeEmbeddingPlatform NodejsPlatform { get; } =
-        new(LibnodePath, new NodeEmbeddingPlatformSettings
+        new(null, new NodeEmbeddingPlatformSettings
         {
             Args = new[] { "node", "--expose-gc" }
         });

--- a/test/NodejsEmbeddingTests.cs
+++ b/test/NodejsEmbeddingTests.cs
@@ -24,7 +24,7 @@ public class NodejsEmbeddingTests
 
     // The Node.js platform may only be initialized once per process.
     internal static NodeEmbeddingPlatform NodejsPlatform { get; } =
-        new(null, new NodeEmbeddingPlatformSettings
+        new(new NodeEmbeddingPlatformSettings
         {
             Args = new[] { "node", "--expose-gc" }
         });

--- a/test/TestUtils.cs
+++ b/test/TestUtils.cs
@@ -77,11 +77,6 @@ public static class TestUtils
         else return ".so";
     }
 
-    public static string GetLibnodePath() =>
-        Path.Combine(
-            Path.GetDirectoryName(GetAssemblyLocation()) ?? string.Empty,
-            "libnode" + GetSharedLibraryExtension());
-
     public static string? LogOutput(
         Process process,
         StreamWriter logWriter)


### PR DESCRIPTION
Resubmitting a PR I did directly against @vmoroz's local fork earlier. As we talked about over there, right now, this PR has the LibNode packages pointing to my local fork, where the runtimes/{rid}/native directory is populated correctly. The PR thus is not ready to be accepted until the upstream LibNode packages are fixed up. But getting the discovery code visible I thought would be beneficial.

Allow null to be passed as libpath. The result is that a series of procedures for locating the libnode library is done.

a) On Core+ platforms, NativeLibrary is used directly with a relative path off of the assembly. This causes a search across the applications .deps.json. This is the ideal scenario as long as the LibNode packages deliver the library into runtimes/{rid}/native.
b) On Framework platforms a search procedure is used. First, libnode is attempted to be loaded by relative name directly. This handles the situation where the library is directly available in some way. Such as relative to the executable. Second runtimes/{rid}/native is examined with a known RID based on current platform.

A few local NativeLibrary methods were improved.

+ Load was updated to support non-Windows platforms. This handles the scenario of Framework on ~Windows. Such as Mono.
+ TryLoad was introduced to probe paths during discovery.
+ GetExport/TryGetExport was updated to support non-Windows platforms. This handles the scenario of Framework on ~Windows. Such as Mono.
+ dlerror() was introduced to handle the situation of null exports. Which should not reaaaaly happen in libnode. But is technically correct.
+ The pinvokes to libdl are technically out of date. dl was merged into libc on Linux. And was already present in libc on OS X. But these are left.
+ Expects to use Microsoft.JavaScript.LibNode version that deposit native libraries properly.
Change tests to not need a hard coded libnode path.