### PR TITLE
Fix SIGSEGV when a worker_threads Worker that loaded node-api-dotnet …

### DIFF
--- a/src/NodeApi/DotNetHost/NativeHost.cs
+++ b/src/NodeApi/DotNetHost/NativeHost.cs
@@ -43,12 +43,93 @@ internal unsafe partial class NativeHost : IDisposable
         }
     }
 
+    private static bool s_moduleUnloadPrevented;
+
+    /// <summary>
+    /// Pins this native host module in memory so the OS never unloads it.
+    /// </summary>
+    /// <remarks>
+    /// This native host is compiled with NativeAOT, so it embeds a .NET runtime whose
+    /// per-thread cleanup is registered with the OS via a <c>pthread_key</c> destructor that
+    /// points into this module's own code. Node.js unloads (<c>dlclose</c>) an addon when the
+    /// environment that loaded it is torn down. When a <c>worker_threads</c> Worker loads this
+    /// module and is then terminated, Node unloads the module while the worker's OS thread is
+    /// still alive; the still-registered destructor then points at unmapped memory and the
+    /// process crashes with SIGSEGV as the thread exits (glibc <c>__nptl_deallocate_tsd</c>).
+    /// Keeping the module mapped for the lifetime of the process keeps that destructor valid.
+    /// <para/>
+    /// This only affects Unix (glibc) hosting; on Windows module/thread teardown does not hit
+    /// this issue. The pin is best-effort: any failure is traced but does not block init.
+    /// </remarks>
+    private static unsafe void PreventModuleUnload()
+    {
+        if (s_moduleUnloadPrevented)
+        {
+            return;
+        }
+
+        s_moduleUnloadPrevented = true;
+
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        {
+            return;
+        }
+
+        try
+        {
+            // Resolve the file path of this shared library from the address of one of its
+            // own functions, then re-open it with RTLD_NODELETE so it is never unmapped.
+            nint moduleFunction =
+                (nint)(delegate* unmanaged[Cdecl]<napi_env, napi_value, napi_value>)
+                &InitializeModule;
+
+            if (dladdr(moduleFunction, out Dl_info info) != 0 && info.dli_fname != default)
+            {
+                // RTLD_NOLOAD resolves the already-loaded module without loading a new copy;
+                // RTLD_NODELETE keeps it mapped for the process lifetime. The extra (never
+                // released) reference also prevents Node's dlclose from unmapping it.
+                const int RTLD_LAZY = 0x0001;
+                const int RTLD_NOLOAD = 0x0004;
+                const int RTLD_NODELETE = 0x1000;
+                nint handle = dlopen(info.dli_fname, RTLD_LAZY | RTLD_NOLOAD | RTLD_NODELETE);
+                Trace($"    Pinned native host module ({(handle != default ? "ok" : "no-op")}).");
+            }
+            else
+            {
+                Trace("    Could not resolve native host module path to pin it.");
+            }
+        }
+        catch (Exception ex)
+        {
+            Trace("    Failed to pin native host module: " + ex);
+        }
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct Dl_info
+    {
+        public nint dli_fname;
+        public nint dli_fbase;
+        public nint dli_sname;
+        public nint dli_saddr;
+    }
+
+    [DllImport("libc.so.6")]
+    private static extern int dladdr(nint addr, out Dl_info info);
+
+    [DllImport("libc.so.6")]
+    private static extern nint dlopen(nint filename, int flags);
+
     [UnmanagedCallersOnly(
         EntryPoint = nameof(napi_register_module_v1),
         CallConvs = new[] { typeof(CallConvCdecl) })]
     public static napi_value InitializeModule(napi_env env, napi_value exports)
     {
         Trace($"> NativeHost.InitializeModule({env.Handle:X8}, {exports.Handle:X8})");
+
+        // Ensure this native module stays loaded for the lifetime of the process. See
+        // PreventModuleUnload() for details on the worker-thread teardown crash this avoids.
+        PreventModuleUnload();
 
         s_jsRuntime ??= new NodejsRuntime();
 

--- a/src/NodeApi/DotNetHost/NativeHost.cs
+++ b/src/NodeApi/DotNetHost/NativeHost.cs
@@ -58,8 +58,11 @@ internal unsafe partial class NativeHost : IDisposable
     /// process crashes with SIGSEGV as the thread exits (glibc <c>__nptl_deallocate_tsd</c>).
     /// Keeping the module mapped for the lifetime of the process keeps that destructor valid.
     /// <para/>
-    /// This only affects Unix (glibc) hosting; on Windows module/thread teardown does not hit
-    /// this issue. The pin is best-effort: any failure is traced but does not block init.
+    /// This affects Unix hosting (Linux and macOS), which unload modules via <c>dlclose</c> and
+    /// run NativeAOT's per-thread destructors from the dynamic loader; on Windows module/thread
+    /// teardown does not hit this issue. The macOS path mirrors the Linux one but uses that
+    /// platform's <c>RTLD_*</c> flag values and system library. The pin is best-effort: any
+    /// failure is traced but does not block init.
     /// </remarks>
     private static unsafe void PreventModuleUnload()
     {
@@ -70,7 +73,8 @@ internal unsafe partial class NativeHost : IDisposable
 
         s_moduleUnloadPrevented = true;
 
-        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        bool isMacOS = RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Linux) && !isMacOS)
         {
             return;
         }
@@ -83,15 +87,24 @@ internal unsafe partial class NativeHost : IDisposable
                 (nint)(delegate* unmanaged[Cdecl]<napi_env, napi_value, napi_value>)
                 &InitializeModule;
 
-            if (dladdr(moduleFunction, out Dl_info info) != 0 && info.dli_fname != default)
+            Dl_info info;
+            int found = isMacOS
+                ? DlAddrMacOS(moduleFunction, out info)
+                : DlAddrLinux(moduleFunction, out info);
+
+            if (found != 0 && info.dli_fname != default)
             {
                 // RTLD_NOLOAD resolves the already-loaded module without loading a new copy;
                 // RTLD_NODELETE keeps it mapped for the process lifetime. The extra (never
-                // released) reference also prevents Node's dlclose from unmapping it.
+                // released) reference also prevents Node's dlclose from unmapping it. The flag
+                // values differ between glibc and macOS/dyld.
                 const int RTLD_LAZY = 0x0001;
-                const int RTLD_NOLOAD = 0x0004;
-                const int RTLD_NODELETE = 0x1000;
-                nint handle = dlopen(info.dli_fname, RTLD_LAZY | RTLD_NOLOAD | RTLD_NODELETE);
+                int rtldNoLoad = isMacOS ? 0x0010 : 0x0004;
+                int rtldNoDelete = isMacOS ? 0x0080 : 0x1000;
+                int flags = RTLD_LAZY | rtldNoLoad | rtldNoDelete;
+                nint handle = isMacOS
+                    ? DlOpenMacOS(info.dli_fname, flags)
+                    : DlOpenLinux(info.dli_fname, flags);
                 Trace($"    Pinned native host module ({(handle != default ? "ok" : "no-op")}).");
             }
             else
@@ -114,11 +127,18 @@ internal unsafe partial class NativeHost : IDisposable
         public nint dli_saddr;
     }
 
-    [DllImport("libc.so.6")]
-    private static extern int dladdr(nint addr, out Dl_info info);
+    // dladdr / dlopen live in libc.so.6 on Linux (glibc) and libSystem on macOS.
+    [LibraryImport("libc.so.6", EntryPoint = "dladdr")]
+    private static partial int DlAddrLinux(nint addr, out Dl_info info);
 
-    [DllImport("libc.so.6")]
-    private static extern nint dlopen(nint filename, int flags);
+    [LibraryImport("libSystem", EntryPoint = "dladdr")]
+    private static partial int DlAddrMacOS(nint addr, out Dl_info info);
+
+    [LibraryImport("libc.so.6", EntryPoint = "dlopen")]
+    private static partial nint DlOpenLinux(nint filename, int flags);
+
+    [LibraryImport("libSystem", EntryPoint = "dlopen")]
+    private static partial nint DlOpenMacOS(nint filename, int flags);
 
     [UnmanagedCallersOnly(
         EntryPoint = nameof(napi_register_module_v1),


### PR DESCRIPTION
## Summary

Fixes a **SIGSEGV** (process crash, exit 139) that occurs on Linux when a `worker_threads` Worker loads `node-api-dotnet` and the worker is then terminated.

Issue: #486 

## Repro

Load the module inside a Worker, then terminate the worker:

```js
// worker.cjs
const { parentPort } = require('node:worker_threads');
require('node-api-dotnet/net10.0');
parentPort.postMessage('ready');
```

```js
// main.cjs
const { Worker } = require('node:worker_threads');
const w = new Worker('./worker.cjs');
w.once('message', async () => {
  await w.terminate();
  console.log('terminated ok');
});
```

On Linux the process crashes with SIGSEGV instead of printing `terminated ok`.

## Root cause

The native host (`Microsoft.JavaScript.NodeApi.node`) is compiled with **NativeAOT**, so the `.node` embeds its own .NET runtime. That runtime registers per-thread cleanup with the OS via a `pthread_key` destructor whose function pointer points **into this module's own code**.

When a Worker environment is torn down, Node.js unloads the addon (`dlclose`) while the worker's OS thread is **still alive**. The `pthread_key` destructor is still registered, but now points at unmapped memory. When the worker thread subsequently exits, glibc's `__nptl_deallocate_tsd` invokes that dangling destructor → **SIGSEGV**.

This was confirmed with gdb: at crash time the faulting destructor belonged to the `.node`, which had **0 memory mappings** (already `dlclose`d). No-op'ing `dlclose` via `LD_PRELOAD` produced a clean exit, confirming the unmap-while-thread-alive diagnosis.

## Fix

Pin the native host module for the lifetime of the process on Linux. Resolve the module's own path via `dladdr` on one of its functions, then re-open it with `dlopen(RTLD_NOLOAD | RTLD_NODELETE)`:

- `RTLD_NOLOAD` resolves the already-loaded module without loading a second copy.
- `RTLD_NODELETE` keeps it mapped for the process lifetime, and the extra (never-released) reference prevents Node's `dlclose` from unmapping it.

This keeps the `pthread_key` destructor address valid for the life of the process. The change is:

- **Scoped to Linux/glibc** — Windows module/thread teardown does not hit this path.
- **Best-effort** — any failure is traced and non-fatal, so it never blocks module init.

## Testing

Reproduced and validated in Docker (`mcr.microsoft.com/dotnet/sdk:10.0` + Node 24.13.0, which crashes deterministically):

| | Before | After |
|---|--------|-------|
| Node 24.13.0 | exit 139 (SIGSEGV) | **exit 0** (`terminated ok`), 5/5 runs |

`NodeApi` builds clean on `net8.0`, `net9.0`, `net10.0`, and `netstandard2.0`.

> Note: This addresses only the crash. A separate hang on Node.js >= 24.14 (TSFN release deadlock during env teardown) is fixed independently.