### PR TITLE
Fix deadlock releasing TSFN after environment shutdown

### DIFF
--- a/src/NodeApi/Interop/JSSynchronizationContext.cs
+++ b/src/NodeApi/Interop/JSSynchronizationContext.cs
@@ -247,13 +247,15 @@ public abstract class JSSynchronizationContext : SynchronizationContext, IDispos
 internal sealed class JSTsfnSynchronizationContext : JSSynchronizationContext
 {
     private readonly JSThreadSafeFunction _tsfn;
+    private bool _tsfnFinalized;
 
     public JSTsfnSynchronizationContext()
     {
         _tsfn = new JSThreadSafeFunction(
             maxQueueSize: 0,
             initialThreadCount: 1,
-            asyncResourceName: (JSValue)nameof(JSSynchronizationContext));
+            asyncResourceName: (JSValue)nameof(JSSynchronizationContext),
+            finalize: _ => _tsfnFinalized = true);
 
         // Unref TSFN to indicate that this TSFN is not preventing Node.JS shutdown.
         _tsfn.Unref();
@@ -267,7 +269,15 @@ internal sealed class JSTsfnSynchronizationContext : JSSynchronizationContext
 
         // Destroy TSFN by releasing last thread use count.
         // TSFN is deleted after this point and must not be used.
-        _tsfn.Release();
+        // During environment shutdown, Node.js finalizes the TSFN before the
+        // instance data finalizer disposes this context. Releasing it then
+        // deadlocks the JS thread on Node.js >= 24.14, where the release
+        // re-locks the TSFN mutex already held by the finalization path, and
+        // is a use-after-free on older versions.
+        if (!_tsfnFinalized)
+        {
+            _tsfn.Release();
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
Since nodejs/node#55877 (appeared in Node 24.14.0), environment shutdown finalizes a TSFN that still has use counts by releasing its resources while holding the TSFN mutex. Dropping the env reference there runs napi finalizers synchronously. The instance data finalizer disposes `JSRuntimeContext`, whose `JSTsfnSynchronizationContext.Dispose()` called `napi_release_threadsafe_function` on the same TSFN and re-locked a mutex the thread already holds. The JS thread deadlocks against itself. On older Node the stale release was a silent use-after-free. In VRCX (Electron 40 / .NET 9 / Linux) every quit hung the process:

```text
Microsoft.JavaScript.NodeApi.Runtime.NodejsRuntime.ReleaseThreadSafeFunction(...)
Microsoft.JavaScript.NodeApi.Interop.JSThreadSafeFunction.Release()
Microsoft.JavaScript.NodeApi.Interop.JSTsfnSynchronizationContext.Dispose()
Microsoft.JavaScript.NodeApi.Interop.JSRuntimeContext.Dispose()
Microsoft.JavaScript.NodeApi.JSValue.FinalizeGCHandleToDisposable(...)
```

`thread_finalize_cb` fires when Node.js destroys the TSFN, before the instance data finalizer runs. The fix tracks it and skips the release once it has fired. The normal dispose path is unchanged, and both the callback and `Dispose()` run on the JS thread, so there is no race on the flag. The [finalization docs](https://nodejs.org/api/n-api.html#finalization-on-the-exit-of-the-nodejs-environment) describe this ordering and warn about use-after-free in `napi_finalize` callbacks.

Repro on Node.js >= 24.14.0 (Linux x64, stock `mcr.microsoft.com/dotnet/runtime:9.0` container): `npm install node-api-dotnet@0.9.21`, then `node -e "require('node-api-dotnet/net9.0')"` never exits, parked on the stack above. With this change it exits immediately. On Node.js <= 24.13.0 the one-liner exits normally. Quit in VRCX hung 3/3 times on stock and exits cleanly 3/3 on this patch, and the existing suite passes.

Considered but left out: the same guard on the other TSFN entry points (`Ref`/`Unref`, `Post`/`Send`), and disposing `JSRuntimeContext` from a cleanup hook registered after the TSFN is created, so it runs while the TSFN is still alive (the pattern those docs recommend). The latter changes disposal timing during shutdown, so it seemed like a separate discussion.