### PR TITLE
Write explicit null terminator in Utf8StringArray

### DIFF
--- a/src/NodeApi/NodeApi.csproj
+++ b/src/NodeApi/NodeApi.csproj
@@ -28,6 +28,10 @@
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="Microsoft.JavaScript.NodeApi.Test" />
+  </ItemGroup>
+
   <Target Name="SetRuntimeConfigValues" BeforeTargets="GenerateBuildRuntimeConfigurationFiles">
     <ItemGroup>
       <RuntimeHostConfigurationOption Include="System.Runtime.InteropServices.EnableConsumingManagedCodeFromNativeHosting" Value="true" />

--- a/src/NodeApi/Runtime/Utf8StringArray.cs
+++ b/src/NodeApi/Runtime/Utf8StringArray.cs
@@ -46,9 +46,13 @@ internal struct Utf8StringArray : IDisposable
             fixed (char* src = strings[i])
             {
                 Utf8Strings[i] = stringBufferPtr + offset;
-                offset += Encoding.UTF8.GetBytes(
-                    src, strings[i].Length, (byte*)(stringBufferPtr + offset), byteLength - offset)
-                    + 1; // +1 for the string Null-terminator.
+                int encodedLength = Encoding.UTF8.GetBytes(
+                    src, strings[i].Length, (byte*)(stringBufferPtr + offset), byteLength - offset);
+
+                // Rented pool buffers are not zero-initialized, so write the terminator explicitly
+                // rather than relying on the reserved byte already being zero (#481).
+                *(byte*)(stringBufferPtr + offset + encodedLength) = 0;
+                offset += encodedLength + 1;
             }
         }
     }

--- a/test/Utf8StringArrayTests.cs
+++ b/test/Utf8StringArrayTests.cs
@@ -1,0 +1,71 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// The bug only affects the .NET path, where the buffer is pool-rented (not zeroed); on .NET
+// Framework it is a zeroed new byte[] and Marshal.PtrToStringUTF8 is unavailable.
+#if !(NETFRAMEWORK || NETSTANDARD)
+
+using System.Buffers;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using Microsoft.JavaScript.NodeApi.Runtime;
+using Xunit;
+
+namespace Microsoft.JavaScript.NodeApi.Test;
+
+public class Utf8StringArrayTests
+{
+    // Regression test for #481: a dirty (non-zeroed) pooled buffer must not leak bytes into the
+    // marshaled strings, which requires writing the null terminator explicitly.
+    [Fact]
+    public void MarshalsStringsCorrectlyWithDirtyPooledBuffer()
+    {
+        string[] input =
+        {
+            "node",
+            "--disable-wasm-trap-handler",
+            "--max-old-space-size=4096",
+        };
+
+        PoisonSharedByteArrayPool();
+
+        string[] roundTripped;
+        using (var utf8Array = new Utf8StringArray(input))
+        {
+            nint[] pointers = utf8Array.Utf8Strings;
+            roundTripped = new string[input.Length];
+            for (int i = 0; i < input.Length; i++)
+            {
+                roundTripped[i] = Marshal.PtrToStringUTF8(pointers[i])!;
+            }
+        }
+
+        Assert.Equal(input, roundTripped);
+    }
+
+    // Fill pooled buffers with non-zero bytes and return them, so the next rent starts dirty.
+    private static void PoisonSharedByteArrayPool()
+    {
+        var rented = new List<byte[]>();
+        for (int size = 8; size <= 1024; size *= 2)
+        {
+            for (int n = 0; n < 16; n++)
+            {
+                byte[] buffer = ArrayPool<byte>.Shared.Rent(size);
+                for (int k = 0; k < buffer.Length; k++)
+                {
+                    buffer[k] = 0xEF;
+                }
+
+                rented.Add(buffer);
+            }
+        }
+
+        foreach (byte[] buffer in rented)
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
+    }
+}
+
+#endif


### PR DESCRIPTION
Fixes #481.

`Utf8StringArray` reserved a byte for each string's null terminator (the `+ 1` in the encoding loop) but never wrote the `\0` — it relied on the reserved byte already being zero. That holds on the `NETFRAMEWORK`/`NETSTANDARD` path (`new byte[]` is zeroed), but on .NET the buffer is rented from `ArrayPool<byte>.Shared`, which is not zero-initialized. Once the pool has been used, the terminator byte can contain leftover data, and native node reads each argv entry past its end — e.g. `bad option: --disable-wasm-trap-handler<garbage>`. It only reproduces after warm-up (dirty pool), which made it hard to track down.

Fix: write the terminator explicitly.

Adds a regression test that dirties `ArrayPool<byte>.Shared` and verifies the marshaled strings round-trip exactly (fails on `main`, passes with this change). Testing the internal struct needs `InternalsVisibleTo` on the test assembly.

Verified: `dotnet test --framework net8.0 --filter Utf8StringArrayTests` passes with the fix and fails without it.
