### PR TITLE
Support .NET 10

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
-    <TargetFrameworks Condition=" '$(TargetFrameworks)' == '' and ! $([MSBuild]::IsOsPlatform('Windows')) ">net9.0;net8.0;netstandard2.0</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(TargetFrameworks)' == '' and $([MSBuild]::IsOsPlatform('Windows')) ">net9.0;net8.0;netstandard2.0;net472</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(TargetFrameworks)' == '' and ! $([MSBuild]::IsOsPlatform('Windows')) ">net10.0;net9.0;net8.0;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(TargetFrameworks)' == '' and $([MSBuild]::IsOsPlatform('Windows')) ">net10.0;net9.0;net8.0;netstandard2.0;net472</TargetFrameworks>
     <TargetFrameworks Condition=" '$(PublishAot)' == 'true' ">net9.0</TargetFrameworks>
     <LangVersion>12</LangVersion>
     <Nullable>enable</Nullable>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.100",
+    "version": "10.0.100-preview.6",
     "allowPrerelease": true,
     "rollForward": "latestFeature"
   }

--- a/src/node-api-dotnet/pack.js
+++ b/src/node-api-dotnet/pack.js
@@ -20,7 +20,7 @@ if (!packageName || !configuration || rids.length === 0) {
 
 const assemblyName = 'Microsoft.JavaScript.NodeApi';
 
-const targetFrameworks = ['net9.0', 'net8.0'];
+const targetFrameworks = ['net10.0', 'net9.0', 'net8.0'];
 if (process.platform === 'win32') targetFrameworks.push('net472');
 
 const fs = require('fs');
@@ -169,7 +169,7 @@ function copyFrameworkSpecificBinaries(targetFrameworks, packageStageDir, ...bin
         binFileName.startsWith('System.') &&
         !binFileName.includes('MetadataLoadContext')
       ) return;
-      
+
       // Exclude Microsoft.Bcl.AsyncInterfaces from new platforms
       if (
         tfm.includes('.') &&

--- a/test/NativeAotTests.cs
+++ b/test/NativeAotTests.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#if NET9_0_OR_GREATER
+#if NET9_0
 
 using System;
 using System.Collections.Generic;

--- a/test/NodeApi.Test.csproj
+++ b/test/NodeApi.Test.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <!-- Exclude netstandard2.0 from target frameworks for tests. -->
-    <TargetFrameworks Condition=" ! $([MSBuild]::IsOsPlatform('Windows')) ">net9.0;net8.0</TargetFrameworks>
-    <TargetFrameworks Condition=" $([MSBuild]::IsOsPlatform('Windows')) ">net9.0;net8.0;net472</TargetFrameworks>
+    <TargetFrameworks Condition=" ! $([MSBuild]::IsOsPlatform('Windows')) ">net10.0;net9.0;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition=" $([MSBuild]::IsOsPlatform('Windows')) ">net10.0;net9.0;net8.0;net472</TargetFrameworks>
     <TestTfmsInParallel>false</TestTfmsInParallel>
 
     <RootNamespace>Microsoft.JavaScript.NodeApi.Test</RootNamespace>

--- a/test/TestBuilder.cs
+++ b/test/TestBuilder.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using Xunit;
 using static Microsoft.JavaScript.NodeApi.Test.TestUtils;
 
@@ -253,6 +254,14 @@ internal static class TestBuilder
         // that matches the current runtime major version. Roll forward to the latest
         // installed SDK within the same major version.
         string sdkVersion = frameworkVersion.Major + "." + frameworkVersion.Minor + ".100";
+
+        if (RuntimeInformation.FrameworkDescription.Contains("-preview."))
+        {
+            // Append the .NET preview version to the SDK version requested in global.json.
+            sdkVersion += RuntimeInformation.FrameworkDescription.Substring(
+                RuntimeInformation.FrameworkDescription.IndexOf("-preview."));
+        }
+
         string globalJson = $$"""
             {
                 "sdk": {

--- a/test/TestCases/projects/js-cjs-dynamic/net10.0.js
+++ b/test/TestCases/projects/js-cjs-dynamic/net10.0.js
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+const assert = require('assert');
+const dotnet = require('node-api-dotnet/net10.0');
+
+require('./bin/System.Runtime');
+require('./bin/System.Console');
+
+dotnet.System.Console.WriteLine(`Hello from .NET ${dotnet.runtimeVersion}!`);
+assert.strictEqual(dotnet.frameworkMoniker, 'net10.0');

--- a/test/TestCases/projects/js-esm-dynamic/net10.0.js
+++ b/test/TestCases/projects/js-esm-dynamic/net10.0.js
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import assert from 'assert';
+import dotnet from 'node-api-dotnet/net10.0';
+
+import './bin/System.Runtime.js';
+import './bin/System.Console.js';
+
+dotnet.System.Console.WriteLine(`Hello from .NET ${dotnet.runtimeVersion}!`);
+assert.strictEqual(dotnet.frameworkMoniker, 'net10.0');

--- a/test/TestCases/projects/ts-cjs-dynamic/net10.0.ts
+++ b/test/TestCases/projects/ts-cjs-dynamic/net10.0.ts
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import * as assert from 'assert';
+import * as dotnet from 'node-api-dotnet/net10.0';
+
+import './bin/System.Runtime';
+import './bin/System.Console';
+
+dotnet.System.Console.WriteLine(`Hello from .NET ${dotnet.runtimeVersion}!`);
+assert.strictEqual(dotnet.frameworkMoniker, 'net10.0');

--- a/test/TestCases/projects/ts-esm-dynamic/net10.0.ts
+++ b/test/TestCases/projects/ts-esm-dynamic/net10.0.ts
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import * as assert from 'assert';
+import dotnet from 'node-api-dotnet/net10.0';
+
+import './bin/System.Runtime.js';
+import './bin/System.Console.js';
+
+dotnet.System.Console.WriteLine(`Hello from .NET ${dotnet.runtimeVersion}!`);
+assert.strictEqual(dotnet.frameworkMoniker, 'net10.0');


### PR DESCRIPTION
This change updates the root `global.json` from .NET 9 to .NET 10 (preview 6) SDK and adds `net10` build targets for all the projects.

Tests found one major compatibility issue with .NET 10, which is that the runtime type builder is more strict about type attributes and interface method implementations than it was previously. So there are lots of code updates in `SymbolExtensions` to comply with the new validations. After that fix, all unit tests are passing on .NET 10.

I have not yet switched AOT compilation to use .NET 10; AOT builds and tests still use only .NET 9 for now.

I'm creating this PR as a **DRAFT** because I'm not sure if we want to add a dependency on the preview SDK. (Also I haven't updated build pipelines to install .NET 10.)
