### PR TITLE
Fix TS generator crash from duplicated reference assemblies

### DIFF
--- a/src/NodeApi.Generator/TypeDefinitionsGenerator.cs
+++ b/src/NodeApi.Generator/TypeDefinitionsGenerator.cs
@@ -242,6 +242,10 @@ dotnet.load(assemblyName);";
             throw new ArgumentNullException(nameof(modulePaths));
         }
 
+        // Provided reference assemblies may be duplicated when they come from multiple
+        // places in a complex dependency tree.
+        referenceAssemblyPaths = referenceAssemblyPaths.Distinct();
+
         // Create a metadata load context that includes a resolver for system assemblies,
         // referenced assemblies, and the target assembly.
         IEnumerable<string> allReferenceAssemblyPaths = MergeSystemReferenceAssemblies(


### PR DESCRIPTION
When provided duplicate reference assemblies, the type-definitions generator tool crashed with the following stack trace:

```
Unhandled exception. System.ArgumentException: An item with the same key has already been added. Key: <assemblyname>
   at System.Collections.Generic.Dictionary`2.TryInsert(TKey key, TValue value, InsertionBehavior behavior)
   at System.Collections.Generic.Dictionary`2.Add(TKey key, TValue value)
   at Microsoft.JavaScript.NodeApi.Generator.TypeDefinitionsGenerator.GenerateTypeDefinitions(String assemblyPath, IEnumerable`1 referenceAssemblyPaths, IEnumerable`1 systemReferenceAssemblyDirectories, String typeDefinitionsPath, IDictionary`2 modulePaths, String targetFramework, Boolean isSystemAssembly, Boolean suppressWarnings, IEnumerable`1 excludePatterns) at TypeDefinitionsGenerator.cs line 273
   at Microsoft.JavaScript.NodeApi.Generator.Program.Main(String[] args)
```

De-duplicating the list of provided reference assembly paths fixes it.