### PR TITLE
Fix worker assembly loading bug

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -161,6 +161,7 @@ dotnet_diagnostic.CA1835.severity = none
 
 dotnet_diagnostic.IDE0290.severity = none # Use primary constructor
 dotnet_diagnostic.IDE0065.severity = none # Using directives must be placed outside of namespace
+dotnet_diagnostic.IDE0350.severity = none # Lambda expression can be simplified
 
 # Collection initialization can be simplified.
 # This relies on implicit conversions in ways that are sometimes undesirable.

--- a/src/NodeApi.DotNetHost/ManagedHost.cs
+++ b/src/NodeApi.DotNetHost/ManagedHost.cs
@@ -562,7 +562,7 @@ public sealed class ManagedHost : JSEventEmitter, IDisposable
             _loadedAssembliesByName.GetOrAdd(assembly.GetName().Name!, assembly);
         }
 
-        var version = assembly?.GetName().Version?.ToString() ?? "(native library)";
+        string version = assembly?.GetName().Version?.ToString() ?? "(native library)";
         Trace($"< ManagedHost.LoadAssembly() => {assemblyFilePath} {version}");
         return assembly;
     }


### PR DESCRIPTION
Fixes: #447 

When multiple worker threads (or main + worker) attempt to resolve the same dependency assembly, loads failed after the first one. The bug was caused by a duplicate-key exception trying to update the internal dictionary that tracks loaded assemblies:

```C#
_loadedAssembliesByPath.Add(assemblyFilePath, assembly);
```

The fix skips loading the requested assembly if it is already in that dictionary, and also switches to `ConcurrentDictionary` in case multiple threads access it simultaneously.