### PR TITLE
Combine all release jobs into one stage

### DIFF
--- a/.ado/release.yml
+++ b/.ado/release.yml
@@ -41,11 +41,11 @@ extends:
           '**/*.*'
 
     stages:
-    - stage: ms_react_native_nuget_publish
-      displayName: Nuget ms/react-native feed
+    - stage: main_release
+      displayName: Publish packages
       jobs:
-      - job: ms_react_native_nuget_job
-        displayName: Publish Nuget to ms/react-native
+      - job: nuget_ms_react_native_public_job
+        displayName: NuGet to ADO ms/react-native-public feed
         templateContext:
           inputs:
           - input: pipelineArtifact
@@ -72,11 +72,8 @@ extends:
             externalEndpoint: 'Nuget - ms/react-native-public'
             publishPackageMetadata: true
 
-    - stage: ms_react_native_npm_publish
-      displayName: npm ms/react-native feed
-      jobs:
-      - job: ms_react_native_npm_job
-        displayName: Agent job
+      - job: npm_ms_react_native_job
+        displayName: NPM to ADO ms/react-native feed
         templateContext:
           inputs:
           - input: pipelineArtifact
@@ -114,11 +111,8 @@ extends:
               cd $(Pipeline.Workspace)\published-packages
               for %%i in (*.tgz) do npm publish %%i
 
-    - stage: nuget_org_publish
-      displayName: Nuget nuget.org feed
-      jobs:
       - job: nuget_org_job
-        displayName: Publish Nuget to nuget.org
+        displayName: NuGet to nuget.org
         templateContext:
           inputs:
           - input: pipelineArtifact
@@ -153,11 +147,8 @@ extends:
             -Verbosity Detailed
           displayName: 'NuGet push (nuget.org)'
 
-    - stage: npmjs_com_npm_publish
-      displayName: npm npmjs.com feed
-      jobs:
-      - job: npmjs_com_npm_job
-        displayName: Publish to npmjs.com
+      - job: npmjs_com_job
+        displayName: NPM to npmjs.com
         templateContext:
           inputs:
           - input: pipelineArtifact


### PR DESCRIPTION
Currently publishing to the supported target feeds is split up into stages that sequentially depend on each other.
If one of the stages fail, then all consequent stages will not run.
It creates some unexpected issues like with the release 0.9.7 where the failure to publish duplicated NuGet package to the ADO feed prevented publishing to other feeds.

This PR replaces all the stages with one stage while keeping the same jobs per each target feed.
After the change all the jobs can be run in parallel and failure in one job does not prevent other jobs from completion.
It also gives us an opportunity to rerun only failed jobs in case if we just need to update API key or change any other settings outside of the pipeline.