### PR TITLE
Fix publish and release pipelines

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -386,7 +386,19 @@ extends:
                 displayName: Show RID list
 
               - ${{ if ne(variables.DisableSigning, true) }}:
-                - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@5
+                # ESRP's PendingAnalysis stage rejects the .node extension, so rename to .dll
+                # for signing and rename back after. The signing task below picks it up via the
+                # **/Microsoft.JavaScript.NodeApi.dll glob.
+                - task: PowerShell@2
+                  displayName: Rename .node to .dll for ESRP signing
+                  inputs:
+                    targetType: inline
+                    script: |
+                      Rename-Item `
+                        -Path "$(Build.SourcesDirectory)/out/bin/Release/NodeApi/aot/win-x64/publish/Microsoft.JavaScript.NodeApi.node" `
+                        -NewName "Microsoft.JavaScript.NodeApi.dll"
+
+                - task: EsrpCodeSigning@6
                   displayName: CodeSign Binaries
                   inputs:
                     ConnectedServiceName: 'ESRP-JSHost3'
@@ -398,7 +410,6 @@ extends:
                     FolderPath: $(Build.SourcesDirectory)/out/bin/Release
                     # Recursively finds files matching these patterns:
                     Pattern: |
-                      NodeApi/aot/win-x64/publish/Microsoft.JavaScript.NodeApi.node
                       **/Microsoft.JavaScript.NodeApi.dll
                       **/Microsoft.JavaScript.NodeApi.DotNetHost.dll
                       **/Microsoft.JavaScript.NodeApi.Generator.dll
@@ -429,6 +440,15 @@ extends:
                         }
                       ]
 
+                - task: PowerShell@2
+                  displayName: Rename signed .dll back to .node
+                  inputs:
+                    targetType: inline
+                    script: |
+                      Rename-Item `
+                        -Path "$(Build.SourcesDirectory)/out/bin/Release/NodeApi/aot/win-x64/publish/Microsoft.JavaScript.NodeApi.dll" `
+                        -NewName "Microsoft.JavaScript.NodeApi.node"
+
               # Make symbols available through http://symweb.
               - task: PublishSymbols@2
                 displayName: Publish symbols
@@ -450,7 +470,7 @@ extends:
                   RuntimeIdentifierList: $(TargetRuntimeList)
 
               - ${{ if ne(variables.DisableSigning, true) }}:
-                - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@5
+                - task: EsrpCodeSigning@6
                   displayName: CodeSign NuGets
                   inputs:
                     ConnectedServiceName: 'ESRP-JSHost3'

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -396,7 +396,7 @@ extends:
                     script: |
                       Rename-Item `
                         -Path "$(Build.SourcesDirectory)/out/bin/Release/NodeApi/aot/win-x64/publish/Microsoft.JavaScript.NodeApi.node" `
-                        -NewName "Microsoft.JavaScript.NodeApi.dll"
+                        -NewName "Microsoft.JavaScript.NodeApi.node.dll"
 
                 - task: EsrpCodeSigning@6
                   displayName: CodeSign Binaries
@@ -410,6 +410,7 @@ extends:
                     FolderPath: $(Build.SourcesDirectory)/out/bin/Release
                     # Recursively finds files matching these patterns:
                     Pattern: |
+                      NodeApi/aot/win-x64/publish/Microsoft.JavaScript.NodeApi.node.dll
                       **/Microsoft.JavaScript.NodeApi.dll
                       **/Microsoft.JavaScript.NodeApi.DotNetHost.dll
                       **/Microsoft.JavaScript.NodeApi.Generator.dll
@@ -446,7 +447,7 @@ extends:
                     targetType: inline
                     script: |
                       Rename-Item `
-                        -Path "$(Build.SourcesDirectory)/out/bin/Release/NodeApi/aot/win-x64/publish/Microsoft.JavaScript.NodeApi.dll" `
+                        -Path "$(Build.SourcesDirectory)/out/bin/Release/NodeApi/aot/win-x64/publish/Microsoft.JavaScript.NodeApi.node.dll" `
                         -NewName "Microsoft.JavaScript.NodeApi.node"
 
               # Make symbols available through http://symweb.

--- a/.ado/release.yml
+++ b/.ado/release.yml
@@ -19,20 +19,18 @@ resources:
         - main
 
   repositories:
-  - repository: CustomPipelineTemplates
+  - repository: OfficePipelineTemplates
     type: git
     name: 1ESPipelineTemplates/OfficePipelineTemplates
     ref: refs/tags/release
 
 extends:
-  template: v1/Office.Official.PipelineTemplate.yml@CustomPipelineTemplates
+  template: v1/Office.Official.PipelineTemplate.yml@OfficePipelineTemplates
   parameters:
     pool:
       name: Azure-Pipelines-1ESPT-ExDShared
       vmImage: windows-latest
       os: windows
-    customBuildTags:
-    - ES365AIMigrationTooling-BulkMigrated-Release
     sdl:
       eslint:
         enableExclusions: true
@@ -63,6 +61,20 @@ extends:
         - script: dotnet nuget list source
           displayName: Show Nuget sources
 
+        - task: AzureCLI@2
+          displayName: Override NuGet credentials with Managed Identity
+          inputs:
+            azureSubscription: 'Office-Hermes-Windows-Bot'
+            visibleAzLogin: false
+            scriptType: 'pscore'
+            scriptLocation: 'inlineScript'
+            inlineScript: |
+              $accessToken = az account get-access-token --query accessToken --resource 499b84ac-1321-427f-aa17-267ca6975798 -o tsv
+              # Set the access token as a secret, so it doesn't get leaked in the logs
+              Write-Host "##vso[task.setsecret]$accessToken"
+              # Override the apitoken of the nuget service connection, for the duration of this stage
+              Write-Host "##vso[task.setendpoint id=29e4c04c-ae69-4453-b9f3-bfef7a4c8d32;field=authParameter;key=apitoken]$accessToken"
+
         - task: 1ES.PublishNuGet@1
           displayName: NuGet push
           inputs:
@@ -85,7 +97,10 @@ extends:
             artifactName: 'published-packages'
             targetPath: $(Pipeline.Workspace)\published-packages
 
-        # Use the NPM utility to authenticate and publish to ADO ms/react-native feed
+        # Use the NPM utility to authenticate and publish to ADO ms/react-native feed.
+        # PAT-based auth is no longer permitted, so override the service connection's
+        # token with an AAD access token obtained via Managed Identity, mirroring the
+        # NuGet job above.
         steps:
         - task: NodeTool@0
           displayName: Use Node 22.x
@@ -98,6 +113,20 @@ extends:
             script: |
               echo registry=https://pkgs.dev.azure.com/ms/_packaging/react-native/npm/registry/ > $(Pipeline.Workspace)\published-packages\.npmrc
               echo always-auth=true >> $(Pipeline.Workspace)\published-packages\.npmrc
+
+        - task: AzureCLI@2
+          displayName: Override npm credentials with Managed Identity
+          inputs:
+            azureSubscription: 'Office-Hermes-Windows-Bot'
+            visibleAzLogin: false
+            scriptType: 'pscore'
+            scriptLocation: 'inlineScript'
+            inlineScript: |
+              $accessToken = az account get-access-token --query accessToken --resource 499b84ac-1321-427f-aa17-267ca6975798 -o tsv
+              # Set the access token as a secret, so it doesn't get leaked in the logs
+              Write-Host "##vso[task.setsecret]$accessToken"
+              # Override the apitoken of the npm service connection, for the duration of this stage.
+              Write-Host "##vso[task.setendpoint id=9991cb9c-14ba-4683-9a34-100f96f80607;field=authParameter;key=apitoken]$accessToken"
 
         - task: npmAuthenticate@0
           displayName: npm Authenticate .npmrc


### PR DESCRIPTION
# Fix publish and release pipelines

Two unrelated breakages were blocking releases.

## publish.yml — ESRP rejects `.node` files

`Microsoft.JavaScript.NodeApi.node` is a native module — a PE/COFF DLL
with a non-`.dll` extension. ESRP's PendingAnalysis stage cannot handle
that extension and fails after a 30-minute hang.

**Fix:** rename `.node` → `.dll` before ESRP, sign it, and rename back after.

Also bumped `EsrpCodeSigning@5` → `@6` (two call sites).

## release.yml — PAT-based service connections no longer permitted

The `Nuget - ms/react-native-public` and `Npm - ms/react-native` service
connections authenticate via PAT, which policy now forbids. Managed
Identity is mandatory.

**Fix:** before each publish, an `AzureCLI@2` step fetches an AAD token
for the AzDO resource (`499b84ac-1321-427f-aa17-267ca6975798`) under MI
and overrides the service connection's auth at runtime via
`##vso[task.setendpoint id=<guid>;field=authParameter;key=apitoken]`.
`1ES.PublishNuGet@1` and `npmAuthenticate@0` then run unchanged and
transparently use the MI-derived token.

Notes:

- **Why the inline override?** ADO does not allow MI-based auth on
  service connections, so the connection itself still has to be
  configured with a PAT. The override-at-runtime pattern is the only
  way to actually publish under MI today; the stored PAT is bypassed
  on every build. This is the long-term shape unless ADO changes.
- **Temporary MI subscription.** `Office-Hermes-Windows-Bot` is used
  because the official `Office-Node-Api-DotNet-Bot` MI does not yet
  have the right permissions on these feeds. Switch back once it does.

## Drive-by

- `release.yml`: renamed `CustomPipelineTemplates` →
  `OfficePipelineTemplates` and dropped the
  `ES365AIMigrationTooling-BulkMigrated-Release` legacy build tag.

## Test runs

- Publish: <https://dev.azure.com/office/ISS/_build/results?buildId=49400440&view=results>
- Release: <https://dev.azure.com/office/ISS/_build/results?buildId=49406519&view=results>
