### PR TITLE
Enable Globalization Invariant Mode for tests

### DIFF
--- a/test/TestBuilder.cs
+++ b/test/TestBuilder.cs
@@ -297,6 +297,9 @@ internal static class TestBuilder
             WorkingDirectory = Path.GetDirectoryName(logFilePath)!,
         };
 
+        // Globalization data will not be used, even if available
+        startInfo.Environment["DOTNET_SYSTEM_GLOBALIZATION_INVARIANT"] = "true";
+
         foreach (KeyValuePair<string, string> pair in testEnvironmentVariables)
         {
             startInfo.Environment[pair.Key] = pair.Value;


### PR DESCRIPTION
Some tests were failing in my environment, because those tests rely on number formatting which is different based on regional settings.
This PR fixes the issue by enabling "globalization invariant mode" via DOTNET_SYSTEM_GLOBALIZATION_INVARIANT  env var.